### PR TITLE
logs: replace S3 JSONL sink with Postgres + monthly Parquet archive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,27 +6,40 @@ This is an LLM proxy service that routes chat completion requests to NRP, OpenRo
 
 ## Evaluating Logs
 
-Logs live in two places: pod stdout (ephemeral) and S3 bucket `logs-open-llm-proxy` (persisted as JSONL chunks, preferred).
+Logs live in three surfaces: **Postgres** (primary, 1-year retention, sub-second freshness), **pod stdout** (live tail / fallback), and **S3 Parquet** (monthly cold archive, forever). Query Postgres for anything current; reach for S3 Parquet only when spanning more than a year back.
 
-The bucket is private. Agents should assume `LOG_S3_KEY` and `LOG_S3_SECRET` are pre-set in the shell and use those env vars via the Bash tool — the shell expands them at execution time so the values never appear in chat. Do not hunt for credentials in rclone config, k8s secrets, etc.
+Agents should assume `LOG_DB_READ_URL` is pre-set in the shell (DSN for the read-only role) and use it via the Bash tool — the shell expands it at execution time so the password never appears in chat. Do not hunt for credentials in k8s Secrets.
 
 ```bash
-duckdb -s "
-CREATE SECRET logs_s3 (TYPE S3, KEY_ID '$LOG_S3_KEY', SECRET '$LOG_S3_SECRET',
-  ENDPOINT 's3-west.nrp-nautilus.io', USE_SSL true, URL_STYLE 'path');
-SELECT * FROM read_ndjson_auto('s3://logs-open-llm-proxy/2026-04-07/*.jsonl', union_by_name=true);
+psql "$LOG_DB_READ_URL" -c "
+  SELECT ts, entry->>'user_question' AS q, entry->'tool_calls' AS tools
+  FROM logs
+  WHERE origin='https://tpl.nrp-nautilus.io' AND ts > now() - INTERVAL '1 hour'
+  ORDER BY ts DESC;
 "
 ```
 
-Narrow the S3 glob to an hour (`2026-04-07/17-*.jsonl`) when you only need recent traffic.
+Or with DuckDB when you need joins / analytical queries:
 
-Each LLM call produces a `request` entry and a `response` entry linked by `request_id`. Key fields:
+```bash
+duckdb -s "
+INSTALL postgres; LOAD postgres;
+ATTACH '$LOG_DB_READ_URL' AS pg (TYPE postgres, READ_ONLY);
+SELECT req.ts, req.entry->>'user_question' AS q, resp.entry->'tool_calls' AS tools
+FROM pg.public.logs req
+JOIN pg.public.logs resp ON req.request_id = resp.request_id
+WHERE req.type='request' AND resp.type='response'
+  AND req.ts > now() - INTERVAL 20 MINUTES;
+"
+```
 
-- **Request**: `user_question`, `tool_results_this_turn`, `model`, `origin`, `message_count`
-- **Response**: `tool_calls`, `content_preview`, `tokens`, `latency_ms`, `error` (sparse — only present in files that contain failures; omit from JOIN queries or use `TRY(resp.error)`)
+Each LLM call produces a `request` row and a `response` row linked by `request_id`. The full payload lives in `entry` (JSONB). Key fields inside `entry`:
 
-**Reconstructing a conversation**: group by `user_question`, filter by `origin`, sort by `timestamp`. The `tool_results_this_turn` on each request shows what the previous turn's tool calls returned; `tool_calls` on each response shows what the LLM called next.
+- **Request**: `user_question`, `tool_results_this_turn`, `model`, `message_count`
+- **Response**: `tool_calls`, `content_preview`, `tokens`, `latency_ms`, `error` (only on failures)
 
-See [LOGGING.md](LOGGING.md) for full field reference, SQL patterns, kubectl access, and session reconstruction examples.
+**Reconstructing a conversation**: group by `entry->>'user_question'`, filter by `origin`, sort by `ts`. The `tool_results_this_turn` on each request shows what the previous turn's tool calls returned; `tool_calls` on each response shows what the LLM called next.
+
+See [LOGGING.md](LOGGING.md) for full field reference, SQL patterns, kubectl access, S3 Parquet archive format, and session reconstruction examples.
 
 When analyzing geo-agent app behavior (tool-call counts, query failures, session reconstructions), invoke the `geo-agent-training` skill — it provides the full step-by-step diagnostic workflow.

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -2,154 +2,169 @@
 
 ## Where logs live
 
-Logs are written to two places:
+Every LLM request/response pair is written to **three** surfaces. Each serves a distinct purpose:
 
-1. **Pod stdout** — available immediately via `kubectl`, lost on pod restart
-2. **S3 bucket `logs-open-llm-proxy`** — flushed every 60 seconds (configurable via `FLUSH_INTERVAL` env var) as JSONL chunk files, persisted indefinitely
+| Surface | Purpose | Latency | Retention |
+|---|---|---|---|
+| **Postgres `logs` table** | Primary durable store; queryable | Sub-second | 1 year |
+| **Pod stdout** | Live tail for active debugging | Real-time | Until pod restart |
+| **S3 `archive/YYYY-MM.parquet`** | Cold archive; monthly rollup | End of month + ~3h | Forever |
 
-### S3 layout
+The Postgres row **is** the log. Stdout is a realtime view and a safety net if Postgres is unreachable. S3 Parquet is the long-term archive so the Postgres PVC stays bounded.
+
+## Postgres (primary access pattern)
+
+### Credentials
+
+There are two roles, both created at Postgres first-init:
+
+- `log_writer` — `INSERT` only, used by the proxy itself (`LOG_DB_URL` secret)
+- `log_reader` — `SELECT` only, used by developers / cron archive job
+
+Agents and developers should have **`LOG_DB_READ_URL`** pre-set in their shell, pointing at the reader role:
 
 ```
-logs-open-llm-proxy/
-├── 2026-03-31/
-│   ├── 02-00-05-39.jsonl     # flush at 02:00:05 from worker PID 39
-│   ├── 02-05-07-39.jsonl
-│   └── ...
-├── 2026-04-01/
-│   └── ...
+postgresql://log_reader:<password>@<host>:5432/logs
 ```
 
-Each file is newline-delimited JSON (one log entry per line, mix of request and response entries).
+Use the env var via the Bash tool so the password never appears in chat. **Do not** look up or copy the password out of `postgres-logs-auth` or any k8s Secret.
 
-## Access pattern
+### Schema
 
-### S3 (preferred — no kubectl needed)
+```sql
+CREATE TABLE logs (
+    id         BIGSERIAL PRIMARY KEY,
+    ts         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    type       TEXT NOT NULL,            -- 'request' | 'response'
+    request_id TEXT,
+    origin     TEXT,
+    entry      JSONB NOT NULL            -- the full payload
+);
+```
 
-The bucket is **private**. Set `LOG_S3_KEY` and `LOG_S3_SECRET` in your shell (scoped keys for this bucket — distinct from your general NRP credentials) and let the shell expand them into DuckDB's `CREATE SECRET`. Agents should use the Bash tool so shell expansion keeps the secret values out of the conversation transcript.
+`entry` is the full JSON object — query into it with `entry->>'field'` (text) or `entry->'field'` (jsonb).
+
+### psql (simple one-offs)
+
+```bash
+psql "$LOG_DB_READ_URL" -c "
+  SELECT ts, entry->>'user_question' AS q, entry->'tool_calls' AS tools
+  FROM logs
+  WHERE type='response' AND origin='https://tpl.nrp-nautilus.io'
+    AND ts > now() - INTERVAL '1 hour'
+  ORDER BY ts DESC;
+"
+```
+
+### DuckDB (joins, Parquet spillover, richer analysis)
+
+DuckDB has a `postgres` extension that can query the live table directly:
+
+```bash
+duckdb -s "
+INSTALL postgres; LOAD postgres;
+ATTACH '$LOG_DB_READ_URL' AS pg (TYPE postgres, READ_ONLY);
+
+-- Pair requests and responses
+SELECT req.ts, req.entry->>'user_question' AS q,
+       resp.entry->'tool_calls' AS tools, (resp.entry->>'latency_ms')::INT AS ms
+FROM pg.public.logs req
+JOIN pg.public.logs resp ON req.request_id = resp.request_id
+WHERE req.type='request' AND resp.type='response'
+  AND req.origin='https://tpl.nrp-nautilus.io'
+  AND req.ts > now() - INTERVAL 20 MINUTES
+ORDER BY req.ts DESC;
+"
+```
+
+## Stdout (live tail, fallback)
+
+Same JSON payload as Postgres, on every pod. Use `kubectl` for real-time inspection during active debugging:
+
+```bash
+kubectl -n biodiversity logs deployment/open-llm-proxy -f \
+  | grep '"origin":"https://tpl.nrp-nautilus.io"'
+```
+
+If the Postgres pod is unavailable, log rows will **only** exist in stdout until the pod restarts. That's the safety net.
+
+## S3 Parquet archive (cold storage)
+
+On the first day of each month, a CronJob dumps the previous month's rows to `s3://logs-open-llm-proxy/archive/YYYY-MM.parquet` (zstd-compressed). The archive format keeps `entry` as a JSON-encoded `VARCHAR` column so DuckDB can still parse into it:
 
 ```bash
 duckdb -s "
 CREATE SECRET logs_s3 (TYPE S3, KEY_ID '$LOG_S3_KEY', SECRET '$LOG_S3_SECRET',
   ENDPOINT 's3-west.nrp-nautilus.io', USE_SSL true, URL_STYLE 'path');
 
--- All logs for a date
-SELECT * FROM read_ndjson_auto('s3://logs-open-llm-proxy/2026-03-31/*.jsonl', union_by_name=true);
-
--- Filter to one app
-SELECT * FROM read_ndjson_auto('s3://logs-open-llm-proxy/2026-03-31/*.jsonl', union_by_name=true)
-WHERE origin = 'https://padus.nrp-nautilus.io';
-
--- Pair requests and responses
-SELECT req.user_question, req.timestamp, resp.tool_calls, resp.tokens
-FROM read_ndjson_auto('s3://logs-open-llm-proxy/2026-03-31/*.jsonl', union_by_name=true) req
-JOIN read_ndjson_auto('s3://logs-open-llm-proxy/2026-03-31/*.jsonl', union_by_name=true) resp
-  ON req.request_id = resp.request_id
-WHERE req.type = 'request' AND resp.type = 'response';
+SELECT ts, entry::JSON->>'user_question' AS q
+FROM read_parquet('s3://logs-open-llm-proxy/archive/2026-03.parquet')
+WHERE entry::JSON->>'origin' = 'https://tpl.nrp-nautilus.io';
 "
 ```
 
-**Narrow the glob to the current hour** when looking at recent traffic — do NOT scan the whole day. Example: `2026-03-31/14-*.jsonl`. `union_by_name=true` handles schema drift across chunks (e.g. the `error` column appears only in some files). If the queried window has zero error responses, `error` is absent from all files — omit it from JOIN queries or use `TRY(resp.error)`.
+To query live + archive as one set, UNION the Postgres table and the Parquet files in DuckDB.
 
-**Temporal filter:** `timestamp` is stored as VARCHAR (ISO8601). Cast to `TIMESTAMPTZ` (not `TIMESTAMP`) when comparing against `now()`:
-```sql
-CAST(req.timestamp AS TIMESTAMPTZ) >= now() - INTERVAL 20 MINUTES
-```
-Using `TIMESTAMP` causes a type mismatch binder error because `now()` returns `TIMESTAMPTZ`.
+## Log fields
 
-**Log field truncation:** `tool_results_this_turn[N].content` and `content_preview` are truncated to ~200 chars in logs. A tool result that appears to contain only column names likely has full descriptions below the truncation point — verify using the STAC MCP tools directly rather than inferring from log previews.
-
-Inside NRP pods, use the internal endpoint instead (`rook-ceph-rgw-nautiluss3.rook`, `USE_SSL false`) — faster and no public-endpoint throttling.
-
-### kubectl (live logs / last ~60s before next flush)
-
-```bash
-# Live tail
-kubectl -n biodiversity logs deployment/open-llm-proxy -f
-
-# Recent history
-kubectl -n biodiversity logs deployment/open-llm-proxy --tail=500
-
-# Filter to a specific app
-kubectl -n biodiversity logs deployment/open-llm-proxy --tail=1000 \
-  | grep '"origin":"https://padus.nrp-nautilus.io"'
-```
-
-## Log format
-
-Each LLM call produces two JSON entries on stdout: a `REQUEST` line when the call arrives and a `RESPONSE` line when it completes.
-
-### REQUEST entry
-
-```
-📥 REQUEST: {"timestamp": "...", "type": "request", ...}
-```
+### REQUEST entry (`type='request'`)
 
 | Field | Description |
 |---|---|
-| `timestamp` | UTC ISO8601 |
-| `type` | `"request"` |
+| `timestamp` | UTC ISO8601 (also stored as `ts TIMESTAMPTZ`) |
 | `request_id` | 8-char hex — correlates this request to its response |
 | `provider` | `"nrp"`, `"openrouter"`, or `"nimbus"` |
 | `model` | Model name as sent by the client |
 | `origin` | Origin or Referer header — identifies which app sent the request |
 | `message_count` | Total messages in the conversation at this turn |
 | `tools_count` | Number of tools available to the LLM |
-| `user_question` | First `role: user` message in the conversation — the human's original question, stable across all turns of a tool-use loop |
-| `tool_results_this_turn` | Array of `{tool_call_id, content}` for any `role: tool` messages appended since the last assistant turn. Captures results from both local geo-agent tools (e.g. `list_datasets`, `get_dataset_details`) and remote MCP tools (e.g. `query`). `null` on the first turn. |
+| `user_question` | First `role: user` message — stable across all turns of a tool-use loop |
+| `tool_results_this_turn` | Array of `{tool_call_id, content}` for any `role: tool` messages appended since the last assistant turn. `null` on the first turn. Content truncated to ~500 chars. |
 
-### RESPONSE entry
-
-```
-✓ RESPONSE: {"timestamp": "...", "type": "response", ...}
-✗ RESPONSE: {"timestamp": "...", "type": "response", "error": "...", ...}
-```
+### RESPONSE entry (`type='response'`)
 
 | Field | Description |
 |---|---|
-| `timestamp` | UTC ISO8601 |
-| `type` | `"response"` |
-| `request_id` | Matches the corresponding request entry |
-| `provider` | Provider that handled the request |
-| `model` | Model used |
-| `origin` | Same as request — identifies which app |
+| `timestamp`, `request_id`, `provider`, `model`, `origin` | Same semantics as request |
 | `latency_ms` | End-to-end latency in milliseconds |
-| `has_content` | Whether the LLM returned text content |
-| `has_tool_calls` | Whether the LLM made tool calls |
+| `has_content`, `has_tool_calls` | Booleans |
 | `content_preview` | First 200 chars of text response |
 | `tool_calls` | Array of `{name, arguments}` — full tool call arguments including SQL query strings |
-| `tokens` | Token usage object from the provider (`prompt_tokens`, `completion_tokens`, `total_tokens`) |
+| `tokens` | Token usage from the provider (`prompt_tokens`, `completion_tokens`, `total_tokens`) |
 | `error` | Error detail string (only present on failed requests) |
 
 ## Reconstructing a conversation
 
-Each POST to `/v1/chat/completions` is one LLM turn. A single user session produces multiple request/response pairs. To reconstruct a session:
+Each POST to `/v1/chat/completions` is one LLM turn. To reconstruct a session:
 
-1. Match by `origin` to isolate one app
-2. Group turns by `user_question` (same question = same session)
-3. Sort by `timestamp`
-4. Interleave: each request's `tool_results_this_turn` shows what the previous turn's tool calls returned; each response's `tool_calls` shows what the LLM decided to call next
+1. Filter by `origin` to isolate one app
+2. Group turns by `entry->>'user_question'` (same question = same session)
+3. Sort by `ts`
+4. Pair each request with its response via `request_id`. Each request's `tool_results_this_turn` shows what the previous turn's tool calls returned; each response's `tool_calls` shows what the LLM decided to call next.
 
-Use `request_id` to pair each request with its response when log lines are interleaved under concurrent load.
+## Bootstrap (one-time)
 
-## Example session reconstruction
+Before the proxy can log to Postgres, the cluster needs:
 
-```
-REQUEST  msg=2  user_question="Tell me about datasets"  tool_results=null
-RESPONSE tool_calls=[{name: list_datasets, arguments: {}}]
-
-REQUEST  msg=4  user_question="Tell me about datasets"  tool_results=[{content: "[{id: pad-us...}]"}]
-RESPONSE tool_calls=[{name: get_schema, arguments: {dataset_id: "pad-us-4.1-fee"}}]
-
-REQUEST  msg=6  user_question="Tell me about datasets"  tool_results=[{content: "path: s3://... | column | sample..."}]
-RESPONSE has_content=true  content_preview="The PAD-US dataset contains..."
-```
-
-Note: `list_datasets` and `get_schema` are local geo-agent tools — their results appear in `tool_results_this_turn` on the proxy but never reach the MCP server.
-
-## What the MCP server logs add
-
-The DuckDB MCP server logs SQL execution separately. MCP logs are only needed for:
-- SQL execution errors not visible to the LLM (failed queries that return an error string)
-- Exact query timing at the database layer
-
-For conversation-level analysis (what users asked, what the LLM decided, what tools returned), proxy logs are self-sufficient.
+1. **Secret `postgres-logs-auth`** — three passwords (superuser, writer, reader). Generate and apply manually (not committed).
+   ```bash
+   kubectl -n biodiversity create secret generic postgres-logs-auth \
+     --from-literal=POSTGRES_PASSWORD="$(openssl rand -base64 32)" \
+     --from-literal=LOG_WRITER_PASSWORD="$(openssl rand -base64 32)" \
+     --from-literal=LOG_READER_PASSWORD="$(openssl rand -base64 32)"
+   ```
+2. **`log-db-url` key in `open-llm-proxy-secrets`** — writer DSN used by the proxy pod:
+   ```
+   postgresql://log_writer:<LOG_WRITER_PASSWORD>@postgres-logs:5432/logs
+   ```
+3. **Apply manifests in order**:
+   ```bash
+   kubectl apply -f postgres-initdb-configmap.yaml
+   kubectl apply -f postgres-statefulset.yaml
+   kubectl apply -f postgres-service.yaml
+   # wait for LoadBalancer IP to be assigned, verify external 5432 reachable
+   kubectl apply -f archive-cronjob.yaml
+   kubectl apply -f retention-cronjob.yaml
+   # finally, roll the proxy
+   kubectl -n biodiversity rollout restart deployment/open-llm-proxy
+   ```

--- a/archive-cronjob.yaml
+++ b/archive-cronjob.yaml
@@ -1,0 +1,96 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres-logs-archive
+  labels:
+    app: postgres-logs
+spec:
+  # 03:00 UTC on day 1 of every month — dumps the completed previous month
+  schedule: "0 3 1 * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 604800
+      template:
+        spec:
+          priorityClassName: opportunistic
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: feature.node.kubernetes.io/pci-10de.present
+                        operator: NotIn
+                        values: ["true"]
+          containers:
+            - name: archive
+              image: python:3.12-slim
+              env:
+                - name: LOG_READER_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-logs-auth
+                      key: LOG_READER_PASSWORD
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef: { name: aws, key: AWS_ACCESS_KEY_ID }
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef: { name: aws, key: AWS_SECRET_ACCESS_KEY }
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+                  pip install --quiet duckdb
+
+                  START=$(date -u -d "$(date -u +%Y-%m-01) -1 month" +%Y-%m-%d)
+                  END=$(date -u +%Y-%m-01)
+                  MONTH=$(date -u -d "$START" +%Y-%m)
+                  echo "Archiving logs from $START (inclusive) to $END (exclusive) → archive/$MONTH.parquet"
+
+                  python - <<PY
+                  import os, duckdb
+                  con = duckdb.connect()
+                  con.execute("INSTALL httpfs; LOAD httpfs;")
+                  con.execute("INSTALL postgres; LOAD postgres;")
+                  con.execute(f"""
+                      CREATE SECRET s3_archive (
+                          TYPE S3,
+                          KEY_ID '{os.environ["AWS_ACCESS_KEY_ID"]}',
+                          SECRET '{os.environ["AWS_SECRET_ACCESS_KEY"]}',
+                          ENDPOINT 'rook-ceph-rgw-nautiluss3.rook',
+                          USE_SSL false,
+                          URL_STYLE 'path'
+                      )
+                  """)
+                  con.execute(f"""
+                      ATTACH 'postgresql://log_reader:{os.environ["LOG_READER_PASSWORD"]}@postgres-logs:5432/logs'
+                      AS pg (TYPE postgres, READ_ONLY)
+                  """)
+                  con.execute(f"""
+                      COPY (
+                          SELECT ts, type, request_id, origin, entry::VARCHAR AS entry
+                          FROM pg.public.logs
+                          WHERE ts >= TIMESTAMPTZ '$START'
+                            AND ts <  TIMESTAMPTZ '$END'
+                      ) TO 's3://logs-open-llm-proxy/archive/$MONTH.parquet'
+                      (FORMAT PARQUET, COMPRESSION zstd)
+                  """)
+                  rows = con.execute(f"""
+                      SELECT count(*) FROM pg.public.logs
+                      WHERE ts >= TIMESTAMPTZ '$START' AND ts < TIMESTAMPTZ '$END'
+                  """).fetchone()[0]
+                  print(f"✓ Archived {rows} rows to s3://logs-open-llm-proxy/archive/$MONTH.parquet")
+                  PY
+              resources:
+                requests:
+                  cpu: "500m"
+                  memory: "1Gi"
+                limits:
+                  cpu: "500m"
+                  memory: "1Gi"

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
       - name: open-llm-proxy
         image: astral/uv:python3.12-bookworm-slim
-        command: ["uvx", "--from", "uvicorn", "--with", "fastapi", "--with", "httpx", "--with", "pydantic", "--with", "boto3", "uvicorn", "llm_proxy:app", "--host", "0.0.0.0", "--port", "8002", "--workers", "4"]
+        command: ["uvx", "--from", "uvicorn", "--with", "fastapi", "--with", "httpx", "--with", "pydantic", "--with", "asyncpg", "uvicorn", "llm_proxy:app", "--host", "0.0.0.0", "--port", "8002", "--workers", "4"]
         workingDir: /app
         ports:
         - containerPort: 8002
@@ -64,12 +64,11 @@ spec:
             secretKeyRef:
               name: open-llm-proxy-secrets
               key: cache-salt
-        - name: AWS_ACCESS_KEY_ID
+        - name: LOG_DB_URL
           valueFrom:
-            secretKeyRef: { name: aws, key: AWS_ACCESS_KEY_ID }
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef: { name: aws, key: AWS_SECRET_ACCESS_KEY }
+            secretKeyRef:
+              name: open-llm-proxy-secrets
+              key: log-db-url
         resources:
           requests:
             cpu: "1000m"

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -20,53 +20,68 @@ from typing import List, Dict, Any, Optional
 from datetime import datetime
 from pathlib import Path
 
-# --- S3 log buffer -----------------------------------------------------------
-_log_buffer: List[dict] = []
-_LOG_BUCKET = os.getenv("LOG_BUCKET", "logs-open-llm-proxy")
-_S3_ENDPOINT = os.getenv("AWS_S3_ENDPOINT_URL", "http://rook-ceph-rgw-nautiluss3.rook")
-_S3_ENABLED = bool(os.getenv("AWS_ACCESS_KEY_ID"))
-_FLUSH_INTERVAL = int(os.getenv("FLUSH_INTERVAL", "60"))
+# --- Postgres log sink -------------------------------------------------------
+# stdout (print) is always active — kubectl logs remains the live real-time view
+# and the fallback if Postgres is unavailable. The pool is best-effort: any
+# failure in pool init or INSERT degrades to stdout-only logging.
+_LOG_DB_URL = os.getenv("LOG_DB_URL")
+_pg_pool: Optional[Any] = None
+_bg_tasks: set = set()
+
+async def _init_pg_pool():
+    """Create the asyncpg connection pool. Failure is non-fatal."""
+    global _pg_pool
+    if not _LOG_DB_URL:
+        print("ℹ️  LOG_DB_URL not set — Postgres log sink disabled (stdout still active)", flush=True)
+        return
+    try:
+        import asyncpg
+        _pg_pool = await asyncpg.create_pool(
+            _LOG_DB_URL,
+            min_size=1,
+            max_size=8,
+            command_timeout=5,
+        )
+        print("✓ Postgres log pool connected", flush=True)
+    except Exception as e:
+        print(f"⚠️  Postgres log pool init failed: {e} — stdout-only logging", flush=True)
+        _pg_pool = None
+
+async def _pg_insert(entry: dict):
+    """Insert one log entry. Best-effort; stdout already captured it."""
+    if _pg_pool is None:
+        return
+    try:
+        async with _pg_pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO logs (ts, type, request_id, origin, entry) "
+                "VALUES ($1::timestamptz, $2, $3, $4, $5::jsonb)",
+                entry.get("timestamp"),
+                entry.get("type"),
+                entry.get("request_id"),
+                entry.get("origin"),
+                json.dumps(entry),
+            )
+    except Exception as e:
+        print(f"⚠️  Postgres log insert failed: {e}", flush=True)
 
 def _emit(log_entry: dict):
-    """Print log entry and add to S3 buffer."""
-    _log_buffer.append(log_entry)
-
-async def _flush_to_s3():
-    """Write buffered log entries to S3 as a JSONL chunk file."""
-    if not _log_buffer or not _S3_ENABLED:
+    """Fire-and-forget Postgres insert. Holds the task reference so the GC
+    doesn't cancel it before it runs."""
+    if _pg_pool is None:
         return
-    entries, _log_buffer[:] = list(_log_buffer), []
-    body = "\n".join(json.dumps(e) for e in entries) + "\n"
-    now = datetime.utcnow()
-    key = f"{now.strftime('%Y-%m-%d')}/{now.strftime('%H-%M-%S')}-{os.getpid()}.jsonl"
-    try:
-        import boto3
-        client = boto3.client(
-            "s3",
-            endpoint_url=_S3_ENDPOINT,
-            aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-            aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
-        )
-        loop = asyncio.get_event_loop()
-        await loop.run_in_executor(
-            None,
-            lambda: client.put_object(Bucket=_LOG_BUCKET, Key=key, Body=body.encode())
-        )
-        print(f"✓ Flushed {len(entries)} log entries to s3://{_LOG_BUCKET}/{key}", flush=True)
-    except Exception as e:
-        print(f"⚠️  S3 flush failed: {e} — entries remain in pod logs only", flush=True)
-
-async def _flush_loop():
-    while True:
-        await asyncio.sleep(_FLUSH_INTERVAL)
-        await _flush_to_s3()
+    task = asyncio.create_task(_pg_insert(log_entry))
+    _bg_tasks.add(task)
+    task.add_done_callback(_bg_tasks.discard)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    task = asyncio.create_task(_flush_loop())
+    await _init_pg_pool()
     yield
-    task.cancel()
-    await _flush_to_s3()  # final flush on shutdown
+    if _bg_tasks:
+        await asyncio.gather(*list(_bg_tasks), return_exceptions=True)
+    if _pg_pool is not None:
+        await _pg_pool.close()
 
 app = FastAPI(title="Multi-Provider LLM Proxy", lifespan=lifespan)
 

--- a/postgres-initdb-configmap.yaml
+++ b/postgres-initdb-configmap.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-logs-initdb
+  labels:
+    app: postgres-logs
+data:
+  # Runs only on first initialization (empty PGDATA). Schema migrations after
+  # first init must be applied manually via psql.
+  init.sh: |
+    #!/bin/bash
+    set -e
+
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<EOF
+    CREATE TABLE IF NOT EXISTS logs (
+        id         BIGSERIAL PRIMARY KEY,
+        ts         TIMESTAMPTZ NOT NULL DEFAULT now(),
+        type       TEXT NOT NULL,
+        request_id TEXT,
+        origin     TEXT,
+        entry      JSONB NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS logs_ts_idx         ON logs (ts DESC);
+    CREATE INDEX IF NOT EXISTS logs_request_id_idx ON logs (request_id);
+    CREATE INDEX IF NOT EXISTS logs_origin_ts_idx  ON logs (origin, ts DESC);
+    CREATE INDEX IF NOT EXISTS logs_entry_gin_idx  ON logs USING GIN (entry jsonb_path_ops);
+
+    DO \$\$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'log_writer') THEN
+        CREATE ROLE log_writer LOGIN PASSWORD '$LOG_WRITER_PASSWORD';
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'log_reader') THEN
+        CREATE ROLE log_reader LOGIN PASSWORD '$LOG_READER_PASSWORD';
+      END IF;
+    END
+    \$\$;
+
+    GRANT CONNECT ON DATABASE "$POSTGRES_DB" TO log_writer, log_reader;
+    GRANT USAGE ON SCHEMA public TO log_writer, log_reader;
+    GRANT INSERT ON logs TO log_writer;
+    GRANT USAGE, SELECT ON SEQUENCE logs_id_seq TO log_writer;
+    GRANT SELECT ON logs TO log_reader;
+    EOF

--- a/postgres-service.yaml
+++ b/postgres-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-logs
+  labels:
+    app: postgres-logs
+spec:
+  type: LoadBalancer
+  selector:
+    app: postgres-logs
+  ports:
+    - protocol: TCP
+      port: 5432
+      targetPort: 5432
+      name: postgres

--- a/postgres-statefulset.yaml
+++ b/postgres-statefulset.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres-logs
+  labels:
+    app: postgres-logs
+spec:
+  serviceName: postgres-logs
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres-logs
+  template:
+    metadata:
+      labels:
+        app: postgres-logs
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: postgres
+          image: postgres:16
+          ports:
+            - containerPort: 5432
+              name: postgres
+          env:
+            - name: POSTGRES_DB
+              value: logs
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-logs-auth
+                  key: POSTGRES_PASSWORD
+            - name: LOG_WRITER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-logs-auth
+                  key: LOG_WRITER_PASSWORD
+            - name: LOG_READER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-logs-auth
+                  key: LOG_READER_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "2000m"
+              memory: "4Gi"
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: initdb
+              mountPath: /docker-entrypoint-initdb.d
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres", "-d", "logs"]
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres", "-d", "logs"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+      volumes:
+        - name: initdb
+          configMap:
+            name: postgres-logs-initdb
+            defaultMode: 0755
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi

--- a/retention-cronjob.yaml
+++ b/retention-cronjob.yaml
@@ -1,0 +1,61 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres-logs-retention
+  labels:
+    app: postgres-logs
+spec:
+  # 04:00 UTC every Sunday — archive lead time ensures deleted rows already
+  # live in S3 Parquet (monthly archive runs day 1; retention boundary is ~11
+  # months behind the most recent archived month).
+  schedule: "0 4 * * 0"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 604800
+      template:
+        spec:
+          priorityClassName: opportunistic
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: feature.node.kubernetes.io/pci-10de.present
+                        operator: NotIn
+                        values: ["true"]
+          containers:
+            - name: retention
+              image: postgres:16
+              env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-logs-auth
+                      key: POSTGRES_PASSWORD
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+                  psql -h postgres-logs -U postgres -d logs -v ON_ERROR_STOP=1 <<'SQL'
+                  BEGIN;
+                  WITH del AS (
+                      DELETE FROM logs
+                      WHERE ts < now() - INTERVAL '365 days'
+                      RETURNING 1
+                  )
+                  SELECT count(*) AS rows_deleted FROM del;
+                  COMMIT;
+                  SQL
+              resources:
+                requests:
+                  cpu: "200m"
+                  memory: "256Mi"
+                limits:
+                  cpu: "200m"
+                  memory: "256Mi"


### PR DESCRIPTION
## Summary
- Swap the per-worker 60s S3 JSONL flush for per-event `INSERT` into a Postgres `logs` table (JSONB). Sub-second freshness, rich query surface via SQL, queryable from anywhere using a read-only role — no k8s auth required.
- Stdout stays as live tail / fallback (kubectl unchanged). Postgres failures degrade to stdout-only logging — proxy never blocks on the log sink.
- New monthly CronJob dumps the previous month's rows to `s3://logs-open-llm-proxy/archive/YYYY-MM.parquet` (zstd). Weekly retention CronJob deletes rows > 365 days old.

## Why
The old flush wrote a separate JSONL chunk per worker every 60s — hundreds of tiny files per day made queries slow (many S3 round-trips) and raising `FLUSH_INTERVAL` would have hurt live debugging. Postgres decouples ingestion latency from archive granularity: live queries hit one indexed table, archives are one big Parquet per month.

## What's new

**Manifests:**
- `postgres-statefulset.yaml` — Postgres 16, 10 Gi PVC, GPU-node avoidance
- `postgres-service.yaml` — `type: LoadBalancer` on 5432
- `postgres-initdb-configmap.yaml` — schema + `log_writer` (INSERT) and `log_reader` (SELECT) roles, created on first-init
- `archive-cronjob.yaml` — `0 3 1 * *`, DuckDB `postgres` + `httpfs` extensions, one `COPY` to Parquet
- `retention-cronjob.yaml` — `0 4 * * 0`, `DELETE FROM logs WHERE ts < now() - INTERVAL '365 days'`

**Code / config:**
- `llm_proxy.py` — drop `_log_buffer`/`_flush_to_s3`/`_flush_loop`; new `_init_pg_pool` + fire-and-forget `_pg_insert` with held task refs; stdout `print(..., flush=True)` stays unconditional
- `deployment.yaml` — `boto3` → `asyncpg` in `uvx --with`, drop `AWS_*` env, add `LOG_DB_URL` from `open-llm-proxy-secrets`

**Docs:**
- `LOGGING.md` — rewritten for Postgres-primary access (`LOG_DB_READ_URL`), plus S3 Parquet archive format and bootstrap steps
- `AGENTS.md` — updated log-evaluation stanza

## Bootstrap (not in this PR — run manually before rolling the proxy)
1. Create `postgres-logs-auth` secret with three random passwords (`POSTGRES_PASSWORD`, `LOG_WRITER_PASSWORD`, `LOG_READER_PASSWORD`) — exact `kubectl create secret` command in LOGGING.md
2. Add `log-db-url` key to `open-llm-proxy-secrets` (writer DSN: `postgresql://log_writer:<PW>@postgres-logs:5432/logs`)
3. `kubectl apply` Postgres manifests, wait for LoadBalancer IP, verify external 5432 connectivity
4. `kubectl apply` the two CronJobs
5. `kubectl rollout restart deployment/open-llm-proxy`

## Test plan
- [ ] Postgres pod becomes Ready; `psql` as superuser confirms `logs` table + `log_writer` + `log_reader` roles exist
- [ ] LoadBalancer Service gets an external IP; `psql` from a laptop with `LOG_DB_READ_URL` returns rows
- [ ] Proxy rollout: `kubectl logs` shows `✓ Postgres log pool connected`
- [ ] Send a chat completion; verify both `request` and `response` rows appear in `logs` within 1 s
- [ ] Kill the Postgres pod briefly; verify proxy keeps serving, stdout keeps logging, and rows resume flowing after Postgres comes back
- [ ] Manually trigger the archive CronJob on a small date range; verify a `YYYY-MM.parquet` appears and DuckDB can read it
- [ ] Manually trigger the retention CronJob with a tighter interval in a dev copy; verify `DELETE` count is sensible