### PR TITLE
logs: tiered-rollup CronJobs consolidate JSONL into daily/monthly Parquet

### DIFF
--- a/LOGGING.md
+++ b/LOGGING.md
@@ -7,19 +7,41 @@ Logs are written to two places:
 1. **Pod stdout** — available immediately via `kubectl`, lost on pod restart
 2. **S3 bucket `logs-open-llm-proxy`** — flushed every 60 seconds (configurable via `FLUSH_INTERVAL` env var) as JSONL chunk files, persisted indefinitely
 
-### S3 layout
+### S3 layout (tiered rollup)
+
+Three tiers, each holding a different age of data. A daily CronJob rolls
+raw JSONL into daily Parquet; a monthly CronJob rolls completed months
+of daily Parquet into one monthly Parquet. At any moment:
 
 ```
 logs-open-llm-proxy/
-├── 2026-03-31/
-│   ├── 02-00-05-39.jsonl     # flush at 02:00:05 from worker PID 39
-│   ├── 02-05-07-39.jsonl
+├── 2026-04-17/                        ← today: raw JSONL (live debug tier)
+│   ├── 02-00-05-39.jsonl              # flush at 02:00:05 from worker PID 39
 │   └── ...
-├── 2026-04-01/
-│   └── ...
+├── consolidated/
+│   ├── daily/
+│   │   ├── 2026-04-15.parquet         # recent completed days
+│   │   └── 2026-04-16.parquet
+│   └── monthly/
+│       ├── 2026-02.parquet            # older completed months
+│       └── 2026-03.parquet
 ```
 
-Each file is newline-delimited JSON (one log entry per line, mix of request and response entries).
+| Tier | Format | When it gets written | When it gets deleted |
+|---|---|---|---|
+| Raw JSONL (`YYYY-MM-DD/*.jsonl`) | JSONL chunks | Proxy flushes every 60s | Next day's daily consolidation (03:00 UTC) |
+| Daily (`consolidated/daily/YYYY-MM-DD.parquet`) | Parquet (zstd) | Daily cron at 03:00 UTC | Monthly rollup on day 2 (04:00 UTC) |
+| Monthly (`consolidated/monthly/YYYY-MM.parquet`) | Parquet (zstd) | Monthly cron on day 2 | Never (long-term archive) |
+
+The **Parquet schema** (identical across daily and monthly tiers):
+
+| Column | Type | Notes |
+|---|---|---|
+| `ts` | `TIMESTAMPTZ` | Extracted from the `timestamp` field of the raw JSON |
+| `type` | `VARCHAR` | `'request'` or `'response'` |
+| `request_id` | `VARCHAR` | Correlates request ↔ response |
+| `origin` | `VARCHAR` | App the traffic came from |
+| `entry` | `VARCHAR` | The full original JSON record — parse with `entry::JSON` |
 
 ## Access pattern
 
@@ -32,23 +54,30 @@ duckdb -s "
 CREATE SECRET logs_s3 (TYPE S3, KEY_ID '$LOG_S3_KEY', SECRET '$LOG_S3_SECRET',
   ENDPOINT 's3-west.nrp-nautilus.io', USE_SSL true, URL_STYLE 'path');
 
--- All logs for a date
-SELECT * FROM read_ndjson_auto('s3://logs-open-llm-proxy/2026-03-31/*.jsonl', union_by_name=true);
+-- Historical: all consolidated data in one read (daily + monthly Parquet)
+SELECT ts, entry::JSON->>'user_question' AS q
+FROM read_parquet('s3://logs-open-llm-proxy/consolidated/**/*.parquet')
+WHERE entry::JSON->>'origin' = 'https://tpl.nrp-nautilus.io'
+  AND ts > now() - INTERVAL 7 DAYS;
 
--- Filter to one app
-SELECT * FROM read_ndjson_auto('s3://logs-open-llm-proxy/2026-03-31/*.jsonl', union_by_name=true)
-WHERE origin = 'https://padus.nrp-nautilus.io';
+-- Today's live data (raw JSONL — narrow the glob to an hour when possible)
+SELECT * FROM read_ndjson_auto(
+  's3://logs-open-llm-proxy/2026-04-17/*.jsonl', union_by_name=true);
 
--- Pair requests and responses
-SELECT req.user_question, req.timestamp, resp.tool_calls, resp.tokens
-FROM read_ndjson_auto('s3://logs-open-llm-proxy/2026-03-31/*.jsonl', union_by_name=true) req
-JOIN read_ndjson_auto('s3://logs-open-llm-proxy/2026-03-31/*.jsonl', union_by_name=true) resp
+-- Pair requests and responses from consolidated Parquet
+SELECT req.ts, req.entry::JSON->>'user_question' AS q,
+       resp.entry::JSON->'tool_calls' AS tools,
+       (resp.entry::JSON->>'latency_ms')::INT AS ms
+FROM read_parquet('s3://logs-open-llm-proxy/consolidated/**/*.parquet') req
+JOIN read_parquet('s3://logs-open-llm-proxy/consolidated/**/*.parquet') resp
   ON req.request_id = resp.request_id
 WHERE req.type = 'request' AND resp.type = 'response';
 "
 ```
 
-**Narrow the glob to the current hour** when looking at recent traffic — do NOT scan the whole day. Example: `2026-03-31/14-*.jsonl`. `union_by_name=true` handles schema drift across chunks (e.g. the `error` column appears only in some files). If the queried window has zero error responses, `error` is absent from all files — omit it from JOIN queries or use `TRY(resp.error)`.
+For queries that span today + history, UNION raw JSONL and consolidated Parquet with a shared projection (cast JSONL rows' `timestamp` to `TIMESTAMPTZ` and wrap the full row back into JSON if needed).
+
+**Narrow the raw JSONL glob to the current hour** (e.g. `2026-04-17/14-*.jsonl`) — do NOT scan the whole day. `union_by_name=true` handles schema drift across chunks (e.g. the `error` column appears only in some files). If the queried window has zero error responses, `error` is absent from all files — omit it from JOIN queries or use `TRY(resp.error)`.
 
 **Temporal filter:** `timestamp` is stored as VARCHAR (ISO8601). Cast to `TIMESTAMPTZ` (not `TIMESTAMP`) when comparing against `now()`:
 ```sql

--- a/consolidate-daily-cronjob.yaml
+++ b/consolidate-daily-cronjob.yaml
@@ -1,0 +1,132 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: logs-consolidate-daily
+  labels:
+    app: logs-consolidate
+spec:
+  # 03:00 UTC every day — consolidates each completed YYYY-MM-DD/ directory
+  # of JSONL chunks into one consolidated/daily/YYYY-MM-DD.parquet and deletes
+  # the originals. Idempotent: skips days that already have a Parquet and
+  # always skips today (still being written).
+  schedule: "0 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 604800
+      template:
+        spec:
+          priorityClassName: opportunistic
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: feature.node.kubernetes.io/pci-10de.present
+                        operator: NotIn
+                        values: ["true"]
+          containers:
+            - name: consolidate
+              image: python:3.12-slim
+              env:
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom: { secretKeyRef: { name: aws, key: AWS_ACCESS_KEY_ID } }
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom: { secretKeyRef: { name: aws, key: AWS_SECRET_ACCESS_KEY } }
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+                  pip install --quiet duckdb boto3
+                  python - <<'PY'
+                  import os, datetime, boto3, duckdb
+                  from botocore.client import Config
+
+                  BUCKET   = 'logs-open-llm-proxy'
+                  ENDPOINT = 'http://rook-ceph-rgw-nautiluss3.rook'
+
+                  s3 = boto3.client(
+                      's3',
+                      endpoint_url=ENDPOINT,
+                      aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
+                      aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
+                      config=Config(s3={'addressing_style': 'path'}),
+                  )
+
+                  today = datetime.datetime.utcnow().date().isoformat()
+                  paginator = s3.get_paginator('list_objects_v2')
+
+                  # Discover all YYYY-MM-DD/ prefixes at the bucket root
+                  date_prefixes = set()
+                  for page in paginator.paginate(Bucket=BUCKET, Delimiter='/'):
+                      for p in page.get('CommonPrefixes', []):
+                          pref = p['Prefix'].rstrip('/')
+                          try:
+                              datetime.date.fromisoformat(pref)
+                              date_prefixes.add(pref)
+                          except ValueError:
+                              pass
+
+                  # Existing consolidated daily Parquet files
+                  existing = set()
+                  for page in paginator.paginate(Bucket=BUCKET, Prefix='consolidated/daily/'):
+                      for obj in page.get('Contents', []):
+                          name = obj['Key'].split('/')[-1]
+                          if name.endswith('.parquet'):
+                              existing.add(name[:-len('.parquet')])
+
+                  to_do = sorted(d for d in date_prefixes if d != today and d not in existing)
+                  print(f"Days to consolidate ({len(to_do)}): {to_do}")
+                  if not to_do:
+                      print("Nothing to do.")
+                      raise SystemExit(0)
+
+                  con = duckdb.connect()
+                  con.execute(f"""
+                      CREATE SECRET s3_logs (
+                          TYPE S3,
+                          KEY_ID '{os.environ["AWS_ACCESS_KEY_ID"]}',
+                          SECRET '{os.environ["AWS_SECRET_ACCESS_KEY"]}',
+                          ENDPOINT 'rook-ceph-rgw-nautiluss3.rook',
+                          USE_SSL false,
+                          URL_STYLE 'path'
+                      )
+                  """)
+
+                  for day in to_do:
+                      print(f"→ {day}")
+                      con.execute(f"""
+                          COPY (
+                              SELECT (json->>'timestamp')::TIMESTAMPTZ AS ts,
+                                     json->>'type'       AS type,
+                                     json->>'request_id' AS request_id,
+                                     json->>'origin'     AS origin,
+                                     json::VARCHAR       AS entry
+                              FROM read_ndjson_objects('s3://{BUCKET}/{day}/*.jsonl')
+                              ORDER BY ts
+                          ) TO 's3://{BUCKET}/consolidated/daily/{day}.parquet'
+                            (FORMAT PARQUET, COMPRESSION zstd)
+                      """)
+                      # Verify Parquet exists before destroying inputs
+                      s3.head_object(Bucket=BUCKET, Key=f'consolidated/daily/{day}.parquet')
+                      to_delete = []
+                      for page in paginator.paginate(Bucket=BUCKET, Prefix=f'{day}/'):
+                          for obj in page.get('Contents', []):
+                              to_delete.append({'Key': obj['Key']})
+                      for i in range(0, len(to_delete), 1000):
+                          s3.delete_objects(Bucket=BUCKET, Delete={'Objects': to_delete[i:i+1000]})
+                      print(f"  ✓ {len(to_delete)} JSONL chunks removed")
+                  print("Done.")
+                  PY
+              resources:
+                requests:
+                  cpu: "500m"
+                  memory: "1Gi"
+                limits:
+                  cpu: "500m"
+                  memory: "1Gi"

--- a/consolidate-monthly-cronjob.yaml
+++ b/consolidate-monthly-cronjob.yaml
@@ -1,0 +1,114 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: logs-consolidate-monthly
+  labels:
+    app: logs-consolidate
+spec:
+  # 04:00 UTC on day 2 of every month — merges the just-closed month's daily
+  # Parquet files into consolidated/monthly/YYYY-MM.parquet, then deletes the
+  # daily inputs. Day 2 (not day 1) so the daily job for the 1st of the new
+  # month has already run and consolidated the final day of the previous month.
+  schedule: "0 4 2 * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 604800
+      template:
+        spec:
+          priorityClassName: opportunistic
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: feature.node.kubernetes.io/pci-10de.present
+                        operator: NotIn
+                        values: ["true"]
+          containers:
+            - name: rollup
+              image: python:3.12-slim
+              env:
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom: { secretKeyRef: { name: aws, key: AWS_ACCESS_KEY_ID } }
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom: { secretKeyRef: { name: aws, key: AWS_SECRET_ACCESS_KEY } }
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+                  pip install --quiet duckdb boto3
+                  python - <<'PY'
+                  import os, datetime, boto3, duckdb
+                  from botocore.client import Config
+
+                  BUCKET   = 'logs-open-llm-proxy'
+                  ENDPOINT = 'http://rook-ceph-rgw-nautiluss3.rook'
+
+                  s3 = boto3.client(
+                      's3',
+                      endpoint_url=ENDPOINT,
+                      aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
+                      aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
+                      config=Config(s3={'addressing_style': 'path'}),
+                  )
+
+                  # Previous completed month (UTC)
+                  today = datetime.datetime.utcnow().date()
+                  first_of_this_month = today.replace(day=1)
+                  prev_month_end  = first_of_this_month - datetime.timedelta(days=1)
+                  prev_month      = prev_month_end.strftime('%Y-%m')
+                  print(f"Rolling up month: {prev_month}")
+
+                  paginator = s3.get_paginator('list_objects_v2')
+
+                  # Daily files for that month
+                  daily_keys = []
+                  for page in paginator.paginate(Bucket=BUCKET, Prefix=f'consolidated/daily/{prev_month}-'):
+                      for obj in page.get('Contents', []):
+                          if obj['Key'].endswith('.parquet'):
+                              daily_keys.append(obj['Key'])
+                  print(f"Daily files found: {len(daily_keys)}")
+                  if not daily_keys:
+                      print("Nothing to roll up.")
+                      raise SystemExit(0)
+
+                  monthly_key = f'consolidated/monthly/{prev_month}.parquet'
+
+                  con = duckdb.connect()
+                  con.execute(f"""
+                      CREATE SECRET s3_logs (
+                          TYPE S3,
+                          KEY_ID '{os.environ["AWS_ACCESS_KEY_ID"]}',
+                          SECRET '{os.environ["AWS_SECRET_ACCESS_KEY"]}',
+                          ENDPOINT 'rook-ceph-rgw-nautiluss3.rook',
+                          USE_SSL false,
+                          URL_STYLE 'path'
+                      )
+                  """)
+                  con.execute(f"""
+                      COPY (
+                          SELECT * FROM read_parquet('s3://{BUCKET}/consolidated/daily/{prev_month}-*.parquet')
+                          ORDER BY ts
+                      ) TO 's3://{BUCKET}/{monthly_key}' (FORMAT PARQUET, COMPRESSION zstd)
+                  """)
+
+                  # Verify monthly file exists before deleting daily inputs
+                  s3.head_object(Bucket=BUCKET, Key=monthly_key)
+                  delete_batch = [{'Key': k} for k in daily_keys]
+                  for i in range(0, len(delete_batch), 1000):
+                      s3.delete_objects(Bucket=BUCKET, Delete={'Objects': delete_batch[i:i+1000]})
+                  print(f"✓ Rolled up {len(daily_keys)} daily files → {monthly_key}; daily files removed.")
+                  PY
+              resources:
+                requests:
+                  cpu: "500m"
+                  memory: "1Gi"
+                limits:
+                  cpu: "500m"
+                  memory: "1Gi"


### PR DESCRIPTION
## Summary
- Keep the existing architecture (proxy flushes JSONL to S3 every 60s — unchanged).
- Add two CronJobs that roll small JSONL files into coarser Parquet as they age, standard tiered / GFS-style rollup.
- No always-on infrastructure. Fixes the "hundreds of tiny files per day make queries slow" problem by reducing file count at the query surface.

## Why not Postgres
Explored in #10. A 24/7 Postgres Deployment is wrong shape for ~1 MiB/day of traffic on NRP — cluster policy expects resource requests to reflect actual usage. Batch rollups serve the same query-speed goal without an idle pod.

## Three-tier layout

| Age | Format | Path |
|---|---|---|
| Today | raw JSONL | `YYYY-MM-DD/HH-MM-SS-PID.jsonl` |
| Yesterday → end of previous month | daily Parquet (zstd) | `consolidated/daily/YYYY-MM-DD.parquet` |
| Any completed month | monthly Parquet (zstd) | `consolidated/monthly/YYYY-MM.parquet` |

Shared Parquet schema: `(ts TIMESTAMPTZ, type, request_id, origin, entry VARCHAR)` — `entry` is the full original JSON record. Query with `read_parquet('consolidated/**/*.parquet')`.

## Jobs

- **`consolidate-daily-cronjob.yaml`** — 03:00 UTC every day. Scans bucket for completed `YYYY-MM-DD/` directories without a matching daily Parquet, writes one Parquet per day, deletes the originals after verifying the write. Idempotent and safe to re-run. **First run backfills all existing historical days** (16 days of April 2026).
- **`consolidate-monthly-cronjob.yaml`** — 04:00 UTC on day 2 of every month. Merges previous month's daily Parquets into one monthly Parquet, deletes the dailies.

Both use `python:3.12-slim` + `pip install duckdb boto3`, `priorityClassName: opportunistic`, GPU-node avoidance.

## LOGGING.md
Updated with the tiered layout, Parquet schema, and query examples for all three tiers.

## Test plan
- [ ] `kubectl apply` both CronJobs
- [ ] Trigger a manual run of the daily job and verify it produces `consolidated/daily/2026-04-01.parquet` through `consolidated/daily/2026-04-16.parquet`
- [ ] Verify each source `YYYY-MM-DD/` directory is emptied on success
- [ ] Query `read_parquet('s3://.../consolidated/**/*.parquet')` and confirm rowcounts match the previous `pre-postgres-2026-04.parquet` snapshot (3494 rows)
- [ ] Delete the orphan `archive/pre-postgres-2026-04.parquet` snapshot once daily backfill is verified
- [ ] Let the daily job run on its schedule at 03:00 UTC and confirm today's directory gets consolidated the next day