### PR TITLE
docs: refresh AGENTS.md log-access stanza for tiered Parquet layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,27 +6,45 @@ This is an LLM proxy service that routes chat completion requests to NRP, OpenRo
 
 ## Evaluating Logs
 
-Logs live in two places: pod stdout (ephemeral) and S3 bucket `logs-open-llm-proxy` (persisted as JSONL chunks, preferred).
+Logs land in three tiers by age (see [LOGGING.md](LOGGING.md) for the full spec):
 
-The bucket is private. Agents should assume `LOG_S3_KEY` and `LOG_S3_SECRET` are pre-set in the shell and use those env vars via the Bash tool — the shell expands them at execution time so the values never appear in chat. Do not hunt for credentials in rclone config, k8s secrets, etc.
+- **Today**: raw JSONL at `s3://logs-open-llm-proxy/YYYY-MM-DD/*.jsonl` (sub-minute freshness)
+- **Historical**: Parquet at `s3://logs-open-llm-proxy/consolidated/**/*.parquet` — daily files roll up into monthly files on day 2 of the following month
+- **kubectl**: `kubectl -n biodiversity logs deployment/open-llm-proxy -f` for live tail of the last few seconds before the next S3 flush
+
+The bucket is private. `LOG_S3_KEY` and `LOG_S3_SECRET` are pre-set in the shell — use them via the Bash tool so shell expansion keeps the values out of chat. Do not hunt for credentials in rclone config or k8s secrets.
+
+**Parquet schema** (same for daily and monthly tiers): `(ts TIMESTAMPTZ, type, request_id, origin, entry VARCHAR)` — `entry` is the full original log record as JSON text. Access fields with `entry::JSON->>'field'`.
 
 ```bash
+# Historical: query the consolidated Parquet (this is the common case)
 duckdb -s "
 CREATE SECRET logs_s3 (TYPE S3, KEY_ID '$LOG_S3_KEY', SECRET '$LOG_S3_SECRET',
   ENDPOINT 's3-west.nrp-nautilus.io', USE_SSL true, URL_STYLE 'path');
-SELECT * FROM read_ndjson_auto('s3://logs-open-llm-proxy/2026-04-07/*.jsonl', union_by_name=true);
+SELECT ts, entry::JSON->>'user_question' AS q, entry::JSON->'tool_calls' AS tools
+FROM read_parquet('s3://logs-open-llm-proxy/consolidated/**/*.parquet')
+WHERE origin = 'https://tpl.nrp-nautilus.io' AND ts > now() - INTERVAL 7 DAYS
+ORDER BY ts DESC;
+"
+
+# Today: raw JSONL — narrow the glob to the current hour when possible
+duckdb -s "
+CREATE SECRET logs_s3 (TYPE S3, KEY_ID '$LOG_S3_KEY', SECRET '$LOG_S3_SECRET',
+  ENDPOINT 's3-west.nrp-nautilus.io', USE_SSL true, URL_STYLE 'path');
+SELECT * FROM read_ndjson_auto('s3://logs-open-llm-proxy/YYYY-MM-DD/*.jsonl',
+                               union_by_name=true);
 "
 ```
 
-Narrow the S3 glob to an hour (`2026-04-07/17-*.jsonl`) when you only need recent traffic.
-
-Each LLM call produces a `request` entry and a `response` entry linked by `request_id`. Key fields:
+Each LLM call produces a `request` row and a `response` row linked by `request_id`. Key fields inside `entry` (Parquet) or as top-level columns (JSONL):
 
 - **Request**: `user_question`, `tool_results_this_turn`, `model`, `origin`, `message_count`
-- **Response**: `tool_calls`, `content_preview`, `tokens`, `latency_ms`, `error` (sparse — only present in files that contain failures; omit from JOIN queries or use `TRY(resp.error)`)
+- **Response**: `tool_calls`, `content_preview`, `tokens`, `latency_ms`, `error` (only on failures)
 
-**Reconstructing a conversation**: group by `user_question`, filter by `origin`, sort by `timestamp`. The `tool_results_this_turn` on each request shows what the previous turn's tool calls returned; `tool_calls` on each response shows what the LLM called next.
+**Reconstructing a conversation**: group by `user_question`, filter by `origin`, sort by `ts` (Parquet) / `timestamp` (JSONL). The `tool_results_this_turn` on each request shows what the previous turn's tool calls returned; `tool_calls` on each response shows what the LLM called next.
 
-See [LOGGING.md](LOGGING.md) for full field reference, SQL patterns, kubectl access, and session reconstruction examples.
+**Midnight crossover caveat**: flush-time (not entry `ts`) determines the source file path. An entry with `ts = 23:59:58` may live in the next UTC day's file if it was buffered past midnight. Always filter on `ts`, not on file path, when you care about a calendar day.
+
+See [LOGGING.md](LOGGING.md) for full field reference, SQL patterns, kubectl access, session reconstruction examples, and the CronJob details.
 
 When analyzing geo-agent app behavior (tool-call counts, query failures, session reconstructions), invoke the `geo-agent-training` skill — it provides the full step-by-step diagnostic workflow.


### PR DESCRIPTION
AGENTS.md still described the pre-consolidation JSONL-only world. Replace with:

- Three-tier layout (today = JSONL, older = consolidated Parquet, live = kubectl)
- Correct Parquet schema and the `entry::JSON->>` field-access idiom
- Midnight-crossover caveat so agents filter on `ts`, not directory name

Also updated the `geo-agent-training` user-level skill (outside this repo) with the same query patterns — sanity-tested against real data.