### PR TITLE
headless: run matrix sweeps as a k8s Job, not locally

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,25 +75,29 @@ PROXY_KEY=... node run.js "QUESTION" \
 
 Tag experimental runs with a distinctive `--origin` suffix (e.g. `…/agent_runner`) so they're filterable apart from real user traffic when you later query the logs. See `headless/README.md` for all flags.
 
-### Matrix runs (model × question grids)
+### Matrix runs (model × question grids) — run on the cluster
 
-`headless/run_matrix.sh APP_DIR` runs every (model × question × trial) cell, writes a transcript per cell to `runs/<APP_NAME>/`, and emits a `summary.tsv`. Defaults: questions from `APP_DIR/layers-input.json` welcome.examples, models from `APP_DIR/k8s/configmap.yaml`, 2 trials, origin `https://<APP_NAME>.nrp-nautilus.io/agent_runner`.
+**Always run matrix sweeps as a Kubernetes Job, not locally.** `PROXY_KEY` lives in the `open-llm-proxy-secrets` Secret in the `biodiversity` namespace; on-cluster runs mount it directly, avoiding the local credential dance (stale `/tmp/proxy_key`, 401 sprees, laptop sleep killing a 20-minute matrix mid-run).
 
-**Use this — do not write a bespoke driver script per request.** Both inputs are env-overridable, so any ad-hoc matrix is a one-liner:
+`headless/run-matrix-k8s.sh APP_REPO` templates `headless/k8s/matrix-job.yaml` and `kubectl create`s a one-shot Job. The Job clones `open-llm-proxy` + `geo-agent` + the app repo in the sibling layout the runner expects, `npm ci`s, runs `run_matrix.sh`, and dumps per-cell transcripts + `summary.tsv` to pod stdout. Proxy logs (filtered by `ORIGIN`) carry the full request/response pairs.
 
 ```bash
-# Custom question list (one per line, blank lines and # comments OK):
-cat > /tmp/log-qs.txt <<'EOF'
+# 1. Write questions to a file (one per line, blank/#-comment lines ignored).
+cat > headless/runs/log-qs.txt <<'EOF'
 How much has the Land and Water Conservation Fund invested in Senate District 2?
 how many miles of river have been protected by TPL projects within Tahoe National Forest
 EOF
 
+# 2. Launch. APP_REPO is org/repo; QUESTIONS_FILE is local; TAG must be [a-z0-9-]+.
+TAG=logqs \
+QUESTIONS_FILE=headless/runs/log-qs.txt \
 MODELS="qwen3 qwen3-small glm-5 nemotron gemma" \
-QUESTIONS_FILE=/tmp/log-qs.txt \
 TRIALS=1 \
-ORIGIN=https://tpl-ca.nrp-nautilus.io/agent_runner_logqs \
-RUNS_DIR=runs/tpl-ca-logqs \
-  ./headless/run_matrix.sh ../tpl-ca
+  ./headless/run-matrix-k8s.sh boettiger-lab/tpl-ca
+
+# 3. Follow + analyze (commands printed by step 2).
+kubectl -n biodiversity logs -f job/<JOB_NAME>
+./sync-logs.sh && duckdb -s "... WHERE origin='<ORIGIN>' ..."
 ```
 
-When asked to "test these questions across these models," reach for this — populate `QUESTIONS_FILE` from the log questions, set `MODELS` from the user's list, pick an `ORIGIN` suffix that says what the run is for (so future log queries can grep it apart from production traffic and apart from other matrix runs), and launch.
+When asked to "test these questions across these models," reach for this — **do not** fall back to running `run_matrix.sh` locally and **do not** write a bespoke driver script per request. The local `run_matrix.sh` still exists, called by the Job; it is no longer a recommended user-facing entrypoint for matrix work.

--- a/headless/README.md
+++ b/headless/README.md
@@ -25,20 +25,66 @@ Three pieces are intentionally local:
 3. **`fetch` wrapper inside `run.js`** — injects the `Origin` header so proxy
    logs can tag headless runs. Node's `fetch` omits `Origin` by default.
 
-## Requirements
+## Matrix testing: run on the cluster, not locally
 
-- Node 20+
+For any (model × question × trial) sweep, use **`run-matrix-k8s.sh`**. It
+launches a one-shot Kubernetes Job that pulls `PROXY_KEY` from the
+`open-llm-proxy-secrets` Secret already in the `biodiversity` namespace — no
+local credential handling, no `/tmp/proxy_key` dance, no laptop sleep
+interrupting a 20-minute run.
+
+```bash
+# 1. Write the questions to a file (one per line).
+cat > runs/trails-q.txt <<'EOF'
+which state has the most federal trail miles
+EOF
+
+# 2. Launch.
+TAG=trails-matrix QUESTIONS_FILE=runs/trails-q.txt \
+  ./run-matrix-k8s.sh boettiger-lab/geo-agent-template
+
+# 3. Follow + analyze.
+kubectl -n biodiversity logs -f job/<JOB_NAME>     # printed by step 2
+./sync-logs.sh && duckdb -s "...WHERE origin='<ORIGIN>'..."  # filter the proxy logs
+```
+
+The Job clones `open-llm-proxy`, `geo-agent`, and the app repo in the
+sibling layout the runner expects, `npm ci`s, and delegates to
+`run_matrix.sh`. The per-cell JSON transcripts and `summary.tsv` are dumped
+to the pod's stdout at the end, so `kubectl logs job/<JOB_NAME>` is
+self-sufficient. Proxy logs (filtered by ORIGIN) carry the full
+request/response pairs.
+
+### Required env / flags
+
+| Var | Notes |
+|---|---|
+| `APP_REPO` (positional) | `org/repo` of the geo-agent app (e.g. `boettiger-lab/geo-agent-template`) |
+| `QUESTIONS_FILE` | Local file, one question per line. Read once and base64'd into the Job env. |
+| `TAG` | `[a-z0-9-]+` identifier — becomes `JOB_NAME` suffix and `ORIGIN` query tag |
+| `MODELS` | Optional override. Default: read from the app's `k8s/configmap.yaml` inside the pod |
+| `TRIALS` / `MAX_TURNS` / `APP_BRANCH` / `NAMESPACE` | Optional; sensible defaults |
+
+## Local single-run usage (ad-hoc debugging only)
+
+For iterating on the runner code itself, or reproducing one specific failure
+once, you can run `run.js` directly against the proxy. **Do not use this for
+matrix testing — use the k8s Job above.**
+
+### Requirements
+
+- Node 22+ (24 LTS recommended; the cluster Job uses 24)
 - `boettiger-lab/geo-agent` cloned as a sibling (`../../geo-agent/`)
-- A valid proxy key (same one the app uses), via `PROXY_KEY` env var or `--api-key`
+- A valid proxy key, via `PROXY_KEY` env var or `--api-key`
 
-## Install
+### Install
 
 ```bash
 cd headless
 npm install
 ```
 
-## Usage
+### Run one question
 
 ```bash
 PROXY_KEY=... node run.js "Which New Jersey municipalities have passed conservation ballot measures?" \

--- a/headless/k8s/matrix-job.yaml
+++ b/headless/k8s/matrix-job.yaml
@@ -1,0 +1,123 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  labels:
+    app: headless-matrix
+    matrix-tag: ${TAG}
+    matrix-app: ${APP_NAME}
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app: headless-matrix
+        matrix-tag: ${TAG}
+        matrix-app: ${APP_NAME}
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      containers:
+        - name: matrix
+          image: node:24-bookworm-slim
+          env:
+            - name: PROXY_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: open-llm-proxy-secrets
+                  key: proxy-key
+            - name: APP_REPO
+              value: "${APP_REPO}"
+            - name: APP_BRANCH
+              value: "${APP_BRANCH}"
+            - name: APP_NAME
+              value: "${APP_NAME}"
+            - name: ORIGIN
+              value: "${ORIGIN}"
+            - name: TRIALS
+              value: "${TRIALS}"
+            - name: MAX_TURNS
+              value: "${MAX_TURNS}"
+            - name: MODELS
+              value: "${MODELS}"
+            - name: QUESTIONS_B64
+              value: "${QUESTIONS_B64}"
+            - name: JOB_NAME
+              value: "${JOB_NAME}"
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              echo "=== headless matrix job: $JOB_NAME ==="
+              apt-get update -qq
+              apt-get install -y -qq --no-install-recommends \
+                  git ca-certificates python3 python3-yaml >/dev/null
+
+              # Clone repos into the sibling layout the headless runner expects:
+              #   /work/open-llm-proxy   /work/geo-agent   /work/<APP_NAME>
+              mkdir -p /work && cd /work
+              git clone --depth 1 https://github.com/boettiger-lab/open-llm-proxy.git
+              git clone --depth 1 https://github.com/boettiger-lab/geo-agent.git
+              git clone --depth 1 --branch "$APP_BRANCH" \
+                  "https://github.com/$APP_REPO.git" "$APP_NAME"
+
+              cd /work/open-llm-proxy/headless
+              npm ci --no-audit --no-fund
+
+              # PROXY_KEY → /tmp/proxy_key (run_matrix.sh reads from this path)
+              printf %s "$PROXY_KEY" > /tmp/proxy_key
+
+              # QUESTIONS_FILE: decode base64 blob from wrapper
+              QFILE=/tmp/questions.txt
+              echo "$QUESTIONS_B64" | base64 -d > "$QFILE"
+
+              echo "--- questions ---"
+              cat "$QFILE"
+              echo "--- models override: ${MODELS:-<from configmap>} ---"
+              echo
+
+              # Delegate to the existing matrix script. RUNS_DIR is pod-local;
+              # transcripts are dumped to stdout below so kubectl logs captures them.
+              RUNS_DIR_REL="runs/$JOB_NAME"
+              rc=0
+              QUESTIONS_FILE="$QFILE" \
+              ORIGIN="$ORIGIN" \
+              TRIALS="$TRIALS" \
+              MAX_TURNS="$MAX_TURNS" \
+              MODELS="$MODELS" \
+              RUNS_DIR="$RUNS_DIR_REL" \
+                  ./run_matrix.sh "/work/$APP_NAME" || rc=$?
+
+              echo
+              echo "=== per-cell transcripts (json) ==="
+              for f in "$RUNS_DIR_REL"/*.json; do
+                  [ -f "$f" ] || continue
+                  echo "----- $(basename "$f") -----"
+                  cat "$f"
+                  echo
+              done
+
+              echo "=== summary.tsv ==="
+              cat "$RUNS_DIR_REL/summary.tsv" 2>/dev/null || echo "(no summary written)"
+
+              echo
+              echo "=== filter proxy logs by origin: $ORIGIN ==="
+              exit "$rc"
+          resources:
+            requests:
+              cpu: "1"
+              memory: "2Gi"
+              ephemeral-storage: "5Gi"
+            limits:
+              cpu: "1"
+              memory: "2Gi"
+              ephemeral-storage: "5Gi"

--- a/headless/run-matrix-k8s.sh
+++ b/headless/run-matrix-k8s.sh
@@ -65,7 +65,11 @@ QUESTIONS_B64="$(base64 -w0 < "$QUESTIONS_FILE")"
 
 export APP_REPO APP_BRANCH APP_NAME JOB_NAME ORIGIN TAG TRIALS MAX_TURNS MODELS QUESTIONS_B64
 
-envsubst < k8s/matrix-job.yaml | kubectl -n "$NAMESPACE" create -f -
+# Allowlist: only these placeholders are substituted. Without this, envsubst
+# also replaces every $VAR reference in the bash script body (e.g. $QFILE,
+# $PROXY_KEY, $rc) with empty strings, breaking the pod at runtime.
+envsubst '${APP_REPO} ${APP_BRANCH} ${APP_NAME} ${JOB_NAME} ${ORIGIN} ${TAG} ${TRIALS} ${MAX_TURNS} ${MODELS} ${QUESTIONS_B64}' \
+    < k8s/matrix-job.yaml | kubectl -n "$NAMESPACE" create -f -
 
 cat <<EOF
 

--- a/headless/run-matrix-k8s.sh
+++ b/headless/run-matrix-k8s.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# run-matrix-k8s.sh — launch the headless matrix as a one-shot Kubernetes Job.
+#
+# Why this is the default: the proxy key lives in the cluster (Secret
+# `open-llm-proxy-secrets`, key `PROXY_KEY`). Running on-cluster mounts it
+# directly — no local credential handling, no `/tmp/proxy_key` dance.
+#
+# Usage:
+#   QUESTIONS_FILE=... TAG=... ./run-matrix-k8s.sh APP_REPO
+#
+# Positional:
+#   APP_REPO        org/repo of the geo-agent app (e.g. boettiger-lab/geo-agent-template)
+#
+# Required env:
+#   QUESTIONS_FILE  path to a file with one question per line (read locally,
+#                   base64-encoded into the Job env)
+#   TAG             short suffix to identify this run; appears in JOB_NAME and
+#                   ORIGIN. Must match [a-z0-9-]+ (e.g. trails-mileage).
+#
+# Optional env:
+#   MODELS          space-separated model override (default: read from
+#                   APP_REPO/k8s/configmap.yaml inside the pod)
+#   TRIALS          trials per (model, question) (default 2)
+#   MAX_TURNS       agent maxToolCalls (default 20)
+#   APP_BRANCH      app repo branch to clone (default main)
+#   NAMESPACE       k8s namespace (default biodiversity)
+#
+# After applying, the script prints the JOB_NAME and the kubectl/duckdb
+# follow-up commands. The Job logs (kubectl logs job/$JOB_NAME) include the
+# per-cell JSON transcripts and the summary.tsv on completion; the proxy logs
+# (filterable by ORIGIN) carry the full request/response pairs for analysis.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+APP_REPO="${1:-}"
+if [ -z "$APP_REPO" ]; then
+    echo "ERROR: APP_REPO positional argument required (e.g. boettiger-lab/geo-agent-template)" >&2
+    exit 2
+fi
+APP_NAME="$(basename "$APP_REPO")"
+
+: "${QUESTIONS_FILE:?QUESTIONS_FILE is required}"
+: "${TAG:?TAG is required (short identifier, [a-z0-9-]+)}"
+[ -s "$QUESTIONS_FILE" ] || { echo "ERROR: $QUESTIONS_FILE missing or empty" >&2; exit 2; }
+if ! [[ "$TAG" =~ ^[a-z0-9-]+$ ]]; then
+    echo "ERROR: TAG must match [a-z0-9-]+ (got: '$TAG')" >&2
+    exit 2
+fi
+
+MODELS="${MODELS:-}"
+TRIALS="${TRIALS:-2}"
+MAX_TURNS="${MAX_TURNS:-20}"
+APP_BRANCH="${APP_BRANCH:-main}"
+NAMESPACE="${NAMESPACE:-biodiversity}"
+
+TS="$(date -u +%Y%m%d-%H%M%S)"
+JOB_NAME="hmx-${APP_NAME}-${TAG}-${TS}"
+JOB_NAME="${JOB_NAME:0:63}"
+
+# ORIGIN convention: <app>.nrp-nautilus.io/agent_runner_<tag>
+ORIGIN="https://${APP_NAME}.nrp-nautilus.io/agent_runner_${TAG//-/_}"
+
+QUESTIONS_B64="$(base64 -w0 < "$QUESTIONS_FILE")"
+
+export APP_REPO APP_BRANCH APP_NAME JOB_NAME ORIGIN TAG TRIALS MAX_TURNS MODELS QUESTIONS_B64
+
+envsubst < k8s/matrix-job.yaml | kubectl -n "$NAMESPACE" create -f -
+
+cat <<EOF
+
+job:    $JOB_NAME
+origin: $ORIGIN
+
+follow:
+  kubectl -n $NAMESPACE logs -f job/$JOB_NAME
+
+filter proxy logs (after ./sync-logs.sh):
+  duckdb -s "SELECT timestamp, list_transform(tool_calls, x->x.name) AS tools,
+                    SUBSTR(content_preview, 1, 200) AS preview
+             FROM read_ndjson_auto('/tmp/open-llm-proxy-logs/*/*.jsonl', union_by_name=true)
+             WHERE type='response' AND origin='$ORIGIN'
+             ORDER BY timestamp;"
+EOF


### PR DESCRIPTION
## Why

PROXY_KEY lives in the cluster (`open-llm-proxy-secrets` Secret, key `PROXY_KEY`). Running matrix sweeps locally requires shuttling that key through `/tmp/proxy_key`, which is fragile (silent 401 sprees from empty/stale env vars) and incompatible with sweeps that outlive a laptop sleep cycle. The cluster has the credential and stable wall-time — runs should happen there.

## What

- **`headless/k8s/matrix-job.yaml`** — Job template (envsubst-friendly). Node 24 LTS base, `opportunistic` priority, no-GPU affinity. Pulls PROXY_KEY from `open-llm-proxy-secrets`. Clones `open-llm-proxy` + `geo-agent` + the app repo at startup, `npm ci`s, runs `run_matrix.sh`, dumps per-cell transcripts + summary.tsv to pod stdout.
- **`headless/run-matrix-k8s.sh`** — wrapper. Reads a local questions file, base64-encodes it into the Job env, templates the YAML, `kubectl create`s the Job, prints follow-up commands.
- **README + AGENTS.md** — the k8s wrapper is the default for matrix work; local `node run.js` single-run is kept for ad-hoc iteration only.

## Design notes

- **Stdout-only persistence.** Proxy logs (filtered by ORIGIN) are the durable record; transcripts go to `kubectl logs`. No new S3 path, no PVCs. `ttlSecondsAfterFinished: 86400` keeps the Job pod retrievable for a day.
- **Clone-at-startup, not a baked image.** Adds ~60s per run but no image build/maintenance burden. Switch to a baked image only if startup becomes a real bottleneck.
- **No `kubectl wait`.** Matrix sweeps run as long as they run; wrapper returns immediately with follow commands.

## Test plan

- [x] `kubectl --dry-run=client apply` validates the templated Job
- [ ] After merge: run the trails matrix end-to-end against `boettiger-lab/geo-agent-template` (8 models × 1 question × 2 trials) and verify `kubectl logs` contains the summary + transcripts
- [ ] Verify proxy logs are tagged with the per-run ORIGIN suffix and filterable cleanly