### PR TITLE
headless/k8s: SYSTEM_PROMPT_APPEND_FILE for A/B-testing guidance

### DIFF
--- a/headless/k8s/matrix-job.yaml
+++ b/headless/k8s/matrix-job.yaml
@@ -51,6 +51,8 @@ spec:
               value: "${MODELS}"
             - name: QUESTIONS_B64
               value: "${QUESTIONS_B64}"
+            - name: SYSTEM_PROMPT_APPEND_B64
+              value: "${SYSTEM_PROMPT_APPEND_B64}"
             - name: JOB_NAME
               value: "${JOB_NAME}"
           command: ["/bin/bash", "-c"]
@@ -79,6 +81,18 @@ spec:
               # QUESTIONS_FILE: decode base64 blob from wrapper
               QFILE=/tmp/questions.txt
               echo "$QUESTIONS_B64" | base64 -d > "$QFILE"
+
+              # SYSTEM_PROMPT_APPEND_B64: optional overlay for A/B-testing
+              # guidance variants. Appended to the cloned app's system-prompt.md
+              # so the original app-specific text stays in place.
+              if [ -n "${SYSTEM_PROMPT_APPEND_B64:-}" ]; then
+                  SP="/work/$APP_NAME/system-prompt.md"
+                  echo "" >> "$SP"
+                  echo "$SYSTEM_PROMPT_APPEND_B64" | base64 -d >> "$SP"
+                  echo "--- system-prompt overlay applied (last 30 lines) ---"
+                  tail -30 "$SP"
+                  echo "----------------------------------------------------"
+              fi
 
               echo "--- questions ---"
               cat "$QFILE"

--- a/headless/run-matrix-k8s.sh
+++ b/headless/run-matrix-k8s.sh
@@ -18,12 +18,19 @@
 #                   ORIGIN. Must match [a-z0-9-]+ (e.g. trails-mileage).
 #
 # Optional env:
-#   MODELS          space-separated model override (default: read from
-#                   APP_REPO/k8s/configmap.yaml inside the pod)
-#   TRIALS          trials per (model, question) (default 2)
-#   MAX_TURNS       agent maxToolCalls (default 20)
-#   APP_BRANCH      app repo branch to clone (default main)
-#   NAMESPACE       k8s namespace (default biodiversity)
+#   MODELS                 space-separated model override (default: read from
+#                          APP_REPO/k8s/configmap.yaml inside the pod)
+#   TRIALS                 trials per (model, question) (default 2)
+#   MAX_TURNS              agent maxToolCalls (default 20)
+#   APP_BRANCH             app repo branch to clone (default main)
+#   NAMESPACE              k8s namespace (default biodiversity)
+#   SYSTEM_PROMPT_APPEND_FILE
+#                          path to a local file whose contents are appended to
+#                          the app's system-prompt.md before the matrix runs.
+#                          Use this to A/B-test guidance variants without
+#                          forking the app repo or building a custom MCP image.
+#                          The original system-prompt.md is left intact in the
+#                          pod, with the variant text concatenated on the end.
 #
 # After applying, the script prints the JOB_NAME and the kubectl/duckdb
 # follow-up commands. The Job logs (kubectl logs job/$JOB_NAME) include the
@@ -63,12 +70,19 @@ ORIGIN="https://${APP_NAME}.nrp-nautilus.io/agent_runner_${TAG//-/_}"
 
 QUESTIONS_B64="$(base64 -w0 < "$QUESTIONS_FILE")"
 
-export APP_REPO APP_BRANCH APP_NAME JOB_NAME ORIGIN TAG TRIALS MAX_TURNS MODELS QUESTIONS_B64
+SYSTEM_PROMPT_APPEND_B64=""
+if [ -n "${SYSTEM_PROMPT_APPEND_FILE:-}" ]; then
+    [ -s "$SYSTEM_PROMPT_APPEND_FILE" ] || { echo "ERROR: SYSTEM_PROMPT_APPEND_FILE=$SYSTEM_PROMPT_APPEND_FILE missing or empty" >&2; exit 2; }
+    SYSTEM_PROMPT_APPEND_B64="$(base64 -w0 < "$SYSTEM_PROMPT_APPEND_FILE")"
+fi
+
+export APP_REPO APP_BRANCH APP_NAME JOB_NAME ORIGIN TAG TRIALS MAX_TURNS MODELS \
+    QUESTIONS_B64 SYSTEM_PROMPT_APPEND_B64
 
 # Allowlist: only these placeholders are substituted. Without this, envsubst
 # also replaces every $VAR reference in the bash script body (e.g. $QFILE,
 # $PROXY_KEY, $rc) with empty strings, breaking the pod at runtime.
-envsubst '${APP_REPO} ${APP_BRANCH} ${APP_NAME} ${JOB_NAME} ${ORIGIN} ${TAG} ${TRIALS} ${MAX_TURNS} ${MODELS} ${QUESTIONS_B64}' \
+envsubst '${APP_REPO} ${APP_BRANCH} ${APP_NAME} ${JOB_NAME} ${ORIGIN} ${TAG} ${TRIALS} ${MAX_TURNS} ${MODELS} ${QUESTIONS_B64} ${SYSTEM_PROMPT_APPEND_B64}' \
     < k8s/matrix-job.yaml | kubectl -n "$NAMESPACE" create -f -
 
 cat <<EOF


### PR DESCRIPTION
## Why

The k8s matrix runner from #18 lets us measure model behavior on the cluster, but to **test a proposed guidance change** before filing an mcp-data-server issue we still need to actually deploy the variant. Building a custom MCP image and deploying a separate pod for each wording iteration is heavy. This adds the lightest viable A/B path: append a local variant file to the cloned app's \`system-prompt.md\` before the matrix runs.

Lower fidelity than modifying \`h3-guide.md\` proper (the variant lands in the system-prompt slot rather than the tool-docstring slot, so attention/positioning differs). High enough to A/B *direction* before committing to a heavier test setup.

## Usage

\`\`\`bash
SYSTEM_PROMPT_APPEND_FILE=runs/p4-revised-v1.md \
TAG=p4-revised-v1 \
QUESTIONS_FILE=runs/trails-q.txt \
  ./run-matrix-k8s.sh boettiger-lab/geo-agent-template
\`\`\`

The variant file is base64'd into the Job env at launch and appended to \`/work/\$APP_NAME/system-prompt.md\` after the clone. The job logs the last 30 lines of the resulting prompt so the overlay is auditable. Two matrix runs with different TAGs give two ORIGIN-filterable log streams to compare.

## Test plan

- [x] Validates with envsubst allowlist (\`${SYSTEM_PROMPT_APPEND_B64}\` added to the list)
- [ ] In-flight: matrix run with a proposed line-data Problem 4 rewording against the same 8 models / trails question used as baseline in #18's verification. Will post antipattern-rate comparison on completion.