### PR TITLE
Add direct Anthropic provider (OpenAI-compatible endpoint)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Configured in `config.json`. Most deployments only need NRP:
 |---|---|---|
 | **NRP** (`ellm.nrp-nautilus.io`) | `kimi`, `qwen3`, `glm-4.7`, `minimax-m2`, `gpt-oss`, `gemma` | Default; supports `enable_thinking` for applicable models |
 | **OpenRouter** | `anthropic/…`, `mistralai/…`, `openai/…`, `qwen/…`, `nvidia/…`, `amazon/…` | Prefix match; requires separate API key |
+| **Anthropic** | `claude-…` (default `claude-sonnet-4-6`; `claude-opus-4-8`, `claude-haiku-4-5` also route) | Direct via Anthropic's OpenAI-compatible `/v1/chat/completions`; prefix match. Bills the Developer Platform API (not the Claude.ai Team plan) — set `ANTHROPIC_API_KEY`. The default model is chosen app-side (`llm_model`); the proxy just routes whatever `claude-*` it receives |
 | **Nimbus** | `nemotron` | Private vLLM instance; requires separate API key |
 
 Unknown models fall back to NRP. To customize the model list, edit `config.json` — no code change needed.

--- a/config.json
+++ b/config.json
@@ -34,6 +34,16 @@
                 "X-Title": "Open LLM Proxy"
             }
         },
+        "anthropic": {
+            "endpoint": "https://api.anthropic.com/v1/chat/completions",
+            "api_key_env": "ANTHROPIC_API_KEY",
+            "models": [
+                "claude-",
+                "claude-sonnet-4-6",
+                "claude-haiku-4-5",
+                "claude-opus-4-8"
+            ]
+        },
         "nimbus": {
             "endpoint": "https://vllm-nimbus.carlboettiger.info/v1/chat/completions",
             "api_key_env": "NIMBUS_API_KEY",

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -59,6 +59,11 @@ spec:
             secretKeyRef:
               name: nimbus-api-key
               key: NIMBUS_API_KEY
+        - name: ANTHROPIC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: anthropic-api-key
+              key: ANTHROPIC_API_KEY
         - name: CACHE_SALT
           valueFrom:
             secretKeyRef:

--- a/secrets.yaml.example
+++ b/secrets.yaml.example
@@ -40,3 +40,10 @@ stringData:
 #
 #   kubectl create secret generic nimbus-api-key \
 #     --from-literal=NIMBUS_API_KEY='your-key' -n <your-namespace>
+#
+#   Anthropic (direct, OpenAI-compatible endpoint — bills the Developer
+#   Platform API, NOT the Claude.ai Team plan; create the key in the
+#   Console under the same org as an org admin):
+#
+#   kubectl create secret generic anthropic-api-key \
+#     --from-literal=ANTHROPIC_API_KEY='sk-ant-...' -n <your-namespace>


### PR DESCRIPTION
Routes `claude-*` models directly to Anthropic's OpenAI-compatible `/v1/chat/completions` endpoint instead of through OpenRouter — direct Developer Platform API billing (separate channel from the Claude.ai Team subscription), no OpenRouter markup.

## Changes
- **config.json**: new `anthropic` provider (`api.anthropic.com/v1/chat/completions`, `ANTHROPIC_API_KEY`), routed on the `claude-` prefix. Default `claude-sonnet-4-6`; `claude-opus-4-8` / `claude-haiku-4-5` also route.
- **deployment.yaml**: `ANTHROPIC_API_KEY` env from the `anthropic-api-key` secret.
- **secrets.yaml.example / README**: document the provider and the subscription-vs-API billing distinction.

## Notes
- No geo-agent change needed — the compat endpoint speaks OpenAI shape on both request and response, which is exactly what the app sends/parses.
- The actual default model is selected app-side (`llm_model`); the proxy just routes whatever `claude-*` it receives.
- Prompt-caching control is limited on the compat endpoint — tracked in #20.