### PR TITLE
Add duckdb-geo MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+    "mcpServers": {
+        "duckdb-geo": {
+            "type": "http",
+            "url": "https://duckdb-mcp.nrp-nautilus.io/mcp"
+        }
+    }
+}


### PR DESCRIPTION
Adds `.mcp.json` declaring the NRP `duckdb-mcp` HTTP server (`https://duckdb-mcp.nrp-nautilus.io/mcp`) as `duckdb-geo`, matching the config in `data-workflows`. Makes the geo data query MCP tool available when working in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)