### PR TITLE
DNS tuning (ndots:2, attempts:3) to curb upstream EAI_AGAIN 502s

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -22,6 +22,24 @@ spec:
       labels:
         app: open-llm-proxy
     spec:
+      # DNS tuning to curb intermittent upstream "Temporary failure in name
+      # resolution" (EAI_AGAIN) → 502s. See issue #28.
+      #  - ndots:2 — the provider host `ellm.nrp-nautilus.io` has 2 dots, so the
+      #    default ndots:5 appends every search domain FIRST (4 guaranteed-
+      #    NXDOMAIN queries before the real one), 5x-ing CoreDNS load and the
+      #    chance of a transient miss. ndots:2 queries it absolute first (1
+      #    query) while still letting in-cluster short names like
+      #    `rook-ceph-rgw-nautiluss3.rook` (1 dot, for the S3 flush) use search.
+      #  - attempts:3 / timeout:2 — let the resolver re-query a transient miss
+      #    before the app ever sees an error.
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "2"
+          - name: attempts
+            value: "3"
+          - name: timeout
+            value: "2"
       affinity:
         # Spread replicas across nodes so one stuck/unhealthy node can't take
         # the whole service down.


### PR DESCRIPTION
Closes #28 (Step 1).

## What
Adds a pod `dnsConfig` to `deployment.yaml`:
```yaml
dnsConfig:
  options:
    - { name: ndots, value: "2" }
    - { name: attempts, value: "3" }
    - { name: timeout, value: "2" }
```

## Why
Pods resolve `ellm.nrp-nautilus.io` (the upstream provider) under the default `ndots:5` with 5 search domains, so the resolver fires **4 guaranteed-NXDOMAIN queries before the real one** — amplifying CoreDNS load and the chance of an intermittent `Temporary failure in name resolution` (EAI_AGAIN) that surfaces to apps as a mid-session 502. See #28 for the full diagnosis (logs, burst pattern, why the client's existing retry and a health check don't address it).

`ndots:2` makes external FQDNs (≥2 dots) query absolute first (1 query), while in-cluster short names like `rook-ceph-rgw-nautiluss3.rook` (1 dot, used by the S3 flush) still resolve via the search list. `attempts:3`/`timeout:2` let the resolver retry a transient miss before the app sees an error.

## Risk
Low — DNS-resolution behavior only, no code change. Complementary to the geo-agent client's existing one-shot 5xx retry.

## Verify after deploy
- `kubectl -n biodiversity exec deploy/open-llm-proxy -- cat /etc/resolv.conf` shows `options ndots:2 attempts:3 timeout:2`.
- DNS-fail rate drops: `kubectl -n biodiversity logs -l app=open-llm-proxy --since=30m | grep -c 'name resolution'` trends toward zero.

## Follow-up
If failures persist after this is deployed and observed, Step 2 (shared pooled `httpx.AsyncClient` to eliminate per-request DNS lookups) — tracked in #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)