### PR TITLE
Populate session_id from the OpenAI `user` body field (#31)

### DIFF
--- a/LOGGING.md
+++ b/LOGGING.md
@@ -205,9 +205,10 @@ Each LLM call produces two JSON entries on stdout: a `REQUEST` line when the cal
 | `model` | Model name as sent by the client |
 | `origin` | Origin or Referer header — identifies which app sent the request |
 | `client` | `X-Client` header — client app + version, e.g. `geo-agent/v3.13.1`. `null` until the client sends it. Correlates logged behavior with a specific release. |
+| `session_id` | Stable per-browser-session id that ties together every turn **and every follow-up question** of one user session. Sourced from the request body's OpenAI `user` field (geo-agent already sends its per-session UUID there), falling back to the `X-Session-Id` header. **`null` in records written before this was wired up** (see wiring note below) — for those, fall back to the `(origin, user_question)` heuristic and mind the `user_question` caveat. |
 | `message_count` | Total messages in the conversation at this turn |
 | `tools_count` | Number of tools available to the LLM |
-| `user_question` | First `role: user` message in the conversation — the human's original question, stable across all turns of a tool-use loop. Capped at `LOG_USER_QUESTION_MAX` chars (default 4000). |
+| `user_question` | First `role: user` message in the conversation. ⚠️ **First-message-only — this is a trap.** It is the human's *original* opening question and is stable across all turns of a tool-use loop, but it does **not** update when the user asks a follow-up in the same session. A session where the user opens with "Tell me about datasets" and later asks "now map the hardwood woodland" logs **both** turns under `user_question = "Tell me about datasets"`; the follow-up text lives only inside the `messages` array (`full` mode) and is invisible to any `user_question` filter. To find follow-ups, full-text-search the whole record or capture `session_id`. Capped at `LOG_USER_QUESTION_MAX` chars (default 4000). |
 | `tool_results_this_turn` | Array of `{tool_call_id, content}` for any `role: tool` messages appended since the last assistant turn. Captures results from both local geo-agent tools (e.g. `list_datasets`, `get_dataset_details`) and remote MCP tools (e.g. `query`). Each `content` is capped at `LOG_TOOL_RESULT_MAX` chars (default 20000). `null` on the first turn. |
 | `messages` | **Only when `LOG_CAPTURE_MODE=full`.** The entire scrubbed `messages` array sent to the provider — training-grade fidelity. The large system prompt is de-duplicated: each `role: system` message is replaced by `{role, system_sha256, content_len, _dedup: true}` and the full body is emitted once (per worker) as a separate `type: "system_prompt"` entry. Join `messages[].system_sha256` → the `system_prompt` entry to rehydrate. |
 
@@ -227,6 +228,7 @@ Each LLM call produces two JSON entries on stdout: a `REQUEST` line when the cal
 | `model` | Model used |
 | `origin` | Same as request — identifies which app |
 | `client` | Same as request — `X-Client` header (client app + version), `null` until sent |
+| `session_id` | Same as request — per-session id from the `user` body field / `X-Session-Id` header |
 | `latency_ms` | End-to-end latency in milliseconds |
 | `has_content` | Whether the LLM returned text content |
 | `has_tool_calls` | Whether the LLM made tool calls |
@@ -239,6 +241,27 @@ Each LLM call produces two JSON entries on stdout: a `REQUEST` line when the cal
 | `tokens` | Token usage object from the provider (`prompt_tokens`, `completion_tokens`, `total_tokens`) |
 | `error` | Error detail string (only present on failed requests) |
 
+### Wiring up `session_id`
+
+`session_id` is populated server-side from two sources, in priority order:
+
+1. **The OpenAI `user` request-body field (primary).** geo-agent's `Agent` mints
+   one `crypto.randomUUID()` per instance (`this.sessionId`) and already sends it
+   as `user` on every `/chat/completions` POST. The proxy reads `request.user`
+   into `session_id` (`llm_proxy.py`) and logs it — but does **not** forward `user`
+   upstream, so provider-side caching/abuse-monitoring is unaffected. This required
+   no client change and lights up all existing geo-agent traffic.
+2. **The `X-Session-Id` header (fallback).** For non-geo-agent clients that prefer
+   a header. It is in the ingress `cors-allow-headers` allow-list (`ingress.yaml`);
+   CORS is enforced at the ingress, not the app, so any custom header must be
+   listed there or the browser preflight blocks the whole request (same gotcha as
+   `X-Client` in #26).
+
+Records written before this wiring have `session_id = null`; group those by the
+`(origin, user_question)` heuristic instead. For newer records, group by
+`session_id` for exact session reconstruction — it is immune to the
+`user_question` first-message-only trap and survives follow-up questions.
+
 ## Reconstructing a conversation
 
 Each POST to `/v1/chat/completions` is one LLM turn. A single user session produces multiple request/response pairs. To reconstruct a session:
@@ -249,6 +272,10 @@ Each POST to `/v1/chat/completions` is one LLM turn. A single user session produ
 4. Interleave: each request's `tool_results_this_turn` shows what the previous turn's tool calls returned; each response's `tool_calls` shows what the LLM decided to call next
 
 Use `request_id` to pair each request with its response when log lines are interleaved under concurrent load.
+
+> ⚠️ **`user_question` groups by *opening* question, not by session.** Step 2 is a heuristic with two failure modes: (a) two different users who happen to open with the same question collapse into one apparent session, and (b) a single user's **follow-up questions never get their own group** — they stay pinned to the opening `user_question` (see the field note above). When `session_id` is populated, group by it instead — it is exact and survives follow-ups. Until then, treat a single `user_question` group as "one opening question and everything that followed it," not "one atomic question."
+
+> 📋 **Brittle-JSON caveat (consolidated Parquet).** `entry::JSON->>'field'` intermittently throws `Conversion Error: Failed to cast value to numerical` — DuckDB mis-infers an all-`null` or numeric-looking JSON path and tries to cast the whole `entry` blob. It is load-bearing-flaky: the same expression works in a bare `SELECT` but fails inside a `GROUP BY`/aggregate. Use `json_extract_string(entry, '$.field')` (for text) and `json_extract(entry, '$.field')` (for JSON) instead — they never throw.
 
 ## Example session reconstruction
 

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -14,11 +14,11 @@ metadata:
     #   curl -i -X OPTIONS https://open-llm-proxy.nrp-nautilus.io/v1/chat/completions \
     #     -H "Origin: https://tpl.nrp-nautilus.io" \
     #     -H "Access-Control-Request-Method: POST" \
-    #     -H "Access-Control-Request-Headers: authorization,content-type,x-client"
+    #     -H "Access-Control-Request-Headers: authorization,content-type,x-client,x-session-id"
     haproxy-ingress.github.io/cors-enable: "true"
     haproxy-ingress.github.io/cors-allow-origin: "*"
     haproxy-ingress.github.io/cors-allow-methods: "GET, POST, OPTIONS"
-    haproxy-ingress.github.io/cors-allow-headers: "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Accept,Accept-Encoding,Accept-Language,Connection,Host,Origin,Referer,Sec-Fetch-Dest,Sec-Fetch-Mode,Sec-Fetch-Site,Priority,Authorization,X-Client"
+    haproxy-ingress.github.io/cors-allow-headers: "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Accept,Accept-Encoding,Accept-Language,Connection,Host,Origin,Referer,Sec-Fetch-Dest,Sec-Fetch-Mode,Sec-Fetch-Site,Priority,Authorization,X-Client,X-Session-Id"
     haproxy-ingress.github.io/cors-allow-credentials: "false"
     haproxy-ingress.github.io/cors-max-age: "600"
     haproxy-ingress.github.io/timeout-server: "600s"

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -408,6 +408,7 @@ class ChatRequest(BaseModel):
     model: Optional[str] = "gpt-4"
     temperature: Optional[float] = 0.0
     enable_thinking: Optional[bool] = None  # None = use model default; True/False to override
+    user: Optional[str] = None  # OpenAI end-user id; geo-agent sets it to its per-session UUID. Logged as session_id (not forwarded upstream).
 
 @app.post("/v1/chat/completions")
 @app.post("/chat")  # Keep for backward compatibility
@@ -444,7 +445,9 @@ async def proxy_chat(request: ChatRequest, http_request: Request, authorization:
     # Log incoming request
     request_id = uuid.uuid4().hex[:8]
     origin = http_request.headers.get("origin") or http_request.headers.get("referer")
-    session_id = http_request.headers.get("x-session-id")
+    # Session id: prefer the OpenAI `user` body field (geo-agent already sends its
+    # per-session UUID there); fall back to the X-Session-Id header for other clients.
+    session_id = request.user or http_request.headers.get("x-session-id")
     client = http_request.headers.get("x-client")   # e.g. "geo-agent/v3.13.1"; null until clients send it
     log_request(provider_name, request.model, request.messages, len(request.tools or []), origin=origin, request_id=request_id, session_id=session_id, client=client)
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.115.0
 uvicorn==0.32.0
 httpx==0.27.0
 pydantic==2.10.4
+boto3==1.43.0  # S3 log flush (llm_proxy.py) + flush-failure tests; matches deployment's `uvx --with boto3`

--- a/test_logging.py
+++ b/test_logging.py
@@ -231,6 +231,21 @@ def test_flush_failure_caps_buffer_dropping_oldest():
     assert [e["n"] for e in p._log_buffer] == [3, 4, 5, 6, 7]
 
 
+def test_chat_request_parses_user_as_session_id_source():
+    """The OpenAI `user` body field must survive pydantic parsing — geo-agent
+    sends its per-session UUID there and the endpoint logs it as session_id."""
+    p = importlib.reload(llm_proxy)
+    req = p.ChatRequest(
+        messages=[{"role": "user", "content": "hi"}],
+        model="qwen3",
+        user="b1c2d3e4-0000-4444-8888-abcdef012345",
+    )
+    assert req.user == "b1c2d3e4-0000-4444-8888-abcdef012345"
+    # session_id resolution precedence: body `user` wins, header is the fallback.
+    assert (req.user or "from-header") == "b1c2d3e4-0000-4444-8888-abcdef012345"
+    assert (p.ChatRequest(messages=[], model="qwen3").user or "from-header") == "from-header"
+
+
 if __name__ == "__main__":
     import sys
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]


### PR DESCRIPTION
## What

Wires up `session_id` end-to-end so log analysts can group a conversation by an exact key instead of the lossy `(origin, user_question)` heuristic.

Closes part of #31 (the `session_id` wiring + the `user_question`/JSON-cast documentation). The remaining #31 work — flattening hot fields into typed columns and materializing a session/turn view at consolidation time — is deferred to a follow-up; it becomes trivial once `session_id` is populated.

## Why

`session_id` was logged only from an `X-Session-Id` header that no client sends, so it was `null` in **every** record. Meanwhile geo-agent already mints a per-session UUID (`Agent.sessionId`) and sends it as the OpenAI `user` body field on every `/chat/completions` call — but `ChatRequest` dropped it.

## Changes

- **`llm_proxy.py`**: add `user` to `ChatRequest`; resolve `session_id = request.user or X-Session-Id`. `user` is logged only, **not** forwarded upstream (no impact on provider caching/abuse-monitoring). Lights up all existing geo-agent traffic with no client change.
- **`ingress.yaml`**: add `X-Session-Id` to the CORS allow-list (header fallback for non-geo-agent clients; per the #26 CORS gotcha).
- **`LOGGING.md`**: document the `user_question` first-message-only trap, the `entry::JSON->>` → `Failed to cast value to numerical` pitfall (use `json_extract_string`), and the `session_id` field + wiring.
- **`test_logging.py`**: guard that `ChatRequest` parses `user` and the precedence logic.

## Caveat

`request.user` is client-supplied and taken on trust — fine for log grouping (its only use; never forwarded), not for anything security-bearing.

## Test

`python -m pytest test_logging.py` → 14 passed.