### PR TITLE
Add CHANGELOG + release tracking; edit-only-this-repo boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@
 
 This is an LLM proxy service that routes chat completion requests to NRP, OpenRouter, or Nimbus providers and logs every request/response pair. The primary analysis task for agents is evaluating those logs.
 
+> **HARD BOUNDARY — edit only this repo.** Make code edits *only* within `open-llm-proxy`. The agent runner and analysis workflows reference sibling checkouts (e.g. `boettiger-lab/geo-agent`) for context, but you must **never edit another repo's code**. When a fix belongs in a sibling repo, open a GitHub issue on that repo (for its own agents/maintainers to action) and, where relevant, handle the corresponding change on this side. Reading sibling repos and their git history for diagnosis is fine and encouraged; editing them is not.
+
+> **Track changes.** Behavior/config/ops changes should add a [CHANGELOG.md](CHANGELOG.md) entry under `## [Unreleased]`; see [README → Releases](README.md#releases) for the (SemVer) release process.
+
 > **CORS gotcha:** browser CORS is enforced by the **haproxy ingress** (`ingress.yaml` annotations), *not* the app's `CORSMiddleware` (which is effectively dead config). `cors-allow-headers` is an explicit list — a new custom request header (e.g. `X-Client`) must be added there or the browser preflight blocks the whole request. See the comment in `ingress.yaml`.
 
 ## Evaluating Logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+See [Releases](README.md#releases) for how a release is cut.
+
+## [Unreleased]
+
+## [0.1.0] - 2026-06-24
+
+First tagged release. The proxy has run in production (`biodiversity` namespace,
+`https://open-llm-proxy.nrp-nautilus.io`) since 2026-02-26; this release captures
+that accumulated state as a baseline and starts tracking changes going forward.
+
+### Added
+- Multi-provider routing for `/v1/chat/completions` across NRP, OpenRouter,
+  Nimbus, and a direct Anthropic (OpenAI-compatible) provider, selected by model
+  name (#21).
+- `session_id` is now populated from the OpenAI `user` request-body field
+  (falling back to an `X-Session-Id` header), giving every log an exact
+  session key instead of the lossy `(origin, user_question)` heuristic. `user`
+  is logged only, never forwarded upstream (#31, #34).
+- `X-Client` request header captured into logs to correlate behavior with a
+  client release (#26).
+- Training-grade logging: full response `content`/`reasoning_content`, full
+  `tool_calls`, capture modes (`summary`/`full`), per-field caps, system-prompt
+  dedup, and always-on credential scrubbing (#25).
+- Tiered S3 log storage: raw JSONL → daily Parquet → monthly Parquet via
+  consolidation CronJobs; `sync-logs.sh` for local-first analysis (#11, #15).
+- `headless/` session-replay runner that imports geo-agent live, plus k8s Job
+  driver for model × question matrix sweeps (#17, #18, #19).
+- One-off `scrub-historical-logs.py` job to redact leaked credentials from
+  pre-scrubbing Parquet in place (idempotent).
+- `geo-agent-training` skill and `duckdb-geo` MCP server config (#22, #23).
+
+### Changed
+- Default `temperature` is `0.0` (was `0.7`) (#33).
+- S3 log flush interval reduced from 300s to 60s (`FLUSH_INTERVAL`).
+- Provider error truncation raised 200 → 1000 chars for debugging.
+- Scaled to 3 replicas with collision-safe flush keys and HA scheduling.
+
+### Fixed
+- Re-queue buffered log entries on flush failure instead of dropping them (#27).
+- DNS resilience: per-pod CoreDNS caching sidecar with `serve_stale`, plus
+  `ndots`/`attempts` tuning to curb upstream `EAI_AGAIN` 502s (#29, #30).
+- `boto3` added to `requirements.txt` — it was a runtime + test dependency
+  missing from CI, which had been red since #27.
+
+### Infrastructure notes
+- CORS is enforced at the haproxy **ingress**, not the app — custom request
+  headers must be added to `cors-allow-headers` in `ingress.yaml` (#26).
+- Pods pull application code by cloning `main` at startup (init container); a
+  rollout is `kubectl rollout restart`, no image build.
+
+[Unreleased]: https://github.com/boettiger-lab/open-llm-proxy/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/boettiger-lab/open-llm-proxy/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -131,6 +131,28 @@ Push changes to `main` (or your fork), then:
 kubectl rollout restart deployment/open-llm-proxy -n <your-namespace>
 ```
 
+## Releases
+
+Notable changes are tracked in [CHANGELOG.md](CHANGELOG.md)
+([Keep a Changelog](https://keepachangelog.com/) format) and the repo follows
+[Semantic Versioning](https://semver.org/) (`vMAJOR.MINOR.PATCH`). Every PR that
+changes behavior, config, or ops should add an entry under `## [Unreleased]`.
+
+To cut a release once `main` is green:
+
+```bash
+VERSION=0.1.0            # bump per semver
+
+# 1. Move the [Unreleased] entries into a new dated section in CHANGELOG.md,
+#    update the compare/tag links at the bottom, and commit (or merge a PR).
+# 2. Tag and create the GitHub release with notes from the changelog section:
+git tag -a "v$VERSION" -m "v$VERSION"
+git push origin "v$VERSION"
+gh release create "v$VERSION" --title "v$VERSION" --notes "<changelog section>"
+```
+
+Tags are descriptive only — deployment still tracks `main` (see [Update](#update)).
+
 ## Headless agent runner
 
 `headless/run.js` replays a geo-agent session from the command line: it loads the app's STAC catalog, connects to the MCP server, assembles the exact system prompt the browser sees, and drives the tool-use loop through the proxy. Unlike calling MCP tools directly, this exercises the full proxy pipeline and writes real log entries — useful for scripted model comparisons or reproducing failures.


### PR DESCRIPTION
Starts tracking changes/releases now that the repo has grown complex.

- **CHANGELOG.md** — Keep a Changelog format; inaugural `v0.1.0` section captures the production state accumulated since 2026-02-26 (multi-provider routing, training-grade logging, tiered Parquet, DNS resilience, session_id, etc.).
- **README → Releases** — documents the SemVer release process; tags are descriptive, deployment still tracks `main`.
- **AGENTS.md** — records a HARD BOUNDARY: agents edit only this repo and open issues for sibling repos (geo-agent, …) rather than editing them.

Cutting `v0.1.0` immediately after this merges.