### PR TITLE
Flatten consolidated log schema + materialize session view (#31)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Syntax-check the historical scrub job
         run: python -m py_compile scrub.py scrub-historical-logs.py
       - name: Install consolidation deps (duckdb; jobs pip-install these at runtime)
-        run: pip install duckdb
+        # pytz is only needed to materialize TIMESTAMPTZ into Python in the tests'
+        # fetchall; the actual jobs stream SQL -> Parquet and don't require it.
+        run: pip install duckdb pytz
       - name: Run consolidation schema tests (issue #31)
         run: python test_consolidate.py
       - name: Syntax-check the consolidation module

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,9 @@ jobs:
         run: python test_logging.py
       - name: Syntax-check the historical scrub job
         run: python -m py_compile scrub.py scrub-historical-logs.py
+      - name: Install consolidation deps (duckdb; jobs pip-install these at runtime)
+        run: pip install duckdb
+      - name: Run consolidation schema tests (issue #31)
+        run: python test_consolidate.py
+      - name: Syntax-check the consolidation module
+        run: python -m py_compile consolidate.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,20 @@ Logs land in three tiers by age (see [LOGGING.md](LOGGING.md) for the full spec)
 # One-time per session (or whenever you want to refresh)
 ./sync-logs.sh
 
-# Historical: consolidated Parquet (the common case)
+# Historical: consolidated Parquet (the common case). Hot fields are flat typed
+# columns (model, user_question, latency_ms, tool_calls, …) — no entry::JSON needed.
 duckdb -s "
-SELECT ts, entry::JSON->>'user_question' AS q, entry::JSON->'tool_calls' AS tools
+SELECT ts, model, user_question, tool_calls
 FROM read_parquet('/tmp/open-llm-proxy-logs/consolidated/**/*.parquet')
 WHERE origin = 'https://tpl.nrp-nautilus.io' AND ts > now() - INTERVAL 7 DAYS
 ORDER BY ts DESC;
+"
+
+# Reconstruct a whole session in order — sessions/ view, one row per turn (#31)
+duckdb -s "
+SELECT turn_idx, user_question, assistant_text, tool_calls, tool_results
+FROM read_parquet('/tmp/open-llm-proxy-logs/sessions/**/*.parquet')
+WHERE session_key = 'SESSION' ORDER BY turn_idx;
 "
 
 # Today: raw JSONL — narrow the glob to the current hour when possible
@@ -39,7 +47,7 @@ SELECT * FROM read_ndjson_auto('/tmp/open-llm-proxy-logs/YYYY-MM-DD/*.jsonl',
 "
 ```
 
-**Parquet schema** (same for daily and monthly tiers): `(ts TIMESTAMPTZ, type, request_id, origin, entry VARCHAR)` — `entry` is the full original log record as JSON text. Access fields with `entry::JSON->>'field'`.
+**Parquet schema** (`consolidated/**`, same for daily and monthly): hot fields are promoted to typed columns — `ts, type, request_id, origin, session_id, client, model, provider, message_count, tools_count, user_question, latency_ms, has_content, has_tool_calls, has_reasoning_content, total_tokens, tool_calls (JSON), tool_results (JSON), tokens (JSON), error` — plus the full original record in `entry VARCHAR`. Prefer the typed columns; fall back to `entry::JSON->>'field'` for anything not promoted. A separate `sessions/**` view holds one interleaved row per turn (`session_key, turn_idx, user_question, latest_user_message, assistant_text, tool_calls, tool_results, …`) — reconstruct a conversation with `WHERE session_key = ? ORDER BY turn_idx`, no manual interleaving. See [LOGGING.md](LOGGING.md) for both full schemas. *(Flat columns + session view land at consolidation time per #31; older files are backfilled by `flatten-historical-logs-job.yaml`.)*
 
 For automation, one-shot CI queries, or queries that need sub-minute freshness without re-syncing, query S3 directly with `LOG_S3_KEY` / `LOG_S3_SECRET` from the shell — see [LOGGING.md](LOGGING.md#direct-s3-one-shot-queries-automation-or-inside-nrp-pods).
 
@@ -48,7 +56,7 @@ Each LLM call produces a `request` row and a `response` row linked by `request_i
 - **Request**: `user_question`, `tool_results_this_turn`, `model`, `origin`, `message_count`
 - **Response**: `tool_calls`, `content_preview`, `tokens`, `latency_ms`, `error` (only on failures)
 
-**Reconstructing a conversation**: group by `user_question`, filter by `origin`, sort by `ts` (Parquet) / `timestamp` (JSONL). The `tool_results_this_turn` on each request shows what the previous turn's tool calls returned; `tool_calls` on each response shows what the LLM called next.
+**Reconstructing a conversation**: for consolidated data, just query the `sessions/**` view — one row per turn, ordered by `turn_idx`, keyed on `session_key`. For raw JSONL (today) or by hand: group by `session_id` (exact; falls back to `(origin, user_question)` for pre-#34 rows), sort by `ts` (Parquet) / `timestamp` (JSONL). The `tool_results_this_turn` on each request shows what the previous turn's tool calls returned; `tool_calls` on each response shows what the LLM called next.
 
 **Midnight crossover caveat**: flush-time (not entry `ts`) determines the source file path. An entry with `ts = 23:59:58` may live in the next UTC day's file if it was buffered past midnight. Always filter on `ts`, not on file path, when you care about a calendar day.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ See [Releases](README.md#releases) for how a release is cut.
 
 ## [Unreleased]
 
+### Added
+- **Flat consolidated log schema + materialized session view (#31).** Daily/monthly
+  consolidation now promotes hot fields (`model`, `provider`, `session_id`,
+  `client`, `message_count`, `user_question`, `latency_ms`, `has_*`,
+  `total_tokens`, `tool_calls`/`tool_results`/`tokens` as JSON, `error`) to typed
+  columns alongside the raw `entry` blob — no more `entry::JSON->>` casting traps.
+  A new `sessions/**` Parquet tree holds one interleaved row per turn keyed on
+  `session_id` (heuristic fallback for pre-#34 nulls), so a whole conversation is
+  `SELECT … WHERE session_key = ? ORDER BY turn_idx` with no manual request/response
+  matching. Consolidation logic is now a single source of truth in `consolidate.py`
+  (`daily`/`monthly`/`backfill`), git-cloned by the CronJobs.
+- One-off `flatten-historical-logs-job.yaml` to backfill the flat schema + session
+  views onto pre-#31 consolidated Parquet in place (idempotent, row-count-checked).
+- `test_consolidate.py` pins the flatten/session-view SQL (schema, turn pairing,
+  ordering, heuristic key fallback, full-mode `latest_user_message`).
+
+### Changed
+- Consolidation CronJobs (`consolidate-{daily,monthly}-cronjob.yaml`) switched from
+  inline-heredoc Python to git-cloning the repo and running `consolidate.py`,
+  matching the scrub job — keeps the flatten SQL from drifting across entrypoints.
+
 ## [0.1.0] - 2026-06-24
 
 First tagged release. The proxy has run in production (`biodiversity` namespace,

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -18,30 +18,89 @@ logs-open-llm-proxy/
 ├── 2026-04-17/                        ← today: raw JSONL (live debug tier)
 │   ├── 02-00-05-39.jsonl              # flush at 02:00:05 from worker PID 39
 │   └── ...
-├── consolidated/
+├── consolidated/                      ← one row per log entry (flat schema)
 │   ├── daily/
 │   │   ├── 2026-04-15.parquet         # recent completed days
 │   │   └── 2026-04-16.parquet
 │   └── monthly/
 │       ├── 2026-02.parquet            # older completed months
 │       └── 2026-03.parquet
+└── sessions/                          ← one row per turn (interleaved session view)
+    ├── daily/
+    │   └── 2026-04-16.parquet
+    └── monthly/
+        └── 2026-03.parquet
 ```
 
 | Tier | Format | When it gets written | When it gets deleted |
 |---|---|---|---|
 | Raw JSONL (`YYYY-MM-DD/*.jsonl`) | JSONL chunks | Proxy flushes every 60s | Next day's daily consolidation (03:00 UTC) |
-| Daily (`consolidated/daily/YYYY-MM-DD.parquet`) | Parquet (zstd) | Daily cron at 03:00 UTC | Monthly rollup on day 2 (04:00 UTC) |
-| Monthly (`consolidated/monthly/YYYY-MM.parquet`) | Parquet (zstd) | Monthly cron on day 2 | Never (long-term archive) |
+| Daily (`consolidated/daily/…` + `sessions/daily/…`) | Parquet (zstd) | Daily cron at 03:00 UTC | Monthly rollup on day 2 (04:00 UTC) |
+| Monthly (`consolidated/monthly/…` + `sessions/monthly/…`) | Parquet (zstd) | Monthly cron on day 2 | Never (long-term archive) |
 
-The **Parquet schema** (identical across daily and monthly tiers):
+Consolidation logic is a single source of truth in **`consolidate.py`** (`daily` /
+`monthly` / `backfill` subcommands), git-cloned by the CronJobs — so the daily
+job, the monthly rollup, and the one-off backfill can't drift apart.
+
+### `consolidated/` — flat entry schema
+
+One row per log entry (`request` **or** `response`). Hot fields are promoted to
+typed columns; the full original record is kept verbatim in `entry` for fidelity.
+**Prefer the typed columns** — they sidestep the `entry::JSON->>` casting traps
+below. Identical across daily and monthly tiers. Glob: `consolidated/**/*.parquet`.
 
 | Column | Type | Notes |
 |---|---|---|
-| `ts` | `TIMESTAMPTZ` | Extracted from the `timestamp` field of the raw JSON |
+| `ts` | `TIMESTAMPTZ` | From the `timestamp` field |
 | `type` | `VARCHAR` | `'request'` or `'response'` |
 | `request_id` | `VARCHAR` | Correlates request ↔ response |
 | `origin` | `VARCHAR` | App the traffic came from |
+| `session_id` | `VARCHAR` | Exact per-session key (`null` in pre-#34 records) |
+| `client` | `VARCHAR` | `X-Client` header, e.g. `geo-agent/v3.13.1` (`null` until sent) |
+| `model` | `VARCHAR` | |
+| `provider` | `VARCHAR` | `nrp` / `openrouter` / `nimbus` |
+| `message_count` | `INTEGER` | Request rows |
+| `tools_count` | `INTEGER` | Request rows |
+| `user_question` | `VARCHAR` | Request rows — ⚠️ **first-message-only**, see the trap below |
+| `latency_ms` | `INTEGER` | Response rows |
+| `has_content` / `has_tool_calls` / `has_reasoning_content` | `BOOLEAN` | Response rows |
+| `total_tokens` | `INTEGER` | Response rows (from `tokens.total_tokens`) |
+| `tool_calls` | `JSON` | Response rows — `[{name, arguments}]` |
+| `tool_results` | `JSON` | Request rows — `tool_results_this_turn`, what the *previous* turn's calls returned |
+| `tokens` | `JSON` | Response rows — `{prompt_tokens, completion_tokens, total_tokens}` |
+| `error` | `VARCHAR` | Response rows, failures only |
 | `entry` | `VARCHAR` | The full original JSON record — parse with `entry::JSON` |
+
+### `sessions/` — per-turn session view
+
+One row per **turn** (a request paired with its response by `request_id`), already
+interleaved and ordered, so reconstructing a conversation is a single flat
+`SELECT … ORDER BY turn_idx` — no manual request/response matching. Keyed on
+`session_id` (exact), falling back to the `(origin, user_question)` heuristic for
+pre-#34 rows where `session_id` is null. Glob: `sessions/**/*.parquet`.
+
+| Column | Type | Notes |
+|---|---|---|
+| `session_key` | `VARCHAR` | `session_id` when present, else `origin \| user_question`. Group/partition on this. |
+| `session_id` | `VARCHAR` | Raw id (`null` for pre-#34 turns) |
+| `turn_idx` | `BIGINT` | 1-based turn number within the session, ordered by `ts` |
+| `ts` | `TIMESTAMPTZ` | Request timestamp of the turn |
+| `origin`, `model`, `provider`, `client` | `VARCHAR` | |
+| `message_count` | `INTEGER` | |
+| `user_question` | `VARCHAR` | Opening question (first-message-only — see trap) |
+| `latest_user_message` | `VARCHAR` | The turn's *latest* `role:user` message. Populated only in `full` capture mode (needs the `messages` array); **`null` in summary mode** — use `session_id` to follow up-questions instead. |
+| `assistant_text` | `VARCHAR` | Response `content` (full), falling back to `content_preview` |
+| `tool_calls` | `JSON` | What the LLM called this turn |
+| `tool_results` | `JSON` | What the previous turn's calls returned (fed into this request) |
+| `has_content`, `has_tool_calls` | `BOOLEAN` | |
+| `latency_ms`, `total_tokens` | `INTEGER` | |
+| `error` | `VARCHAR` | |
+| `request_id` | `VARCHAR` | |
+
+The daily tier computes `turn_idx` within the day; the monthly rollup rebuilds the
+view from the merged month so `turn_idx` is correct for sessions that span days.
+A session that crosses a midnight UTC boundary is split across two daily session
+files until the monthly rollup merges them.
 
 ## Access pattern
 
@@ -60,26 +119,37 @@ Then query the local path — no `CREATE SECRET` needed:
 
 ```bash
 duckdb -s "
--- Historical: all consolidated data in one read (daily + monthly Parquet)
-SELECT ts, entry::JSON->>'user_question' AS q
+-- Historical: all consolidated data in one read (daily + monthly Parquet).
+-- Use the typed columns — no entry::JSON gymnastics needed.
+SELECT ts, model, user_question
 FROM read_parquet('/tmp/open-llm-proxy-logs/consolidated/**/*.parquet')
-WHERE entry::JSON->>'origin' = 'https://tpl.nrp-nautilus.io'
+WHERE origin = 'https://tpl.nrp-nautilus.io'
   AND ts > now() - INTERVAL 7 DAYS;
+
+-- Every turn of one session in order, with tool calls + results, no manual
+-- interleaving — this is what the sessions/ view is for (issue #31).
+SELECT turn_idx, user_question, assistant_text, tool_calls, tool_results
+FROM read_parquet('/tmp/open-llm-proxy-logs/sessions/**/*.parquet')
+WHERE session_key = '<session_id-or-origin|question>'
+ORDER BY turn_idx;
 
 -- Today's live data (raw JSONL — narrow the glob to an hour when possible)
 SELECT * FROM read_ndjson_auto(
   '/tmp/open-llm-proxy-logs/2026-04-17/*.jsonl', union_by_name=true);
 
--- Pair requests and responses from consolidated Parquet
-SELECT req.ts, req.entry::JSON->>'user_question' AS q,
-       resp.entry::JSON->'tool_calls' AS tools,
-       (resp.entry::JSON->>'latency_ms')::INT AS ms
+-- Pair requests and responses from the flat consolidated Parquet
+SELECT req.ts, req.user_question, resp.tool_calls, resp.latency_ms
 FROM read_parquet('/tmp/open-llm-proxy-logs/consolidated/**/*.parquet') req
 JOIN read_parquet('/tmp/open-llm-proxy-logs/consolidated/**/*.parquet') resp
   ON req.request_id = resp.request_id
 WHERE req.type = 'request' AND resp.type = 'response';
 "
 ```
+
+> The flat typed columns and the `sessions/` view exist for consolidated Parquet
+> written **after** issue #31. The one-off `flatten-historical-logs-job.yaml`
+> backfills both onto older consolidated files in place. Today's raw JSONL is
+> still nested JSON — flatten it at read time or wait for daily consolidation.
 
 Live data caveat: raw JSONL for today is only as fresh as the last `./sync-logs.sh`. Re-run it before querying if you care about the last few minutes. For sub-minute freshness, use `kubectl` (below) or the direct-S3 path.
 
@@ -264,7 +334,13 @@ Records written before this wiring have `session_id = null`; group those by the
 
 ## Reconstructing a conversation
 
-Each POST to `/v1/chat/completions` is one LLM turn. A single user session produces multiple request/response pairs. To reconstruct a session:
+**The easy way (consolidated data):** query the `sessions/**/*.parquet` view —
+one row per turn, already interleaved and ordered by `turn_idx`, keyed on
+`session_key`. `SELECT … WHERE session_key = ? ORDER BY turn_idx` gives the whole
+conversation with no manual matching. The steps below are the underlying mechanics
+(still needed for today's raw JSONL, or to understand what the view materializes).
+
+Each POST to `/v1/chat/completions` is one LLM turn. A single user session produces multiple request/response pairs. To reconstruct a session by hand:
 
 1. Match by `origin` to isolate one app
 2. Group turns by `user_question` (same question = same session)

--- a/consolidate-daily-cronjob.yaml
+++ b/consolidate-daily-cronjob.yaml
@@ -5,10 +5,15 @@ metadata:
   labels:
     app: logs-consolidate
 spec:
-  # 03:00 UTC every day — consolidates each completed YYYY-MM-DD/ directory
-  # of JSONL chunks into one consolidated/daily/YYYY-MM-DD.parquet and deletes
-  # the originals. Idempotent: skips days that already have a Parquet and
-  # always skips today (still being written).
+  # 03:00 UTC every day — consolidates each completed YYYY-MM-DD/ directory of
+  # JSONL chunks into one flat consolidated/daily/YYYY-MM-DD.parquet (hot fields
+  # promoted to typed columns) plus a per-turn sessions/daily/YYYY-MM-DD.parquet
+  # session view, then deletes the originals. Idempotent: skips days that already
+  # have a Parquet and always skips today (still being written).
+  #
+  # The consolidation logic lives in consolidate.py (git-cloned below) so the
+  # flattened schema is a single source of truth shared with the monthly rollup
+  # and the one-off backfill Job (flatten-historical-logs-job.yaml) — see #31.
   schedule: "0 3 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
@@ -29,100 +34,28 @@ spec:
                       - key: feature.node.kubernetes.io/pci-10de.present
                         operator: NotIn
                         values: ["true"]
+          initContainers:
+            - name: git-sync
+              image: alpine/git:latest
+              command: ["sh", "-c", "git clone --depth 1 https://github.com/boettiger-lab/open-llm-proxy.git /repo"]
+              volumeMounts:
+                - name: repo
+                  mountPath: /repo
           containers:
             - name: consolidate
               image: python:3.12-slim
+              workingDir: /repo
               env:
                 - name: AWS_ACCESS_KEY_ID
                   valueFrom: { secretKeyRef: { name: aws, key: AWS_ACCESS_KEY_ID } }
                 - name: AWS_SECRET_ACCESS_KEY
                   valueFrom: { secretKeyRef: { name: aws, key: AWS_SECRET_ACCESS_KEY } }
-              command:
-                - /bin/bash
-                - -c
+              command: ["/bin/bash", "-c"]
+              args:
                 - |
                   set -euo pipefail
                   pip install --quiet duckdb boto3
-                  python - <<'PY'
-                  import os, datetime, boto3, duckdb
-                  from botocore.client import Config
-
-                  BUCKET   = 'logs-open-llm-proxy'
-                  ENDPOINT = 'http://rook-ceph-rgw-nautiluss3.rook'
-
-                  s3 = boto3.client(
-                      's3',
-                      endpoint_url=ENDPOINT,
-                      aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
-                      aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
-                      config=Config(s3={'addressing_style': 'path'}),
-                  )
-
-                  today = datetime.datetime.utcnow().date().isoformat()
-                  paginator = s3.get_paginator('list_objects_v2')
-
-                  # Discover all YYYY-MM-DD/ prefixes at the bucket root
-                  date_prefixes = set()
-                  for page in paginator.paginate(Bucket=BUCKET, Delimiter='/'):
-                      for p in page.get('CommonPrefixes', []):
-                          pref = p['Prefix'].rstrip('/')
-                          try:
-                              datetime.date.fromisoformat(pref)
-                              date_prefixes.add(pref)
-                          except ValueError:
-                              pass
-
-                  # Existing consolidated daily Parquet files
-                  existing = set()
-                  for page in paginator.paginate(Bucket=BUCKET, Prefix='consolidated/daily/'):
-                      for obj in page.get('Contents', []):
-                          name = obj['Key'].split('/')[-1]
-                          if name.endswith('.parquet'):
-                              existing.add(name[:-len('.parquet')])
-
-                  to_do = sorted(d for d in date_prefixes if d != today and d not in existing)
-                  print(f"Days to consolidate ({len(to_do)}): {to_do}")
-                  if not to_do:
-                      print("Nothing to do.")
-                      raise SystemExit(0)
-
-                  con = duckdb.connect()
-                  con.execute(f"""
-                      CREATE SECRET s3_logs (
-                          TYPE S3,
-                          KEY_ID '{os.environ["AWS_ACCESS_KEY_ID"]}',
-                          SECRET '{os.environ["AWS_SECRET_ACCESS_KEY"]}',
-                          ENDPOINT 'rook-ceph-rgw-nautiluss3.rook',
-                          USE_SSL false,
-                          URL_STYLE 'path'
-                      )
-                  """)
-
-                  for day in to_do:
-                      print(f"→ {day}")
-                      con.execute(f"""
-                          COPY (
-                              SELECT (json->>'timestamp')::TIMESTAMPTZ AS ts,
-                                     json->>'type'       AS type,
-                                     json->>'request_id' AS request_id,
-                                     json->>'origin'     AS origin,
-                                     json::VARCHAR       AS entry
-                              FROM read_ndjson_objects('s3://{BUCKET}/{day}/*.jsonl')
-                              ORDER BY ts
-                          ) TO 's3://{BUCKET}/consolidated/daily/{day}.parquet'
-                            (FORMAT PARQUET, COMPRESSION zstd)
-                      """)
-                      # Verify Parquet exists before destroying inputs
-                      s3.head_object(Bucket=BUCKET, Key=f'consolidated/daily/{day}.parquet')
-                      to_delete = []
-                      for page in paginator.paginate(Bucket=BUCKET, Prefix=f'{day}/'):
-                          for obj in page.get('Contents', []):
-                              to_delete.append({'Key': obj['Key']})
-                      for i in range(0, len(to_delete), 1000):
-                          s3.delete_objects(Bucket=BUCKET, Delete={'Objects': to_delete[i:i+1000]})
-                      print(f"  ✓ {len(to_delete)} JSONL chunks removed")
-                  print("Done.")
-                  PY
+                  python consolidate.py daily
               resources:
                 requests:
                   cpu: "500m"
@@ -130,3 +63,6 @@ spec:
                 limits:
                   cpu: "500m"
                   memory: "1Gi"
+          volumes:
+            - name: repo
+              emptyDir: {}

--- a/consolidate-monthly-cronjob.yaml
+++ b/consolidate-monthly-cronjob.yaml
@@ -6,9 +6,13 @@ metadata:
     app: logs-consolidate
 spec:
   # 04:00 UTC on day 2 of every month — merges the just-closed month's daily
-  # Parquet files into consolidated/monthly/YYYY-MM.parquet, then deletes the
-  # daily inputs. Day 2 (not day 1) so the daily job for the 1st of the new
-  # month has already run and consolidated the final day of the previous month.
+  # Parquet (entry + session view) into consolidated/monthly/YYYY-MM.parquet and
+  # sessions/monthly/YYYY-MM.parquet, then deletes the daily inputs. Day 2 (not
+  # day 1) so the daily job for the 1st has already consolidated the final day of
+  # the previous month. The session view is rebuilt from the merged month so
+  # turn_idx is correct across day boundaries.
+  #
+  # Logic lives in consolidate.py (git-cloned below); see #31 / the daily CronJob.
   schedule: "0 4 2 * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
@@ -29,82 +33,28 @@ spec:
                       - key: feature.node.kubernetes.io/pci-10de.present
                         operator: NotIn
                         values: ["true"]
+          initContainers:
+            - name: git-sync
+              image: alpine/git:latest
+              command: ["sh", "-c", "git clone --depth 1 https://github.com/boettiger-lab/open-llm-proxy.git /repo"]
+              volumeMounts:
+                - name: repo
+                  mountPath: /repo
           containers:
             - name: rollup
               image: python:3.12-slim
+              workingDir: /repo
               env:
                 - name: AWS_ACCESS_KEY_ID
                   valueFrom: { secretKeyRef: { name: aws, key: AWS_ACCESS_KEY_ID } }
                 - name: AWS_SECRET_ACCESS_KEY
                   valueFrom: { secretKeyRef: { name: aws, key: AWS_SECRET_ACCESS_KEY } }
-              command:
-                - /bin/bash
-                - -c
+              command: ["/bin/bash", "-c"]
+              args:
                 - |
                   set -euo pipefail
                   pip install --quiet duckdb boto3
-                  python - <<'PY'
-                  import os, datetime, boto3, duckdb
-                  from botocore.client import Config
-
-                  BUCKET   = 'logs-open-llm-proxy'
-                  ENDPOINT = 'http://rook-ceph-rgw-nautiluss3.rook'
-
-                  s3 = boto3.client(
-                      's3',
-                      endpoint_url=ENDPOINT,
-                      aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
-                      aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'],
-                      config=Config(s3={'addressing_style': 'path'}),
-                  )
-
-                  # Previous completed month (UTC)
-                  today = datetime.datetime.utcnow().date()
-                  first_of_this_month = today.replace(day=1)
-                  prev_month_end  = first_of_this_month - datetime.timedelta(days=1)
-                  prev_month      = prev_month_end.strftime('%Y-%m')
-                  print(f"Rolling up month: {prev_month}")
-
-                  paginator = s3.get_paginator('list_objects_v2')
-
-                  # Daily files for that month
-                  daily_keys = []
-                  for page in paginator.paginate(Bucket=BUCKET, Prefix=f'consolidated/daily/{prev_month}-'):
-                      for obj in page.get('Contents', []):
-                          if obj['Key'].endswith('.parquet'):
-                              daily_keys.append(obj['Key'])
-                  print(f"Daily files found: {len(daily_keys)}")
-                  if not daily_keys:
-                      print("Nothing to roll up.")
-                      raise SystemExit(0)
-
-                  monthly_key = f'consolidated/monthly/{prev_month}.parquet'
-
-                  con = duckdb.connect()
-                  con.execute(f"""
-                      CREATE SECRET s3_logs (
-                          TYPE S3,
-                          KEY_ID '{os.environ["AWS_ACCESS_KEY_ID"]}',
-                          SECRET '{os.environ["AWS_SECRET_ACCESS_KEY"]}',
-                          ENDPOINT 'rook-ceph-rgw-nautiluss3.rook',
-                          USE_SSL false,
-                          URL_STYLE 'path'
-                      )
-                  """)
-                  con.execute(f"""
-                      COPY (
-                          SELECT * FROM read_parquet('s3://{BUCKET}/consolidated/daily/{prev_month}-*.parquet')
-                          ORDER BY ts
-                      ) TO 's3://{BUCKET}/{monthly_key}' (FORMAT PARQUET, COMPRESSION zstd)
-                  """)
-
-                  # Verify monthly file exists before deleting daily inputs
-                  s3.head_object(Bucket=BUCKET, Key=monthly_key)
-                  delete_batch = [{'Key': k} for k in daily_keys]
-                  for i in range(0, len(delete_batch), 1000):
-                      s3.delete_objects(Bucket=BUCKET, Delete={'Objects': delete_batch[i:i+1000]})
-                  print(f"✓ Rolled up {len(daily_keys)} daily files → {monthly_key}; daily files removed.")
-                  PY
+                  python consolidate.py monthly
               resources:
                 requests:
                   cpu: "500m"
@@ -112,3 +62,6 @@ spec:
                 limits:
                   cpu: "500m"
                   memory: "1Gi"
+          volumes:
+            - name: repo
+              emptyDir: {}

--- a/consolidate.py
+++ b/consolidate.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Log consolidation + flattening (issue #31).
+
+Single source of truth for the consolidation SQL, shared by three entrypoints
+so the flattened schema and session-view shape can never drift between them:
+
+    python consolidate.py daily      # raw YYYY-MM-DD/*.jsonl -> flat daily parquet
+                                      #   + sessions/daily/YYYY-MM-DD.parquet
+    python consolidate.py monthly    # roll completed month's daily parquet up
+                                      #   + rebuild sessions/monthly/YYYY-MM.parquet
+    python consolidate.py backfill    # rewrite pre-flatten consolidated parquet
+                                      #   in place to the flat schema + session views
+
+The daily/monthly commands are invoked by the CronJobs (consolidate-*-cronjob.yaml);
+backfill is a one-off Job (flatten-historical-logs-job.yaml). All three run inside
+NRP pods and reach Ceph via the internal RGW endpoint.
+
+Two parquet trees are produced (kept separate so the documented
+`consolidated/**/*.parquet` glob keeps a single, uniform schema):
+
+  consolidated/{daily,monthly}/...  -> one row per log entry (request OR response),
+        hot fields promoted to typed columns alongside the raw `entry` JSON text.
+  sessions/{daily,monthly}/...      -> one row per *turn* (request+response paired),
+        interleaved and keyed on session_id (heuristic fallback for old null rows).
+
+See LOGGING.md for the full schema and query patterns.
+"""
+import os
+import sys
+import datetime
+
+import boto3
+import duckdb
+from botocore.client import Config
+
+BUCKET = os.environ.get("LOG_BUCKET", "logs-open-llm-proxy")
+# Internal RGW endpoint (fast, no public-endpoint throttling) by default; the
+# host (without scheme) is what DuckDB's CREATE SECRET wants.
+ENDPOINT_HOST = os.environ.get("S3_ENDPOINT_HOST", "rook-ceph-rgw-nautiluss3.rook")
+USE_SSL = os.environ.get("S3_USE_SSL", "false").lower() == "true"
+
+
+def s3_client():
+    scheme = "https" if USE_SSL else "http"
+    return boto3.client(
+        "s3",
+        endpoint_url=f"{scheme}://{ENDPOINT_HOST}",
+        aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+        aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+        config=Config(s3={"addressing_style": "path"}),
+    )
+
+
+def duck():
+    con = duckdb.connect()
+    con.execute(
+        f"""
+        CREATE SECRET s3_logs (
+            TYPE S3,
+            KEY_ID '{os.environ["AWS_ACCESS_KEY_ID"]}',
+            SECRET '{os.environ["AWS_SECRET_ACCESS_KEY"]}',
+            ENDPOINT '{ENDPOINT_HOST}',
+            USE_SSL {str(USE_SSL).lower()},
+            URL_STYLE 'path'
+        )
+        """
+    )
+    return con
+
+
+# ── Shared SQL builders ──────────────────────────────────────────────────────
+# Both operate on a relation that exposes an `entry` VARCHAR column holding the
+# full original JSON record. json_extract_string / json_extract are used (never
+# `entry::JSON->>`) because the latter intermittently throws "Failed to cast
+# value to numerical" — see LOGGING.md's brittle-JSON caveat.
+
+def flatten_select(from_clause, entry="entry"):
+    """SELECT that promotes hot fields to typed columns, keeping raw `entry`.
+
+    `from_clause` must yield an `entry` VARCHAR column (aliased per `entry`)."""
+    e = entry
+    return f"""
+        SELECT
+            json_extract_string({e}, '$.timestamp')::TIMESTAMPTZ        AS ts,
+            json_extract_string({e}, '$.type')                          AS type,
+            json_extract_string({e}, '$.request_id')                    AS request_id,
+            json_extract_string({e}, '$.origin')                        AS origin,
+            json_extract_string({e}, '$.session_id')                    AS session_id,
+            json_extract_string({e}, '$.client')                        AS client,
+            json_extract_string({e}, '$.model')                         AS model,
+            json_extract_string({e}, '$.provider')                      AS provider,
+            TRY_CAST(json_extract_string({e}, '$.message_count') AS INTEGER) AS message_count,
+            TRY_CAST(json_extract_string({e}, '$.tools_count')   AS INTEGER) AS tools_count,
+            json_extract_string({e}, '$.user_question')                 AS user_question,
+            TRY_CAST(json_extract_string({e}, '$.latency_ms') AS INTEGER)    AS latency_ms,
+            TRY_CAST(json_extract_string({e}, '$.has_content') AS BOOLEAN)            AS has_content,
+            TRY_CAST(json_extract_string({e}, '$.has_tool_calls') AS BOOLEAN)        AS has_tool_calls,
+            TRY_CAST(json_extract_string({e}, '$.has_reasoning_content') AS BOOLEAN) AS has_reasoning_content,
+            TRY_CAST(json_extract_string({e}, '$.tokens.total_tokens') AS INTEGER)   AS total_tokens,
+            json_extract({e}, '$.tool_calls')                           AS tool_calls,
+            json_extract({e}, '$.tool_results_this_turn')               AS tool_results,
+            json_extract({e}, '$.tokens')                               AS tokens,
+            json_extract_string({e}, '$.error')                         AS error,
+            {e}                                                         AS entry
+        FROM {from_clause}
+    """
+
+
+def session_view(flat_sql):
+    """One row per turn (request+response paired), interleaved and ordered.
+
+    `flat_sql` is any query producing flattened rows (see flatten_select). The
+    session key is the exact `session_id` when present, falling back to the
+    `(origin, user_question)` heuristic for pre-session_id (null) records.
+    `latest_user_message` is the last role:user message and is populated only
+    when the request carries a `messages` array (LOG_CAPTURE_MODE=full); it is
+    NULL in summary mode."""
+    sk = "coalesce(r.session_id, r.origin || '|' || coalesce(r.user_question, ''))"
+    latest_user = """
+        list_last(list_transform(
+            list_filter(
+                CAST(json_extract(r.entry, '$.messages') AS JSON[]),
+                m -> json_extract_string(m, '$.role') = 'user'),
+            m -> json_extract_string(m, '$.content')))
+    """
+    assistant = """
+        coalesce(json_extract_string(p.entry, '$.content'),
+                 json_extract_string(p.entry, '$.content_preview'))
+    """
+    return f"""
+        WITH flat AS ({flat_sql}),
+             r AS (SELECT * FROM flat WHERE type = 'request'),
+             p AS (SELECT * FROM flat WHERE type = 'response')
+        SELECT
+            {sk}                                                          AS session_key,
+            r.session_id                                                  AS session_id,
+            row_number() OVER (PARTITION BY {sk} ORDER BY r.ts, r.request_id) AS turn_idx,
+            r.ts                                                          AS ts,
+            r.origin                                                      AS origin,
+            r.model                                                       AS model,
+            r.provider                                                    AS provider,
+            r.client                                                      AS client,
+            r.message_count                                               AS message_count,
+            r.user_question                                               AS user_question,
+            {latest_user}                                                 AS latest_user_message,
+            {assistant}                                                   AS assistant_text,
+            p.tool_calls                                                  AS tool_calls,
+            r.tool_results                                                AS tool_results,
+            p.has_content                                                 AS has_content,
+            p.has_tool_calls                                              AS has_tool_calls,
+            p.latency_ms                                                  AS latency_ms,
+            p.total_tokens                                                AS total_tokens,
+            p.error                                                       AS error,
+            r.request_id                                                  AS request_id
+        FROM r LEFT JOIN p ON r.request_id = p.request_id
+        ORDER BY session_key, turn_idx
+    """
+
+
+def copy_to(con, select_sql, key):
+    con.execute(
+        f"COPY ({select_sql}) TO 's3://{BUCKET}/{key}' (FORMAT PARQUET, COMPRESSION zstd)"
+    )
+
+
+def list_keys(s3, prefix):
+    keys = []
+    for page in s3.get_paginator("list_objects_v2").paginate(Bucket=BUCKET, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            keys.append(obj["Key"])
+    return keys
+
+
+def delete_keys(s3, keys):
+    objs = [{"Key": k} for k in keys]
+    for i in range(0, len(objs), 1000):
+        s3.delete_objects(Bucket=BUCKET, Delete={"Objects": objs[i : i + 1000]})
+
+
+# ── Commands ─────────────────────────────────────────────────────────────────
+
+def cmd_daily():
+    """Consolidate each completed YYYY-MM-DD/ of JSONL into flat daily parquet
+    + a daily session view, then delete the raw inputs. Skips today and any day
+    already consolidated (idempotent)."""
+    s3 = s3_client()
+    today = datetime.datetime.utcnow().date().isoformat()
+
+    date_prefixes = set()
+    for page in s3.get_paginator("list_objects_v2").paginate(Bucket=BUCKET, Delimiter="/"):
+        for p in page.get("CommonPrefixes", []):
+            pref = p["Prefix"].rstrip("/")
+            try:
+                datetime.date.fromisoformat(pref)
+                date_prefixes.add(pref)
+            except ValueError:
+                pass
+
+    existing = {
+        k.split("/")[-1][: -len(".parquet")]
+        for k in list_keys(s3, "consolidated/daily/")
+        if k.endswith(".parquet")
+    }
+
+    to_do = sorted(d for d in date_prefixes if d != today and d not in existing)
+    print(f"Days to consolidate ({len(to_do)}): {to_do}")
+    if not to_do:
+        print("Nothing to do.")
+        return
+
+    con = duck()
+    for day in to_do:
+        print(f"→ {day}")
+        src = f"(SELECT json::VARCHAR AS entry FROM read_ndjson_objects('s3://{BUCKET}/{day}/*.jsonl'))"
+        flat = flatten_select(src)
+        copy_to(con, f"SELECT * FROM ({flat}) ORDER BY ts", f"consolidated/daily/{day}.parquet")
+        copy_to(con, session_view(flat), f"sessions/daily/{day}.parquet")
+        # Verify both outputs exist before destroying inputs.
+        s3.head_object(Bucket=BUCKET, Key=f"consolidated/daily/{day}.parquet")
+        s3.head_object(Bucket=BUCKET, Key=f"sessions/daily/{day}.parquet")
+        raw = list_keys(s3, f"{day}/")
+        delete_keys(s3, raw)
+        print(f"  ✓ flat + session view written; {len(raw)} JSONL chunks removed")
+    print("Done.")
+
+
+def cmd_monthly():
+    """Roll the just-closed month's daily parquet into one monthly file (entry +
+    session view), then delete the daily inputs. Session turn_idx is recomputed
+    across the full month so it is correct for cross-day sessions."""
+    s3 = s3_client()
+    today = datetime.datetime.utcnow().date()
+    prev_month_end = today.replace(day=1) - datetime.timedelta(days=1)
+    prev_month = prev_month_end.strftime("%Y-%m")
+    print(f"Rolling up month: {prev_month}")
+
+    daily_entry = [
+        k for k in list_keys(s3, f"consolidated/daily/{prev_month}-") if k.endswith(".parquet")
+    ]
+    print(f"Daily entry files found: {len(daily_entry)}")
+    if not daily_entry:
+        print("Nothing to roll up.")
+        return
+
+    daily_sessions = [
+        k for k in list_keys(s3, f"sessions/daily/{prev_month}-") if k.endswith(".parquet")
+    ]
+    entry_key = f"consolidated/monthly/{prev_month}.parquet"
+    session_key = f"sessions/monthly/{prev_month}.parquet"
+
+    con = duck()
+    copy_to(
+        con,
+        f"SELECT * FROM read_parquet('s3://{BUCKET}/consolidated/daily/{prev_month}-*.parquet') ORDER BY ts",
+        entry_key,
+    )
+    # Rebuild the session view from the merged month so turn_idx spans days.
+    flat = f"SELECT * FROM read_parquet('s3://{BUCKET}/{entry_key}')"
+    copy_to(con, session_view(flat), session_key)
+
+    s3.head_object(Bucket=BUCKET, Key=entry_key)
+    s3.head_object(Bucket=BUCKET, Key=session_key)
+    delete_keys(s3, daily_entry + daily_sessions)
+    print(
+        f"✓ Rolled up {len(daily_entry)} daily files → {entry_key} + {session_key}; "
+        f"{len(daily_entry) + len(daily_sessions)} daily files removed."
+    )
+
+
+def _rewrite_flat(con, s3, entry_key, session_key):
+    """Rewrite one pre-flatten entry parquet in place to the flat schema and
+    (re)build its session view. Idempotent: re-running on an already-flat file
+    re-derives the same columns. Verifies row count is preserved before the
+    atomic replace, so a partial read can never truncate the corpus."""
+    src = f"read_parquet('s3://{BUCKET}/{entry_key}')"
+    n_in = con.execute(f"SELECT count(*) FROM {src}").fetchone()[0]
+    tmp = entry_key + ".tmp"
+    flat = flatten_select(src)
+    copy_to(con, f"SELECT * FROM ({flat}) ORDER BY ts", tmp)
+    n_out = con.execute(f"SELECT count(*) FROM read_parquet('s3://{BUCKET}/{tmp}')").fetchone()[0]
+    if n_in != n_out:
+        s3.delete_object(Bucket=BUCKET, Key=tmp)
+        raise RuntimeError(f"{entry_key}: row count {n_in} -> {n_out}; aborting (temp deleted)")
+    s3.copy_object(Bucket=BUCKET, Key=entry_key, CopySource={"Bucket": BUCKET, "Key": tmp})
+    s3.delete_object(Bucket=BUCKET, Key=tmp)
+    # Session view rebuilt from the now-flat entry file.
+    copy_to(con, session_view(f"read_parquet('s3://{BUCKET}/{entry_key}')"), session_key)
+    s3.head_object(Bucket=BUCKET, Key=session_key)
+    print(f"  ✓ {entry_key}: {n_in} rows flattened → + {session_key}")
+
+
+def cmd_backfill():
+    """One-off: rewrite every existing consolidated parquet (daily + monthly) to
+    the flat schema and materialize its session view. Safe to re-run."""
+    s3 = s3_client()
+    con = duck()
+    daily = sorted(k for k in list_keys(s3, "consolidated/daily/") if k.endswith(".parquet"))
+    monthly = sorted(k for k in list_keys(s3, "consolidated/monthly/") if k.endswith(".parquet"))
+    print(f"Backfilling {len(daily)} daily + {len(monthly)} monthly files")
+    for k in daily:
+        name = k.split("/")[-1]
+        _rewrite_flat(con, s3, k, f"sessions/daily/{name}")
+    for k in monthly:
+        name = k.split("/")[-1]
+        _rewrite_flat(con, s3, k, f"sessions/monthly/{name}")
+    print("Backfill done.")
+
+
+COMMANDS = {"daily": cmd_daily, "monthly": cmd_monthly, "backfill": cmd_backfill}
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or sys.argv[1] not in COMMANDS:
+        sys.exit(f"usage: {sys.argv[0]} {{{'|'.join(COMMANDS)}}}")
+    COMMANDS[sys.argv[1]]()

--- a/flatten-historical-logs-job.yaml
+++ b/flatten-historical-logs-job.yaml
@@ -1,0 +1,66 @@
+# One-shot Job: backfill the flat schema + session views onto historical logs
+# already consolidated under the OLD (ts, type, request_id, origin, entry) schema
+# (issue #31).
+#
+# The daily/monthly CronJobs only emit the flattened schema going forward; the
+# consolidated Parquet written before this change has just the 5 original columns
+# and no session view. This Job rewrites every existing consolidated/{daily,
+# monthly}/*.parquet in place to the flat schema and materializes the matching
+# sessions/{daily,monthly}/*.parquet — using the SAME consolidate.py as the live
+# CronJobs, so the two can't diverge.
+#
+#   kubectl -n biodiversity create -f flatten-historical-logs-job.yaml
+#   kubectl -n biodiversity logs -f job/flatten-historical-logs
+#
+# Idempotent: re-running on already-flat files re-derives the same columns. Each
+# entry rewrite goes via a temp key + row-count check + atomic copy, so a partial
+# read can never truncate the corpus. Run AFTER this PR is merged (clones main).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: flatten-historical-logs
+  labels:
+    app: logs-consolidate
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 604800
+  template:
+    spec:
+      priorityClassName: opportunistic
+      restartPolicy: Never
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: feature.node.kubernetes.io/pci-10de.present
+                    operator: NotIn
+                    values: ["true"]
+      initContainers:
+        - name: git-sync
+          image: alpine/git:latest
+          command: ["sh", "-c", "git clone --depth 1 https://github.com/boettiger-lab/open-llm-proxy.git /repo"]
+          volumeMounts:
+            - name: repo
+              mountPath: /repo
+      containers:
+        - name: backfill
+          image: python:3.12-slim
+          workingDir: /repo
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom: { secretKeyRef: { name: aws, key: AWS_ACCESS_KEY_ID } }
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom: { secretKeyRef: { name: aws, key: AWS_SECRET_ACCESS_KEY } }
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              pip install --quiet duckdb boto3
+              python consolidate.py backfill
+          resources:
+            requests: { cpu: "500m", memory: "1Gi" }
+            limits:   { cpu: "1000m", memory: "2Gi" }
+      volumes:
+        - name: repo
+          emptyDir: {}

--- a/test_consolidate.py
+++ b/test_consolidate.py
@@ -1,0 +1,161 @@
+"""Tests for the consolidation SQL builders (consolidate.py, issue #31).
+
+Exercises the pure flatten_select / session_view SQL against synthetic fixtures
+and (when present) a locally-synced copy of the real corpus, so the flattened
+schema and session-view shape are pinned without needing S3.
+
+Runnable standalone (`python test_consolidate.py`, the CI entrypoint) or under
+pytest — same dual style as test_logging.py. Uses only duckdb (no pandas/pytest).
+"""
+import json
+import os
+
+import duckdb
+
+import consolidate
+
+LOCAL_LOGS = "/tmp/open-llm-proxy-logs"
+
+EXPECTED_FLAT_COLS = {
+    "ts", "type", "request_id", "origin", "session_id", "client", "model",
+    "provider", "message_count", "tools_count", "user_question", "latency_ms",
+    "has_content", "has_tool_calls", "has_reasoning_content", "total_tokens",
+    "tool_calls", "tool_results", "tokens", "error", "entry",
+}
+EXPECTED_SESSION_COLS = {
+    "session_key", "session_id", "turn_idx", "ts", "origin", "model", "provider",
+    "client", "message_count", "user_question", "latest_user_message",
+    "assistant_text", "tool_calls", "tool_results", "has_content",
+    "has_tool_calls", "latency_ms", "total_tokens", "error", "request_id",
+}
+
+
+def _rel(con, records):
+    """Register a relation exposing `entry` VARCHAR, one row per record dict."""
+    con.execute("CREATE TABLE raw(entry VARCHAR)")
+    con.executemany("INSERT INTO raw VALUES (?)", [[json.dumps(r)] for r in records])
+    return "raw"
+
+
+def _rows(con, sql):
+    """Run sql, return (column_names_set, list_of_dict_rows)."""
+    cur = con.execute(sql)
+    cols = [d[0] for d in cur.description]
+    return set(cols), [dict(zip(cols, r)) for r in cur.fetchall()]
+
+
+def test_flatten_schema_and_types():
+    con = duckdb.connect()
+    rel = _rel(con, [
+        {"timestamp": "2026-06-01T00:00:00+00:00", "type": "request",
+         "request_id": "abc", "origin": "o", "session_id": "s1", "model": "qwen3",
+         "provider": "nrp", "message_count": 2, "tools_count": 9,
+         "user_question": "hello?", "tool_results_this_turn": None},
+        {"timestamp": "2026-06-01T00:00:01+00:00", "type": "response",
+         "request_id": "abc", "origin": "o", "session_id": "s1", "model": "qwen3",
+         "provider": "nrp", "latency_ms": 1234, "has_content": True,
+         "has_tool_calls": True, "tokens": {"total_tokens": 50},
+         "tool_calls": [{"name": "query", "arguments": {"sql": "SELECT 1"}}]},
+    ])
+    cols, rows = _rows(con, consolidate.flatten_select(rel))
+    assert cols == EXPECTED_FLAT_COLS, cols ^ EXPECTED_FLAT_COLS
+    req = next(r for r in rows if r["type"] == "request")
+    resp = next(r for r in rows if r["type"] == "response")
+    assert req["message_count"] == 2 and req["tools_count"] == 9
+    assert resp["latency_ms"] == 1234 and resp["has_tool_calls"] is True
+    assert resp["total_tokens"] == 50
+    assert json.loads(req["entry"])["user_question"] == "hello?"
+
+
+def test_session_view_pairs_and_orders_turns():
+    con = duckdb.connect()
+    rel = _rel(con, [
+        {"timestamp": "2026-06-01T00:00:00+00:00", "type": "request", "request_id": "r1",
+         "origin": "o", "session_id": "S", "user_question": "open Q", "message_count": 2},
+        {"timestamp": "2026-06-01T00:00:01+00:00", "type": "response", "request_id": "r1",
+         "origin": "o", "session_id": "S", "content": "thinking",
+         "tool_calls": [{"name": "list_datasets", "arguments": {}}]},
+        {"timestamp": "2026-06-01T00:00:05+00:00", "type": "request", "request_id": "r2",
+         "origin": "o", "session_id": "S", "user_question": "open Q", "message_count": 4,
+         "tool_results_this_turn": [{"tool_call_id": "t", "content": "[...]"}]},
+        {"timestamp": "2026-06-01T00:00:06+00:00", "type": "response", "request_id": "r2",
+         "origin": "o", "session_id": "S", "content_preview": "final answer"},
+    ])
+    cols, rows = _rows(con, consolidate.session_view(consolidate.flatten_select(rel)))
+    assert cols == EXPECTED_SESSION_COLS, cols ^ EXPECTED_SESSION_COLS
+    assert [r["turn_idx"] for r in rows] == [1, 2]
+    assert {r["session_key"] for r in rows} == {"S"}
+    t1, t2 = rows
+    assert t1["assistant_text"] == "thinking"          # full content preferred
+    assert t2["assistant_text"] == "final answer"      # falls back to preview
+    assert json.loads(t1["tool_calls"])[0]["name"] == "list_datasets"
+    assert json.loads(t2["tool_results"])[0]["content"] == "[...]"
+
+
+def test_session_key_heuristic_fallback_when_session_id_null():
+    con = duckdb.connect()
+    rel = _rel(con, [
+        {"timestamp": "2026-06-01T00:00:00+00:00", "type": "request", "request_id": "r1",
+         "origin": "app-a", "user_question": "Q1"},
+        {"timestamp": "2026-06-01T00:00:01+00:00", "type": "request", "request_id": "r2",
+         "origin": "app-a", "user_question": "Q2"},
+    ])
+    _, rows = _rows(con, consolidate.session_view(consolidate.flatten_select(rel)))
+    assert {r["session_key"] for r in rows} == {"app-a|Q1", "app-a|Q2"}
+    assert all(r["session_id"] is None for r in rows)
+
+
+def test_latest_user_message_full_mode_only():
+    con = duckdb.connect()
+    rel = _rel(con, [
+        {"timestamp": "2026-06-01T00:00:00+00:00", "type": "request", "request_id": "r1",
+         "origin": "o", "session_id": "S", "user_question": "first Q", "messages": [
+             {"role": "system", "content": "sys"},
+             {"role": "user", "content": "first Q"},
+             {"role": "assistant", "content": "a"},
+             {"role": "user", "content": "follow up Q"}]},
+        {"timestamp": "2026-06-02T00:00:00+00:00", "type": "request", "request_id": "r2",
+         "origin": "o", "session_id": "T", "user_question": "lone Q"},
+    ])
+    _, rows = _rows(con, consolidate.session_view(consolidate.flatten_select(rel)))
+    by_key = {r["session_key"]: r for r in rows}
+    assert by_key["S"]["latest_user_message"] == "follow up Q"
+    assert by_key["T"]["latest_user_message"] is None
+
+
+def test_against_real_corpus_if_synced():
+    """Flatten + session view run cleanly over the real consolidated Parquet and
+    preserve row counts, with dense 1-based turn_idx per session. Skips when no
+    local corpus is synced (e.g. in CI)."""
+    if not os.path.isdir(os.path.join(LOCAL_LOGS, "consolidated")):
+        print("  (skipped: no locally-synced corpus — run ./sync-logs.sh)")
+        return
+    con = duckdb.connect()
+    src = f"read_parquet('{LOCAL_LOGS}/consolidated/**/*.parquet')"
+    n_raw = con.execute(f"SELECT count(*) FROM {src}").fetchone()[0]
+    flat_sql = consolidate.flatten_select(src)
+    assert con.execute(f"SELECT count(*) FROM ({flat_sql})").fetchone()[0] == n_raw
+    cols, _ = _rows(con, consolidate.session_view(flat_sql) + " LIMIT 0")
+    assert cols == EXPECTED_SESSION_COLS, cols ^ EXPECTED_SESSION_COLS
+    con.execute("CREATE VIEW sv AS " + consolidate.session_view(flat_sql))
+    n_req = con.execute(f"SELECT count(*) FROM ({flat_sql}) WHERE type='request'").fetchone()[0]
+    assert con.execute("SELECT count(*) FROM sv").fetchone()[0] == n_req
+    bad = con.execute(
+        "SELECT count(*) FROM (SELECT session_key, min(turn_idx) lo, max(turn_idx) hi, "
+        "count(*) n FROM sv GROUP BY 1) WHERE lo != 1 OR hi != n"
+    ).fetchone()[0]
+    assert bad == 0
+
+
+if __name__ == "__main__":
+    import sys
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except Exception as e:
+            failed += 1
+            print(f"FAIL {fn.__name__}: {type(e).__name__}: {e}")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
Closes the remaining (core) work in #31: the persisted **data shape** that makes session reconstruction a one-line `SELECT` instead of hand-rolled JSON gymnastics. (The *access* friction — `user_question` trap docs, JSON-cast trap docs, exact `session_id`ature — shipped in v0.1.0 / #34.)

## What changed

**`consolidated/**` — flat entry schema.** Daily/monthly consolidation now promotes hot fields to typed columns alongside the raw `entry` blob (kept for fidelity): `session_id, client, model, provider, message_count, tools_count, user_question, latency_ms, has_content, has_tool_calls, has_reasoning_content, total_tokens, tool_calls/tool_results/tokens` (JSON), `error`. Removes the `entry::JSON->>` *"Failed to cast value to numerical"* traps.

**`sessions/**` — per-turn session view.** A new Parquet tree, one row per **turn** (request+response paired), already interleaved and ordered:
```sql
SELECT turn_idx, user_question, assistant_text, tool_calls, tool_results
FROM read_parquet('.../sessions/**/*.parquet')
WHERE session_key = ? ORDER BY turn_idx;
```
Keyed on exact `session_id`, falling back to the `(origin, user_question)` heuristic for pre-#34 null rows. `latest_user_message` is populated in `full` capture mode. Monthly rebuilds the view from the merged month so `turn_idx` is correct across day boundaries. Kept **separate** from `consolidated/**` so that documented glob stays a single uniform schema.

**Single source of truth.** All consolidation logic moves into `consolidate.py` (`daily`/`monthly`/`backfill`), git-cloned by the CronJobs (same pattern as the scrub job) so the flatten SQL can't drift across the three entrypoints.

**Backfill.** `flatten-historical-logs-job.yaml` rewrites pre-#31 consolidated Parquet to the flat schema + builds session views, in place — idempotent, row-count-checked, temp-key + atomic copy.

## Acceptance (#31)
- ✅ "show me every turn of session X in order, with tool calls and results in one flat SELECT, no JSON gymnastics, no manual interleaving" → the `sessions/**` view.
- ✅ Flatten hot fields to typed columns at consolidation, keeping raw `entry`.
- ✅ Materialize the turn/session view keyed on exact `session_id`.

## Testing
- `test_consolidate.py` (new, wired into CI): pins the flat + session schemas, turn pairing/ordering, `turn_idx` density, heuristic-key fallback, and full-mode `latest_user_message`.
- Validated locally against the real synced corpus and today's raw JSONL: faithful row counts, exact-UUID session keys, and JSON columns round-trip through Parquet and stay queryable.

## Rollout
Merge → `kubectl apply -f consolidate-daily-cronjob.yaml -f consolidate-monthly-cronjob.yaml` → run the one-off `flatten-historical-logs-job.yaml` once (before the next monthly rollup) to backfill existing files. Docs updated in LOGGING.md + AGENTS.md; CHANGELOG `[Unreleased]`.