### PR TITLE
Fix response logging silently dropped by client/AsyncClient shadowing (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ See [Releases](README.md#releases) for how a release is cut.
 
 ## [Unreleased]
 
+### Fixed
+- **Response logging restored (#37).** Since the #26 (X-Client) deploy, the
+  `async with httpx.AsyncClient(...) as client` block shadowed the `client`
+  X-Client header parameter, so `log_response(..., client=client)` passed the
+  httpx client object; `json.dumps` then raised inside the `@_never_raises`
+  wrapper and **every response was silently dropped from S3** (requests were
+  unaffected — they log before the block). Renamed the context var to
+  `http_client`. Added a handler-level regression test that drives `proxy_chat`
+  with a mocked upstream and asserts a serializable `type: "response"` entry
+  lands in the buffer.
+
 ## [0.1.0] - 2026-06-24
 
 First tagged release. The proxy has run in production (`biodiversity` namespace,

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -485,10 +485,13 @@ async def proxy_chat(request: ChatRequest, http_request: Request, authorization:
         else:
             print(f"ℹ️  enable_thinking requested for '{request.model}' but no thinking_key configured — ignoring")
     
-    # Make request to LLM provider
-    async with httpx.AsyncClient(timeout=600.0) as client:
+    # Make request to LLM provider. NB: name this `http_client`, NOT `client` —
+    # `client` is the X-Client header value passed to log_response() below; an
+    # `as client` here shadowed it with the AsyncClient object, so json.dumps in
+    # log_response raised and every response was silently dropped from S3 (#37).
+    async with httpx.AsyncClient(timeout=600.0) as http_client:
         try:
-            response = await client.post(endpoint, json=payload, headers=headers)
+            response = await http_client.post(endpoint, json=payload, headers=headers)
             response.raise_for_status()
             result = response.json()
             

--- a/test_logging.py
+++ b/test_logging.py
@@ -246,6 +246,60 @@ def test_chat_request_parses_user_as_session_id_source():
     assert (p.ChatRequest(messages=[], model="qwen3").user or "from-header") == "from-header"
 
 
+def test_handler_emits_response_to_buffer_with_serializable_client():
+    """Regression for #37: a successful turn must enqueue a `type: "response"`
+    entry to the S3 buffer, and its `client` must be the X-Client *string* — not
+    the httpx AsyncClient. The bug was `async with httpx.AsyncClient() as client`
+    shadowing the `client` header param, so json.dumps blew up inside the
+    `@_never_raises`-wrapped log_response and every response was silently dropped.
+
+    Driving the handler (not log_response directly) is what catches it — the
+    defect was at the call site, not in the function. The mocked AsyncClient is
+    itself non-serializable, so pre-fix this test fails (no response buffered);
+    post-fix `client` stays the header string and the entry is serializable."""
+    import asyncio
+    from unittest.mock import patch
+
+    p = _reload(PROXY_KEY="testkey")
+    p._log_buffer.clear()
+
+    class _FakeResp:
+        def raise_for_status(self):
+            pass
+        def json(self):
+            return {"choices": [{"message": {
+                        "content": "hello",
+                        "tool_calls": [{"function": {"name": "query", "arguments": "{}"}}]}}],
+                    "usage": {"total_tokens": 5}}
+
+    class _FakeAsyncClient:  # non-serializable on purpose (mirrors httpx.AsyncClient)
+        def __init__(self, *a, **k):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def post(self, *a, **k):
+            return _FakeResp()
+
+    class _FakeRequest:
+        headers = {"origin": "https://app", "x-client": "geo-agent/v9.9.9"}
+
+    req = p.ChatRequest(model="qwen3", messages=[{"role": "user", "content": "hi"}], user="sess-1")
+    with patch.object(p, "get_provider_for_model",
+                      return_value=("nrp", {"endpoint": "http://upstream", "api_key": "k"})), \
+         patch.object(p.httpx, "AsyncClient", _FakeAsyncClient):
+        result = asyncio.run(p.proxy_chat(req, _FakeRequest(), authorization="Bearer testkey"))
+
+    assert result["choices"][0]["message"]["content"] == "hello"
+    responses = [e for e in p._log_buffer if e.get("type") == "response"]
+    assert len(responses) == 1, "response was dropped from the S3 buffer (#37)"
+    assert responses[0]["client"] == "geo-agent/v9.9.9"   # the header string, not an AsyncClient
+    assert responses[0]["session_id"] == "sess-1"
+    assert responses[0]["has_tool_calls"] is True
+    json.dumps(responses[0])   # must be JSON-serializable — the crux of the bug
+
+
 if __name__ == "__main__":
     import sys
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]


### PR DESCRIPTION
Fixes #37. Live outage: **no `type: "response"` entries have reached S3 since the #26 (X-Client) deploy** — `tool_calls`, `content`, `tokens`, `latency_ms`, and `error` all live only on response rows, so the durable corpus has been losing every model answer. Requests were unaffected.

## Root cause (corrected from the issue)
Not a missing `_emit` — `log_response()` has always called `_emit()` (`:402`). The real bug is **variable shadowing**:

```python
client = http_request.headers.get("x-client")          # the X-Client header string
log_request(..., client=client)                         # OUTSIDE the block → requests log fine
...
async with httpx.AsyncClient(timeout=600.0) as client:  # ← rebinds `client` to the httpx object
    log_response(..., client=client)                    # passes the AsyncClient, not the string
```

`log_response` then puts the `AsyncClient` into `log_entry["client"]`; the `json.dumps(...)` in its print raises `TypeError: Object of type AsyncClient is not JSON serializable`, which the `@_never_raises` wrapper swallows — so the response is never printed *or* emitted. Live evidence on all 3 pods:
```
⚠️  log_response failed (request still served): TypeError: Object of type AsyncClient is not JSON serializable
```
(Introduced by #26 / `5f8265f`, which added `client=client` at the response call sites inside that block.)

## Fix
Rename the context-manager variable to `http_client` so it stops shadowing the parameter. One-line behavioral change + comment to prevent recurrence.

## Test
Adds `test_handler_emits_response_to_buffer_with_serializable_client` to `test_logging.py` — drives `proxy_chat` with a mocked (non-serializable) upstream client and asserts a serializable `type: "response"` entry with `client == "geo-agent/v9.9.9"` lands in `_log_buffer`. Driving the *handler* (not `log_response` directly) is what catches it, since the defect is at the call site. **Verified it fails pre-fix** (`response was dropped from the S3 buffer (#37)`) and passes post-fix. Full suite: 15/15 green.

## Rollout
Merge → `kubectl rollout restart deployment/open-llm-proxy -n biodiversity` (pods clone `main` at startup). Responses already in `kubectl logs`... aren't — they never got printed — so the gap from ~01:27 UTC today onward is unrecoverable; logging resumes from the restart.

Independent of #36; recommend landing this first.