### PR TITLE
Flatten consolidated log schema + materialize session/turn view (#31)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,9 @@ SELECT * FROM read_ndjson_auto('/tmp/open-llm-proxy-logs/YYYY-MM-DD/*.jsonl',
 "
 ```
 
-**Parquet schema** (same for daily and monthly tiers): `(ts TIMESTAMPTZ, type, request_id, origin, entry VARCHAR)` — `entry` is the full original log record as JSON text. Access fields with `entry::JSON->>'field'`.
+**Parquet schema** (same for daily and monthly tiers): the hot fields are flattened to typed columns — `ts, type, request_id, session_id, origin, client, provider, model, message_count, tools_count, user_question, latency_ms, has_tool_calls, has_content, tool_calls, tool_results, tokens, error` — plus `entry VARCHAR`, the full original log record as JSON text (kept for fidelity). Prefer the flat columns; for fields not promoted, use `json_extract_string(entry,'$.field')` / `json_extract(entry,'$.field')` (the `entry::JSON->>` form intermittently throws a cast error in aggregates). Legacy files predating the flatten carry only `ts/type/request_id/origin/entry`.
+
+**Session view** (`s3://logs-open-llm-proxy/sessions/**/*.parquet`): one row per *turn*, request already joined to its response, ordered by `turn_idx` within `session_key`. This is the query-ready artifact — "show me every turn of session X in order, with tool calls and results" is one flat `SELECT`, no manual interleaving. Disjoint from the `consolidated/**` glob. See [LOGGING.md](LOGGING.md#reconstructing-a-conversation).
 
 For automation, one-shot CI queries, or queries that need sub-minute freshness without re-syncing, query S3 directly with `LOG_S3_KEY` / `LOG_S3_SECRET` from the shell — see [LOGGING.md](LOGGING.md#direct-s3-one-shot-queries-automation-or-inside-nrp-pods).
 
@@ -48,7 +50,7 @@ Each LLM call produces a `request` row and a `response` row linked by `request_i
 - **Request**: `user_question`, `tool_results_this_turn`, `model`, `origin`, `message_count`
 - **Response**: `tool_calls`, `content_preview`, `tokens`, `latency_ms`, `error` (only on failures)
 
-**Reconstructing a conversation**: group by `user_question`, filter by `origin`, sort by `ts` (Parquet) / `timestamp` (JSONL). The `tool_results_this_turn` on each request shows what the previous turn's tool calls returned; `tool_calls` on each response shows what the LLM called next.
+**Reconstructing a conversation**: for completed days, just query the **session view** (`sessions/**`) by `session_key` and order by `turn_idx` — the interleaving is already done. To reconstruct by hand (e.g. today's raw JSONL): group by `session_id` (exact; falls back to `user_question` for pre-wiring records), filter by `origin`, sort by `ts` (Parquet) / `timestamp` (JSONL). The `tool_results_this_turn` on each request shows what the previous turn's tool calls returned; `tool_calls` on each response shows what the LLM called next.
 
 **Midnight crossover caveat**: flush-time (not entry `ts`) determines the source file path. An entry with `ts = 23:59:58` may live in the next UTC day's file if it was buffered past midnight. Always filter on `ts`, not on file path, when you care about a calendar day.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,14 @@ See [Releases](README.md#releases) for how a release is cut.
   session views for already-consolidated days that lack one; the monthly rollup
   rebuilds the view over the whole month (correct cross-midnight `turn_idx`) and
   reads daily files with `union_by_name=true` so a month mixing legacy
-  (entry-only) and flattened daily files merges cleanly. `LOGGING.md` / `AGENTS.md`
-  document both schemas and the `sessions/**` ⟂ `consolidated/**` glob split.
+  (entry-only) and flattened daily files merges cleanly. Both jobs also run a
+  **self-healing schema-upgrade pass** that re-flattens any legacy 5-column
+  consolidated file in place from its preserved `entry` blob (lossless,
+  idempotent), so the whole `consolidated/**` corpus converges to one schema and
+  old logs gain the flat columns too — no mixed-schema barrier for analysts.
+  Existing `entry`-based queries were never at risk (DuckDB name-matches common
+  columns across a mixed glob). `LOGGING.md` / `AGENTS.md` document both schemas,
+  the `sessions/**` ⟂ `consolidated/**` glob split, and the mixed-glob caveat.
 
 ### Fixed
 - **Response logging restored (#37).** Since the #26 (X-Client) deploy, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ See [Releases](README.md#releases) for how a release is cut.
 
 ## [Unreleased]
 
+### Added
+- **Query-ready consolidated logs: flattened columns + a materialized session
+  view (#31).** The daily consolidation now promotes the hot fields
+  (`session_id`, `client`, `provider`, `model`, `message_count`, `tools_count`,
+  `user_question`, `latency_ms`, `has_tool_calls`, `has_content`, `tool_calls`,
+  `tool_results`, `tokens`, `error`) to typed columns alongside the verbatim
+  `entry` blob, removing the `entry::JSON->>` cast traps for common queries while
+  staying backward-compatible (existing `entry`-based queries still work). A new
+  `sessions/{daily,monthly}/` tier materializes one row per **turn** — request
+  joined to its response, keyed on `session_key` (`session_id`, or an
+  `anon:<hash>` fallback) and ordered by `turn_idx` — so reconstructing a session
+  ("every turn of X in order, with tool calls and results") is a single flat
+  `SELECT` with no manual request/response interleaving. The daily job backfills
+  session views for already-consolidated days that lack one; the monthly rollup
+  rebuilds the view over the whole month (correct cross-midnight `turn_idx`) and
+  reads daily files with `union_by_name=true` so a month mixing legacy
+  (entry-only) and flattened daily files merges cleanly. `LOGGING.md` / `AGENTS.md`
+  document both schemas and the `sessions/**` ⟂ `consolidated/**` glob split.
+
 ### Fixed
 - **Response logging restored (#37).** Since the #26 (X-Client) deploy, the
   `async with httpx.AsyncClient(...) as client` block shadowed the `client`

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -18,12 +18,18 @@ logs-open-llm-proxy/
 ├── 2026-04-17/                        ← today: raw JSONL (live debug tier)
 │   ├── 02-00-05-39.jsonl              # flush at 02:00:05 from worker PID 39
 │   └── ...
-├── consolidated/
+├── consolidated/                      ← one row per log entry (request OR response)
 │   ├── daily/
 │   │   ├── 2026-04-15.parquet         # recent completed days
 │   │   └── 2026-04-16.parquet
 │   └── monthly/
 │       ├── 2026-02.parquet            # older completed months
+│       └── 2026-03.parquet
+├── sessions/                          ← one row per *turn* (request joined to its response)
+│   ├── daily/
+│   │   ├── 2026-04-15.parquet
+│   │   └── 2026-04-16.parquet
+│   └── monthly/
 │       └── 2026-03.parquet
 ```
 
@@ -32,16 +38,65 @@ logs-open-llm-proxy/
 | Raw JSONL (`YYYY-MM-DD/*.jsonl`) | JSONL chunks | Proxy flushes every 60s | Next day's daily consolidation (03:00 UTC) |
 | Daily (`consolidated/daily/YYYY-MM-DD.parquet`) | Parquet (zstd) | Daily cron at 03:00 UTC | Monthly rollup on day 2 (04:00 UTC) |
 | Monthly (`consolidated/monthly/YYYY-MM.parquet`) | Parquet (zstd) | Monthly cron on day 2 | Never (long-term archive) |
+| Session daily (`sessions/daily/YYYY-MM-DD.parquet`) | Parquet (zstd) | Daily cron, derived from that day's consolidated file | Monthly rollup on day 2 |
+| Session monthly (`sessions/monthly/YYYY-MM.parquet`) | Parquet (zstd) | Monthly cron on day 2 | Never |
 
-The **Parquet schema** (identical across daily and monthly tiers):
+The **consolidated Parquet schema** (identical across daily and monthly tiers). The
+hot fields are flattened to typed columns; the raw JSON is kept verbatim in `entry`
+for fidelity, so old `entry::JSON->>'…'` / `json_extract_string` queries still work:
 
 | Column | Type | Notes |
 |---|---|---|
 | `ts` | `TIMESTAMPTZ` | Extracted from the `timestamp` field of the raw JSON |
 | `type` | `VARCHAR` | `'request'` or `'response'` |
 | `request_id` | `VARCHAR` | Correlates request ↔ response |
+| `session_id` | `VARCHAR` | Per-session id (see field note); `null` in pre-wiring records |
 | `origin` | `VARCHAR` | App the traffic came from |
-| `entry` | `VARCHAR` | The full original JSON record — parse with `entry::JSON` |
+| `client` | `VARCHAR` | e.g. `geo-agent/v3.13.1`; `null` until clients send `X-Client` |
+| `provider` | `VARCHAR` | `nrp` / `openrouter` / `nimbus` |
+| `model` | `VARCHAR` | Model id |
+| `message_count` | `INTEGER` | Request only — messages in the prompt |
+| `tools_count` | `INTEGER` | Request only — tools offered |
+| `user_question` | `VARCHAR` | Request only — **first** user message (see trap below) |
+| `latency_ms` | `BIGINT` | Response only |
+| `has_tool_calls` | `BOOLEAN` | Response only |
+| `has_content` | `BOOLEAN` | Response only |
+| `tool_calls` | `JSON` | Response only — `[{name, arguments}]` |
+| `tool_results` | `JSON` | Request only — `tool_results_this_turn` (prior turn's tool outputs) |
+| `tokens` | `JSON` | Response only — usage object |
+| `error` | `VARCHAR` | Response only — set on failures |
+| `entry` | `VARCHAR` | The full original JSON record — parse with `json_extract_string`/`json_extract` |
+
+Columns not applicable to a row's `type` are `null` (e.g. `latency_ms` on a request).
+Files written before the flatten landed carry only the legacy 5 columns
+(`ts`/`type`/`request_id`/`origin`/`entry`); the monthly rollup reads daily files
+with `union_by_name=true` so a mixed month merges cleanly (legacy rows get `null`
+for the new columns).
+
+The **session Parquet schema** (`sessions/**`) — one row per turn, request already
+joined to its response, so "show me every turn of session X in order, with tool
+calls and results" is a single flat `SELECT` with no JSON gymnastics and no manual
+request/response interleaving:
+
+| Column | Type | Notes |
+|---|---|---|
+| `session_key` | `VARCHAR` | `session_id` when present, else `anon:<md5(origin\|user_question)>` so every turn still groups |
+| `session_id` | `VARCHAR` | Raw id (`null` if the heuristic key was used) |
+| `turn_idx` | `BIGINT` | 1-based turn order within the session. **Daily files index within-day** (a session crossing UTC midnight restarts at 1 in the next day's file); the monthly view recomputes it over the whole month. Ordering by `request_ts` is always correct regardless. |
+| `request_ts` / `response_ts` | `TIMESTAMPTZ` | Turn start / completion |
+| `request_id` | `VARCHAR` | |
+| `origin`, `client`, `provider`, `model` | `VARCHAR` | |
+| `user_question` | `VARCHAR` | Opening question (same first-message-only caveat) |
+| `message_count` | `INTEGER` | |
+| `tool_results` | `JSON` | Tool outputs that came *into* this turn |
+| `assistant_content` / `reasoning_content` | `VARCHAR` | The model's reply this turn |
+| `tool_calls` | `JSON` | Tools the model called *out* this turn |
+| `has_tool_calls`, `has_content` | `BOOLEAN` | |
+| `latency_ms`, `tokens`, `error` | `BIGINT`/`JSON`/`VARCHAR` | |
+
+> Note: the `consolidated/**` and `sessions/**` globs are disjoint top-level
+> prefixes — a `read_parquet('…/consolidated/**/*.parquet')` never picks up session
+> rows, so existing queries are unaffected.
 
 ## Access pattern
 
@@ -263,6 +318,25 @@ Records written before this wiring have `session_id = null`; group those by the
 `user_question` first-message-only trap and survives follow-up questions.
 
 ## Reconstructing a conversation
+
+> ✅ **Easiest path: the session view (`sessions/**`).** For completed days/months,
+> the turn-level reconstruction below is already materialized — one row per turn with
+> request and response joined, `tool_results` (in) and `tool_calls` (out) interleaved,
+> ordered by `turn_idx`. No manual pairing, no JSON casting:
+>
+> ```sql
+> SELECT turn_idx, model, user_question,
+>        json_array_length(tool_results) AS results_in,
+>        json_array_length(tool_calls)   AS calls_out,
+>        assistant_content, latency_ms
+> FROM read_parquet('/tmp/open-llm-proxy-logs/sessions/**/*.parquet')
+> WHERE session_key = '…'          -- session_id, or anon:<hash> for pre-wiring rows
+> ORDER BY turn_idx;
+> ```
+>
+> Find a `session_key` by filtering on `origin`/`user_question`/`ts` first. The manual
+> recipe below still applies to **today's** raw JSONL (not yet consolidated) and is
+> what the session view itself is built from.
 
 Each POST to `/v1/chat/completions` is one LLM turn. A single user session produces multiple request/response pairs. To reconstruct a session:
 

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -68,10 +68,17 @@ for fidelity, so old `entry::JSON->>'…'` / `json_extract_string` queries still
 | `entry` | `VARCHAR` | The full original JSON record — parse with `json_extract_string`/`json_extract` |
 
 Columns not applicable to a row's `type` are `null` (e.g. `latency_ms` on a request).
-Files written before the flatten landed carry only the legacy 5 columns
-(`ts`/`type`/`request_id`/`origin`/`entry`); the monthly rollup reads daily files
-with `union_by_name=true` so a mixed month merges cleanly (legacy rows get `null`
-for the new columns).
+Files written before the flatten landed carried only the legacy 5 columns
+(`ts`/`type`/`request_id`/`origin`/`entry`); both cron jobs run a **self-healing
+schema-upgrade pass** that re-flattens any such file in place from its preserved
+`entry` blob (lossless, idempotent), so the whole `consolidated/**` corpus converges
+to one schema. Two safety nets cover the transient window before that completes:
+existing `entry`-based queries are unaffected (DuckDB name-matches the common
+columns across a mixed glob — no corruption), and the monthly rollup reads daily
+files with `union_by_name=true`. The one mixed-glob gotcha: selecting a *new* flat
+column (e.g. `model`) over a glob that still contains a legacy file raises
+`column not found` — add `union_by_name=true` to `read_parquet(...)`, or just wait
+for the upgrade pass.
 
 The **session Parquet schema** (`sessions/**`) — one row per turn, request already
 joined to its response, so "show me every turn of session X in order, with tool

--- a/consolidate-daily-cronjob.yaml
+++ b/consolidate-daily-cronjob.yaml
@@ -91,9 +91,9 @@ spec:
                   backfill_sessions = sorted(existing - existing_sessions - set(to_do))
                   print(f"Days to consolidate ({len(to_do)}): {to_do}")
                   print(f"Session views to backfill ({len(backfill_sessions)}): {backfill_sessions}")
-                  if not to_do and not backfill_sessions:
-                      print("Nothing to do.")
-                      raise SystemExit(0)
+                  # Note: we always continue to the schema-upgrade pass below, which
+                  # re-flattens any legacy consolidated daily file — it must run even on
+                  # days with nothing new to consolidate or backfill.
 
                   con = duckdb.connect()
                   con.execute(f"""
@@ -166,6 +166,44 @@ spec:
                           ) TO '{dest}' (FORMAT PARQUET, COMPRESSION zstd)
                       """)
 
+                  # Upgrade a legacy (entry-only, 5-column) consolidated Parquet file
+                  # to the flattened wide schema in place, reconstructing the typed
+                  # columns from its own `entry` blob. Lossless (`entry` is preserved
+                  # verbatim) and idempotent: a no-op once the file already has the
+                  # wide schema. Keeps the whole consolidated/** corpus on one schema so
+                  # legacy and new files compose in a single glob without union_by_name
+                  # and without the "column not found" gap on the new flat columns.
+                  # Materializes to a TEMP table first so the read completes before the
+                  # COPY overwrites the source key.
+                  def reflatten(path):
+                      cols = [r[0] for r in con.execute(f"DESCRIBE SELECT * FROM read_parquet('{path}')").fetchall()]
+                      if 'model' in cols:
+                          return False
+                      con.execute(f"""
+                          CREATE OR REPLACE TEMP TABLE _wide AS
+                          SELECT ts, type, request_id,
+                                 json_extract_string(entry,'$.session_id')    AS session_id,
+                                 origin,
+                                 json_extract_string(entry,'$.client')        AS client,
+                                 json_extract_string(entry,'$.provider')      AS provider,
+                                 json_extract_string(entry,'$.model')         AS model,
+                                 TRY_CAST(json_extract_string(entry,'$.message_count') AS INTEGER) AS message_count,
+                                 TRY_CAST(json_extract_string(entry,'$.tools_count')   AS INTEGER) AS tools_count,
+                                 json_extract_string(entry,'$.user_question') AS user_question,
+                                 TRY_CAST(json_extract_string(entry,'$.latency_ms') AS BIGINT) AS latency_ms,
+                                 TRY_CAST(json_extract_string(entry,'$.has_tool_calls') AS BOOLEAN) AS has_tool_calls,
+                                 TRY_CAST(json_extract_string(entry,'$.has_content')   AS BOOLEAN) AS has_content,
+                                 json_extract(entry, '$.tool_calls')             AS tool_calls,
+                                 json_extract(entry, '$.tool_results_this_turn')  AS tool_results,
+                                 json_extract(entry, '$.tokens')                  AS tokens,
+                                 json_extract_string(entry,'$.error')         AS error,
+                                 entry
+                          FROM read_parquet('{path}')
+                          ORDER BY ts
+                      """)
+                      con.execute(f"COPY _wide TO '{path}' (FORMAT PARQUET, COMPRESSION zstd)")
+                      return True
+
                   for day in to_do:
                       print(f"→ {day}")
                       # Flatten the hot fields to typed columns alongside the raw
@@ -215,6 +253,16 @@ spec:
                       print(f"↺ backfill session view: {day}")
                       build_session_view(f's3://{BUCKET}/consolidated/daily/{day}.parquet',
                                          f's3://{BUCKET}/sessions/daily/{day}.parquet')
+
+                  # Schema-upgrade pass: bring any legacy-schema consolidated daily file
+                  # (current month — older months live in monthly files, upgraded by the
+                  # monthly job) up to the wide schema. Self-healing no-op once uniform.
+                  upgraded = 0
+                  for day in sorted(_parquet_days('consolidated/daily/')):
+                      if reflatten(f's3://{BUCKET}/consolidated/daily/{day}.parquet'):
+                          upgraded += 1
+                          print(f"  ⬆ re-flattened {day} to wide schema")
+                  print(f"Legacy daily files upgraded to wide schema: {upgraded}")
                   print("Done.")
                   PY
               resources:

--- a/consolidate-daily-cronjob.yaml
+++ b/consolidate-daily-cronjob.yaml
@@ -96,6 +96,13 @@ spec:
                   # days with nothing new to consolidate or backfill.
 
                   con = duckdb.connect()
+                  # In a container DuckDB sees every node core and spawns that many
+                  # worker threads — each with its own buffers — while CPU is throttled
+                  # to the pod request, so memory balloons and OOMs the pod. Pin a small
+                  # thread count and drop insertion-order buffering to keep COPY/sort
+                  # memory bounded (the data is re-sorted by ts on read anyway).
+                  con.execute("SET threads=2")
+                  con.execute("SET preserve_insertion_order=false")
                   con.execute(f"""
                       CREATE SECRET s3_logs (
                           TYPE S3,

--- a/consolidate-daily-cronjob.yaml
+++ b/consolidate-daily-cronjob.yaml
@@ -72,17 +72,26 @@ spec:
                           except ValueError:
                               pass
 
-                  # Existing consolidated daily Parquet files
-                  existing = set()
-                  for page in paginator.paginate(Bucket=BUCKET, Prefix='consolidated/daily/'):
-                      for obj in page.get('Contents', []):
-                          name = obj['Key'].split('/')[-1]
-                          if name.endswith('.parquet'):
-                              existing.add(name[:-len('.parquet')])
+                  def _parquet_days(prefix):
+                      days = set()
+                      for page in paginator.paginate(Bucket=BUCKET, Prefix=prefix):
+                          for obj in page.get('Contents', []):
+                              name = obj['Key'].split('/')[-1]
+                              if name.endswith('.parquet'):
+                                  days.add(name[:-len('.parquet')])
+                      return days
+
+                  # Existing consolidated daily Parquet files, and existing session views
+                  existing          = _parquet_days('consolidated/daily/')
+                  existing_sessions = _parquet_days('sessions/daily/')
 
                   to_do = sorted(d for d in date_prefixes if d != today and d not in existing)
+                  # Days already consolidated but missing a session view (e.g. files
+                  # written before the session view existed) — backfill from Parquet.
+                  backfill_sessions = sorted(existing - existing_sessions - set(to_do))
                   print(f"Days to consolidate ({len(to_do)}): {to_do}")
-                  if not to_do:
+                  print(f"Session views to backfill ({len(backfill_sessions)}): {backfill_sessions}")
+                  if not to_do and not backfill_sessions:
                       print("Nothing to do.")
                       raise SystemExit(0)
 
@@ -98,15 +107,91 @@ spec:
                       )
                   """)
 
-                  for day in to_do:
-                      print(f"→ {day}")
+                  # Materialize the per-turn session view from a consolidated Parquet
+                  # glob (one row per request_id = one turn, request joined to its
+                  # response). Reads only the raw `entry` JSON via json_extract_string
+                  # / json_extract — the cast-safe access form — so it works on both
+                  # legacy (entry-only) and new (flattened) consolidated files.
+                  # turn_idx is assigned within `src` ordered by ts; for the daily
+                  # tier that means within-day (a session spanning UTC midnight
+                  # restarts at 1 in the next day's file — ordering by ts is still
+                  # correct, only the index resets). The monthly rollup recomputes it
+                  # over the whole month.
+                  def build_session_view(src, dest):
                       con.execute(f"""
                           COPY (
-                              SELECT (json->>'timestamp')::TIMESTAMPTZ AS ts,
-                                     json->>'type'       AS type,
-                                     json->>'request_id' AS request_id,
-                                     json->>'origin'     AS origin,
-                                     json::VARCHAR       AS entry
+                              WITH base AS (
+                                  SELECT ts, type, request_id, origin,
+                                      json_extract_string(entry,'$.session_id')    AS session_id,
+                                      json_extract_string(entry,'$.client')        AS client,
+                                      json_extract_string(entry,'$.provider')      AS provider,
+                                      json_extract_string(entry,'$.model')         AS model,
+                                      TRY_CAST(json_extract_string(entry,'$.message_count') AS INTEGER) AS message_count,
+                                      json_extract_string(entry,'$.user_question') AS user_question,
+                                      json_extract(entry,'$.tool_results_this_turn') AS tool_results,
+                                      TRY_CAST(json_extract_string(entry,'$.latency_ms') AS BIGINT) AS latency_ms,
+                                      TRY_CAST(json_extract_string(entry,'$.has_tool_calls') AS BOOLEAN) AS has_tool_calls,
+                                      TRY_CAST(json_extract_string(entry,'$.has_content')   AS BOOLEAN) AS has_content,
+                                      json_extract(entry,'$.tool_calls')           AS tool_calls,
+                                      json_extract(entry,'$.tokens')               AS tokens,
+                                      json_extract_string(entry,'$.content')       AS assistant_content,
+                                      json_extract_string(entry,'$.reasoning_content') AS reasoning_content,
+                                      json_extract_string(entry,'$.error')         AS error
+                                  FROM read_parquet('{src}')
+                              ),
+                              keyed AS (
+                                  SELECT *, COALESCE(session_id,
+                                      'anon:' || md5(COALESCE(origin,'') || '|' || COALESCE(user_question,''))) AS session_key
+                                  FROM base WHERE type='request'
+                              ),
+                              req AS (
+                                  SELECT session_key, session_id, request_id, ts, origin, client, provider, model,
+                                         user_question, message_count, tool_results,
+                                         ROW_NUMBER() OVER (PARTITION BY session_key ORDER BY ts, request_id) AS turn_idx
+                                  FROM keyed
+                              ),
+                              resp AS (
+                                  SELECT request_id, ts AS response_ts, latency_ms, has_tool_calls, has_content,
+                                         tool_calls, tokens, assistant_content, reasoning_content, error
+                                  FROM base WHERE type='response'
+                              )
+                              SELECT req.session_key, req.session_id, req.turn_idx,
+                                     req.ts AS request_ts, resp.response_ts, req.request_id,
+                                     req.origin, req.client, req.provider, req.model,
+                                     req.user_question, req.message_count, req.tool_results,
+                                     resp.assistant_content, resp.reasoning_content, resp.tool_calls,
+                                     resp.has_tool_calls, resp.has_content, resp.latency_ms, resp.tokens, resp.error
+                              FROM req LEFT JOIN resp USING (request_id)
+                              ORDER BY req.session_key, req.turn_idx
+                          ) TO '{dest}' (FORMAT PARQUET, COMPRESSION zstd)
+                      """)
+
+                  for day in to_do:
+                      print(f"→ {day}")
+                      # Flatten the hot fields to typed columns alongside the raw
+                      # `entry` blob (kept verbatim for fidelity). Direct queries no
+                      # longer need entry::JSON-> casting; `entry` is still there.
+                      con.execute(f"""
+                          COPY (
+                              SELECT (json->>'timestamp')::TIMESTAMPTZ            AS ts,
+                                     json->>'type'                                AS type,
+                                     json->>'request_id'                          AS request_id,
+                                     json->>'session_id'                          AS session_id,
+                                     json->>'origin'                              AS origin,
+                                     json->>'client'                              AS client,
+                                     json->>'provider'                            AS provider,
+                                     json->>'model'                               AS model,
+                                     TRY_CAST(json->>'message_count' AS INTEGER)  AS message_count,
+                                     TRY_CAST(json->>'tools_count'   AS INTEGER)  AS tools_count,
+                                     json->>'user_question'                       AS user_question,
+                                     TRY_CAST(json->>'latency_ms' AS BIGINT)      AS latency_ms,
+                                     TRY_CAST(json->>'has_tool_calls' AS BOOLEAN) AS has_tool_calls,
+                                     TRY_CAST(json->>'has_content'    AS BOOLEAN) AS has_content,
+                                     json_extract(json, '$.tool_calls')              AS tool_calls,
+                                     json_extract(json, '$.tool_results_this_turn')  AS tool_results,
+                                     json_extract(json, '$.tokens')                  AS tokens,
+                                     json->>'error'                               AS error,
+                                     json::VARCHAR                                AS entry
                               FROM read_ndjson_objects('s3://{BUCKET}/{day}/*.jsonl')
                               ORDER BY ts
                           ) TO 's3://{BUCKET}/consolidated/daily/{day}.parquet'
@@ -114,13 +199,22 @@ spec:
                       """)
                       # Verify Parquet exists before destroying inputs
                       s3.head_object(Bucket=BUCKET, Key=f'consolidated/daily/{day}.parquet')
+                      # Build the per-turn session view from the just-written Parquet.
+                      build_session_view(f's3://{BUCKET}/consolidated/daily/{day}.parquet',
+                                         f's3://{BUCKET}/sessions/daily/{day}.parquet')
+                      s3.head_object(Bucket=BUCKET, Key=f'sessions/daily/{day}.parquet')
                       to_delete = []
                       for page in paginator.paginate(Bucket=BUCKET, Prefix=f'{day}/'):
                           for obj in page.get('Contents', []):
                               to_delete.append({'Key': obj['Key']})
                       for i in range(0, len(to_delete), 1000):
                           s3.delete_objects(Bucket=BUCKET, Delete={'Objects': to_delete[i:i+1000]})
-                      print(f"  ✓ {len(to_delete)} JSONL chunks removed")
+                      print(f"  ✓ {len(to_delete)} JSONL chunks removed; session view written")
+
+                  for day in backfill_sessions:
+                      print(f"↺ backfill session view: {day}")
+                      build_session_view(f's3://{BUCKET}/consolidated/daily/{day}.parquet',
+                                         f's3://{BUCKET}/sessions/daily/{day}.parquet')
                   print("Done.")
                   PY
               resources:

--- a/consolidate-monthly-cronjob.yaml
+++ b/consolidate-monthly-cronjob.yaml
@@ -88,6 +88,13 @@ spec:
                   session_monthly_key = f'sessions/monthly/{prev_month}.parquet'
 
                   con = duckdb.connect()
+                  # In a container DuckDB sees every node core and spawns that many
+                  # worker threads — each with its own buffers — while CPU is throttled
+                  # to the pod request, so memory balloons and OOMs the pod. Pin a small
+                  # thread count and drop insertion-order buffering to keep COPY/sort
+                  # memory bounded (the data is re-sorted by ts on read anyway).
+                  con.execute("SET threads=2")
+                  con.execute("SET preserve_insertion_order=false")
                   con.execute(f"""
                       CREATE SECRET s3_logs (
                           TYPE S3,
@@ -247,7 +254,7 @@ spec:
               resources:
                 requests:
                   cpu: "500m"
-                  memory: "1Gi"
+                  memory: "2Gi"
                 limits:
                   cpu: "500m"
-                  memory: "1Gi"
+                  memory: "2Gi"

--- a/consolidate-monthly-cronjob.yaml
+++ b/consolidate-monthly-cronjob.yaml
@@ -78,7 +78,15 @@ spec:
                       print("Nothing to roll up.")
                       raise SystemExit(0)
 
-                  monthly_key = f'consolidated/monthly/{prev_month}.parquet'
+                  # Daily session-view files for that month (deleted after rollup)
+                  session_daily_keys = []
+                  for page in paginator.paginate(Bucket=BUCKET, Prefix=f'sessions/daily/{prev_month}-'):
+                      for obj in page.get('Contents', []):
+                          if obj['Key'].endswith('.parquet'):
+                              session_daily_keys.append(obj['Key'])
+
+                  monthly_key         = f'consolidated/monthly/{prev_month}.parquet'
+                  session_monthly_key = f'sessions/monthly/{prev_month}.parquet'
 
                   con = duckdb.connect()
                   con.execute(f"""
@@ -91,19 +99,106 @@ spec:
                           URL_STYLE 'path'
                       )
                   """)
+
+                  # Materialize the per-turn session view (one row per request_id,
+                  # request joined to its response) from a consolidated Parquet glob.
+                  # Reads only the raw `entry` JSON via cast-safe json_extract_string /
+                  # json_extract, so it works on legacy (entry-only) and flattened files
+                  # alike. Mirrors the daily job's builder; here `src` is a whole month,
+                  # so turn_idx is correct across day boundaries.
+                  def build_session_view(src, dest):
+                      con.execute(f"""
+                          COPY (
+                              WITH base AS (
+                                  SELECT ts, type, request_id, origin,
+                                      json_extract_string(entry,'$.session_id')    AS session_id,
+                                      json_extract_string(entry,'$.client')        AS client,
+                                      json_extract_string(entry,'$.provider')      AS provider,
+                                      json_extract_string(entry,'$.model')         AS model,
+                                      TRY_CAST(json_extract_string(entry,'$.message_count') AS INTEGER) AS message_count,
+                                      json_extract_string(entry,'$.user_question') AS user_question,
+                                      json_extract(entry,'$.tool_results_this_turn') AS tool_results,
+                                      TRY_CAST(json_extract_string(entry,'$.latency_ms') AS BIGINT) AS latency_ms,
+                                      TRY_CAST(json_extract_string(entry,'$.has_tool_calls') AS BOOLEAN) AS has_tool_calls,
+                                      TRY_CAST(json_extract_string(entry,'$.has_content')   AS BOOLEAN) AS has_content,
+                                      json_extract(entry,'$.tool_calls')           AS tool_calls,
+                                      json_extract(entry,'$.tokens')               AS tokens,
+                                      json_extract_string(entry,'$.content')       AS assistant_content,
+                                      json_extract_string(entry,'$.reasoning_content') AS reasoning_content,
+                                      json_extract_string(entry,'$.error')         AS error
+                                  FROM read_parquet('{src}')
+                              ),
+                              keyed AS (
+                                  SELECT *, COALESCE(session_id,
+                                      'anon:' || md5(COALESCE(origin,'') || '|' || COALESCE(user_question,''))) AS session_key
+                                  FROM base WHERE type='request'
+                              ),
+                              req AS (
+                                  SELECT session_key, session_id, request_id, ts, origin, client, provider, model,
+                                         user_question, message_count, tool_results,
+                                         ROW_NUMBER() OVER (PARTITION BY session_key ORDER BY ts, request_id) AS turn_idx
+                                  FROM keyed
+                              ),
+                              resp AS (
+                                  SELECT request_id, ts AS response_ts, latency_ms, has_tool_calls, has_content,
+                                         tool_calls, tokens, assistant_content, reasoning_content, error
+                                  FROM base WHERE type='response'
+                              )
+                              SELECT req.session_key, req.session_id, req.turn_idx,
+                                     req.ts AS request_ts, resp.response_ts, req.request_id,
+                                     req.origin, req.client, req.provider, req.model,
+                                     req.user_question, req.message_count, req.tool_results,
+                                     resp.assistant_content, resp.reasoning_content, resp.tool_calls,
+                                     resp.has_tool_calls, resp.has_content, resp.latency_ms, resp.tokens, resp.error
+                              FROM req LEFT JOIN resp USING (request_id)
+                              ORDER BY req.session_key, req.turn_idx
+                          ) TO '{dest}' (FORMAT PARQUET, COMPRESSION zstd)
+                      """)
+
                   con.execute(f"""
                       COPY (
-                          SELECT * FROM read_parquet('s3://{BUCKET}/consolidated/daily/{prev_month}-*.parquet')
+                          -- union_by_name tolerates a mixed month: daily files written
+                          -- before the flatten landed have the legacy 5-column schema;
+                          -- matching by name back-fills the new columns as NULL instead
+                          -- of mis-mapping by position.
+                          SELECT * FROM read_parquet('s3://{BUCKET}/consolidated/daily/{prev_month}-*.parquet',
+                                                     union_by_name=true)
                           ORDER BY ts
                       ) TO 's3://{BUCKET}/{monthly_key}' (FORMAT PARQUET, COMPRESSION zstd)
                   """)
 
                   # Verify monthly file exists before deleting daily inputs
                   s3.head_object(Bucket=BUCKET, Key=monthly_key)
-                  delete_batch = [{'Key': k} for k in daily_keys]
+
+                  # Rebuild the session view over the whole month from the monthly
+                  # consolidated Parquet, so turn_idx is correct across day boundaries
+                  # (the daily views index within-day).
+                  build_session_view(f's3://{BUCKET}/{monthly_key}',
+                                     f's3://{BUCKET}/{session_monthly_key}')
+                  s3.head_object(Bucket=BUCKET, Key=session_monthly_key)
+
+                  delete_batch = [{'Key': k} for k in daily_keys + session_daily_keys]
                   for i in range(0, len(delete_batch), 1000):
                       s3.delete_objects(Bucket=BUCKET, Delete={'Objects': delete_batch[i:i+1000]})
-                  print(f"✓ Rolled up {len(daily_keys)} daily files → {monthly_key}; daily files removed.")
+                  print(f"✓ Rolled up {len(daily_keys)} daily files → {monthly_key}; "
+                        f"session view → {session_monthly_key}; "
+                        f"{len(daily_keys) + len(session_daily_keys)} daily files removed.")
+
+                  # Backfill: any monthly consolidated file lacking a monthly session
+                  # view (e.g. months rolled up before the session view existed).
+                  def _months(prefix):
+                      out = set()
+                      for page in paginator.paginate(Bucket=BUCKET, Prefix=prefix):
+                          for obj in page.get('Contents', []):
+                              name = obj['Key'].split('/')[-1]
+                              if name.endswith('.parquet'):
+                                  out.add(name[:-len('.parquet')])
+                      return out
+                  backfill = sorted(_months('consolidated/monthly/') - _months('sessions/monthly/'))
+                  print(f"Monthly session views to backfill ({len(backfill)}): {backfill}")
+                  for m in backfill:
+                      build_session_view(f's3://{BUCKET}/consolidated/monthly/{m}.parquet',
+                                         f's3://{BUCKET}/sessions/monthly/{m}.parquet')
                   PY
               resources:
                 requests:

--- a/consolidate-monthly-cronjob.yaml
+++ b/consolidate-monthly-cronjob.yaml
@@ -74,9 +74,8 @@ spec:
                           if obj['Key'].endswith('.parquet'):
                               daily_keys.append(obj['Key'])
                   print(f"Daily files found: {len(daily_keys)}")
-                  if not daily_keys:
-                      print("Nothing to roll up.")
-                      raise SystemExit(0)
+                  # No early exit when there are no daily files to roll up: the schema
+                  # upgrade + session-view backfill passes below still need to run.
 
                   # Daily session-view files for that month (deleted after rollup)
                   session_daily_keys = []
@@ -155,37 +154,68 @@ spec:
                           ) TO '{dest}' (FORMAT PARQUET, COMPRESSION zstd)
                       """)
 
-                  con.execute(f"""
-                      COPY (
-                          -- union_by_name tolerates a mixed month: daily files written
-                          -- before the flatten landed have the legacy 5-column schema;
-                          -- matching by name back-fills the new columns as NULL instead
-                          -- of mis-mapping by position.
-                          SELECT * FROM read_parquet('s3://{BUCKET}/consolidated/daily/{prev_month}-*.parquet',
-                                                     union_by_name=true)
+                  # Upgrade a legacy (entry-only, 5-column) consolidated Parquet file to
+                  # the flattened wide schema in place, from its own `entry` blob.
+                  # Lossless and idempotent (no-op once it already has the wide schema).
+                  # Mirrors the daily job; here it upgrades monthly files.
+                  def reflatten(path):
+                      cols = [r[0] for r in con.execute(f"DESCRIBE SELECT * FROM read_parquet('{path}')").fetchall()]
+                      if 'model' in cols:
+                          return False
+                      con.execute(f"""
+                          CREATE OR REPLACE TEMP TABLE _wide AS
+                          SELECT ts, type, request_id,
+                                 json_extract_string(entry,'$.session_id')    AS session_id,
+                                 origin,
+                                 json_extract_string(entry,'$.client')        AS client,
+                                 json_extract_string(entry,'$.provider')      AS provider,
+                                 json_extract_string(entry,'$.model')         AS model,
+                                 TRY_CAST(json_extract_string(entry,'$.message_count') AS INTEGER) AS message_count,
+                                 TRY_CAST(json_extract_string(entry,'$.tools_count')   AS INTEGER) AS tools_count,
+                                 json_extract_string(entry,'$.user_question') AS user_question,
+                                 TRY_CAST(json_extract_string(entry,'$.latency_ms') AS BIGINT) AS latency_ms,
+                                 TRY_CAST(json_extract_string(entry,'$.has_tool_calls') AS BOOLEAN) AS has_tool_calls,
+                                 TRY_CAST(json_extract_string(entry,'$.has_content')   AS BOOLEAN) AS has_content,
+                                 json_extract(entry, '$.tool_calls')             AS tool_calls,
+                                 json_extract(entry, '$.tool_results_this_turn')  AS tool_results,
+                                 json_extract(entry, '$.tokens')                  AS tokens,
+                                 json_extract_string(entry,'$.error')         AS error,
+                                 entry
+                          FROM read_parquet('{path}')
                           ORDER BY ts
-                      ) TO 's3://{BUCKET}/{monthly_key}' (FORMAT PARQUET, COMPRESSION zstd)
-                  """)
+                      """)
+                      con.execute(f"COPY _wide TO '{path}' (FORMAT PARQUET, COMPRESSION zstd)")
+                      return True
 
-                  # Verify monthly file exists before deleting daily inputs
-                  s3.head_object(Bucket=BUCKET, Key=monthly_key)
+                  if daily_keys:
+                      con.execute(f"""
+                          COPY (
+                              -- union_by_name tolerates a mixed month: daily files written
+                              -- before the flatten landed have the legacy 5-column schema;
+                              -- matching by name back-fills the new columns as NULL instead
+                              -- of mis-mapping by position.
+                              SELECT * FROM read_parquet('s3://{BUCKET}/consolidated/daily/{prev_month}-*.parquet',
+                                                         union_by_name=true)
+                              ORDER BY ts
+                          ) TO 's3://{BUCKET}/{monthly_key}' (FORMAT PARQUET, COMPRESSION zstd)
+                      """)
+                      # Verify monthly file exists before deleting daily inputs
+                      s3.head_object(Bucket=BUCKET, Key=monthly_key)
 
-                  # Rebuild the session view over the whole month from the monthly
-                  # consolidated Parquet, so turn_idx is correct across day boundaries
-                  # (the daily views index within-day).
-                  build_session_view(f's3://{BUCKET}/{monthly_key}',
-                                     f's3://{BUCKET}/{session_monthly_key}')
-                  s3.head_object(Bucket=BUCKET, Key=session_monthly_key)
+                      # Rebuild the session view over the whole month from the monthly
+                      # consolidated Parquet, so turn_idx is correct across day boundaries
+                      # (the daily views index within-day).
+                      build_session_view(f's3://{BUCKET}/{monthly_key}',
+                                         f's3://{BUCKET}/{session_monthly_key}')
+                      s3.head_object(Bucket=BUCKET, Key=session_monthly_key)
 
-                  delete_batch = [{'Key': k} for k in daily_keys + session_daily_keys]
-                  for i in range(0, len(delete_batch), 1000):
-                      s3.delete_objects(Bucket=BUCKET, Delete={'Objects': delete_batch[i:i+1000]})
-                  print(f"✓ Rolled up {len(daily_keys)} daily files → {monthly_key}; "
-                        f"session view → {session_monthly_key}; "
-                        f"{len(daily_keys) + len(session_daily_keys)} daily files removed.")
+                      delete_batch = [{'Key': k} for k in daily_keys + session_daily_keys]
+                      for i in range(0, len(delete_batch), 1000):
+                          s3.delete_objects(Bucket=BUCKET, Delete={'Objects': delete_batch[i:i+1000]})
+                      print(f"✓ Rolled up {len(daily_keys)} daily files → {monthly_key}; "
+                            f"session view → {session_monthly_key}; "
+                            f"{len(daily_keys) + len(session_daily_keys)} daily files removed.")
 
-                  # Backfill: any monthly consolidated file lacking a monthly session
-                  # view (e.g. months rolled up before the session view existed).
                   def _months(prefix):
                       out = set()
                       for page in paginator.paginate(Bucket=BUCKET, Prefix=prefix):
@@ -194,11 +224,25 @@ spec:
                               if name.endswith('.parquet'):
                                   out.add(name[:-len('.parquet')])
                       return out
+
+                  # Schema-upgrade pass: bring any legacy-schema monthly consolidated file
+                  # up to the wide schema (lossless, idempotent), so consolidated/** is
+                  # uniform across daily + monthly tiers.
+                  upgraded = 0
+                  for m in sorted(_months('consolidated/monthly/')):
+                      if reflatten(f's3://{BUCKET}/consolidated/monthly/{m}.parquet'):
+                          upgraded += 1
+                          print(f"  ⬆ re-flattened {m} to wide schema")
+                  print(f"Legacy monthly files upgraded to wide schema: {upgraded}")
+
+                  # Backfill: any monthly consolidated file lacking a monthly session
+                  # view (e.g. months rolled up before the session view existed).
                   backfill = sorted(_months('consolidated/monthly/') - _months('sessions/monthly/'))
                   print(f"Monthly session views to backfill ({len(backfill)}): {backfill}")
                   for m in backfill:
                       build_session_view(f's3://{BUCKET}/consolidated/monthly/{m}.parquet',
                                          f's3://{BUCKET}/sessions/monthly/{m}.parquet')
+                  print("Done.")
                   PY
               resources:
                 requests:


### PR DESCRIPTION
Completes the remaining core of #31 — the persisted *data shape* changes (the access-friction docs landed in #34/v0.1.0). After this, a new agent can answer "show me every turn of session X in order, with tool calls and results" in one flat `SELECT`, no JSON gymnastics, no manual request/response interleaving.

## Changes

**Daily consolidation** (`consolidate-daily-cronjob.yaml`)
- **Flatten** hot fields to typed columns alongside the verbatim `entry` blob: `session_id, client, provider, model, message_count, tools_count, user_question, latency_ms, has_tool_calls, has_content, tool_calls, tool_results, tokens, error`. Backward-compatible — `entry` is kept, existing `entry::JSON->>` / `json_extract_string` queries are unaffected.
- **Materialize a per-turn session view** to a new `sessions/daily/` tier: one row per `request_id` (request joined to its response), keyed on `session_key` (`session_id`, else `anon:<md5(origin|user_question)>`), ordered by `turn_idx`, with `tool_results` (in) and `tool_calls` (out) interleaved. The builder reads only `entry` via cast-safe `json_extract_string`/`json_extract`, so it works on legacy entry-only files too.
- **Backfill** session views for already-consolidated days lacking one.

**Monthly rollup** (`consolidate-monthly-cronjob.yaml`)
- Rebuild the session view over the whole month (correct cross-midnight `turn_idx`) to `sessions/monthly/`; clean up daily session files.
- `union_by_name=true` on the daily read so a month mixing legacy (5-col) and flattened (19-col) daily files merges by name instead of silently mis-mapping by position.
- Backfill monthly session views for months rolled up before the view existed.

**Docs**: `LOGGING.md` + `AGENTS.md` document both schemas and the disjoint `sessions/**` vs `consolidated/**` globs. CHANGELOG `[Unreleased]` entry added.

## Acceptance (per #31)
- ✅ Every turn of session X in order, with tool calls + results, in one flat `SELECT` — via `sessions/**`.
- ✅ `user_question` first-message-only behavior documented (done in #34); session view keys on exact `session_id`.

## Validation
- Ran the exact flatten + session-view SQL end-to-end against real synced logs: both schemas correct, acceptance query works, all responses joined on a complete day; verified the builder works on legacy entry-only consolidated files (session_id null → `anon:` fallback).
- Embedded Python compiles for both cronjobs; YAML parses; 15/15 existing tests pass.
- Confirmed the default multi-file Parquet read silently mis-maps mismatched schemas, motivating `union_by_name=true`.

Rolling out with a one-off Job from the updated daily cronjob to backfill `sessions/` for recent days against real S3 before merge.