### PR TITLE
feat(headless): GEO_AGENT_BRANCH to pin the geo-agent framework clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ See [Releases](README.md#releases) for how a release is cut.
 ## [Unreleased]
 
 ### Added
+- **Headless matrix: `GEO_AGENT_BRANCH` to pin the geo-agent framework clone.**
+  The matrix Job hard-coded a `main` clone of `boettiger-lab/geo-agent`, which
+  supplies the framework (`Agent` / `DatasetCatalog` / `ToolRegistry` /
+  `createMapTools`) the runner imports — so there was no way to evaluate a
+  code-level geo-agent change before it merged and shipped in a pinned release.
+  `run-matrix-k8s.sh` now accepts `GEO_AGENT_BRANCH` (default `main`) and the Job
+  clones that branch, mirroring the existing `APP_BRANCH`. Run the matrix once on
+  a fix branch and once on `main` to A/B a change (e.g. a tool-description
+  variant) across the open model collection before pinning the fleet.
 - **Query-ready consolidated logs: flattened columns + a materialized session
   view (#31).** The daily consolidation now promotes the hot fields
   (`session_id`, `client`, `provider`, `model`, `message_count`, `tools_count`,

--- a/headless/README.md
+++ b/headless/README.md
@@ -64,6 +64,7 @@ request/response pairs.
 | `TAG` | `[a-z0-9-]+` identifier — becomes `JOB_NAME` suffix and `ORIGIN` query tag |
 | `MODELS` | Optional override. Default: read from the app's `k8s/configmap.yaml` inside the pod |
 | `TRIALS` / `MAX_TURNS` / `APP_BRANCH` / `NAMESPACE` | Optional; sensible defaults |
+| `GEO_AGENT_BRANCH` | Optional; `boettiger-lab/geo-agent` branch to clone (default `main`). The runner imports its framework from this checkout, so set it to A/B-test a code-level geo-agent change on the open models before it ships in a pinned release. Pair with a second run on `main` for the baseline. |
 
 ## Local single-run usage (ad-hoc debugging only)
 

--- a/headless/k8s/matrix-job.yaml
+++ b/headless/k8s/matrix-job.yaml
@@ -39,6 +39,8 @@ spec:
               value: "${APP_REPO}"
             - name: APP_BRANCH
               value: "${APP_BRANCH}"
+            - name: GEO_AGENT_BRANCH
+              value: "${GEO_AGENT_BRANCH}"
             - name: APP_NAME
               value: "${APP_NAME}"
             - name: ORIGIN
@@ -68,7 +70,12 @@ spec:
               #   /work/open-llm-proxy   /work/geo-agent   /work/<APP_NAME>
               mkdir -p /work && cd /work
               git clone --depth 1 https://github.com/boettiger-lab/open-llm-proxy.git
-              git clone --depth 1 https://github.com/boettiger-lab/geo-agent.git
+              # geo-agent supplies the framework (Agent / DatasetCatalog /
+              # ToolRegistry / createMapTools) the runner imports. Pin its branch
+              # to A/B-test code-level changes (e.g. tool-description variants)
+              # before they ship in a release the fleet pins.
+              git clone --depth 1 --branch "$GEO_AGENT_BRANCH" \
+                  https://github.com/boettiger-lab/geo-agent.git
               git clone --depth 1 --branch "$APP_BRANCH" \
                   "https://github.com/$APP_REPO.git" "$APP_NAME"
 

--- a/headless/run-matrix-k8s.sh
+++ b/headless/run-matrix-k8s.sh
@@ -23,6 +23,12 @@
 #   TRIALS                 trials per (model, question) (default 2)
 #   MAX_TURNS              agent maxToolCalls (default 20)
 #   APP_BRANCH             app repo branch to clone (default main)
+#   GEO_AGENT_BRANCH       boettiger-lab/geo-agent branch to clone (default
+#                          main). The runner imports its framework (Agent,
+#                          DatasetCatalog, ToolRegistry, createMapTools) from
+#                          this checkout, so set it to A/B-test a code-level
+#                          change (e.g. a tool-description variant) on the open
+#                          model collection before it ships in a pinned release.
 #   NAMESPACE              k8s namespace (default biodiversity)
 #   SYSTEM_PROMPT_APPEND_FILE
 #                          path to a local file whose contents are appended to
@@ -59,6 +65,7 @@ MODELS="${MODELS:-}"
 TRIALS="${TRIALS:-2}"
 MAX_TURNS="${MAX_TURNS:-20}"
 APP_BRANCH="${APP_BRANCH:-main}"
+GEO_AGENT_BRANCH="${GEO_AGENT_BRANCH:-main}"
 NAMESPACE="${NAMESPACE:-biodiversity}"
 
 TS="$(date -u +%Y%m%d-%H%M%S)"
@@ -76,13 +83,13 @@ if [ -n "${SYSTEM_PROMPT_APPEND_FILE:-}" ]; then
     SYSTEM_PROMPT_APPEND_B64="$(base64 -w0 < "$SYSTEM_PROMPT_APPEND_FILE")"
 fi
 
-export APP_REPO APP_BRANCH APP_NAME JOB_NAME ORIGIN TAG TRIALS MAX_TURNS MODELS \
+export APP_REPO APP_BRANCH GEO_AGENT_BRANCH APP_NAME JOB_NAME ORIGIN TAG TRIALS MAX_TURNS MODELS \
     QUESTIONS_B64 SYSTEM_PROMPT_APPEND_B64
 
 # Allowlist: only these placeholders are substituted. Without this, envsubst
 # also replaces every $VAR reference in the bash script body (e.g. $QFILE,
 # $PROXY_KEY, $rc) with empty strings, breaking the pod at runtime.
-envsubst '${APP_REPO} ${APP_BRANCH} ${APP_NAME} ${JOB_NAME} ${ORIGIN} ${TAG} ${TRIALS} ${MAX_TURNS} ${MODELS} ${QUESTIONS_B64} ${SYSTEM_PROMPT_APPEND_B64}' \
+envsubst '${APP_REPO} ${APP_BRANCH} ${GEO_AGENT_BRANCH} ${APP_NAME} ${JOB_NAME} ${ORIGIN} ${TAG} ${TRIALS} ${MAX_TURNS} ${MODELS} ${QUESTIONS_B64} ${SYSTEM_PROMPT_APPEND_B64}' \
     < k8s/matrix-job.yaml | kubectl -n "$NAMESPACE" create -f -
 
 cat <<EOF


### PR DESCRIPTION
## Why

The headless matrix Job cloned `boettiger-lab/geo-agent` at a hard-coded depth-1 `main` ([matrix-job.yaml](headless/k8s/matrix-job.yaml)). That clone supplies the framework the runner imports — `Agent`, `DatasetCatalog`, `ToolRegistry`, `createMapTools`. So a **code-level** geo-agent change (e.g. a tool-description variant) could not be evaluated on the open model collection until it had already merged and shipped in a release the fleet pins. The only A/B knob was `SYSTEM_PROMPT_APPEND_B64`, which can't carry a code change.

This is the gate we want before pinning: prove a change is neutral-or-better on the open models *first*.

## What

Add `GEO_AGENT_BRANCH` (default `main`), mirroring the existing `APP_BRANCH`:
- `run-matrix-k8s.sh`: read the var (default `main`), export it, add to the `envsubst` allowlist, document it.
- `k8s/matrix-job.yaml`: pass it as an env var and use `--branch "$GEO_AGENT_BRANCH"` on the geo-agent clone.
- README env table + CHANGELOG `[Unreleased]`.

Default `main` → existing invocations are unchanged.

## Usage

```bash
# baseline
TAG=baseline GEO_AGENT_BRANCH=main QUESTIONS_FILE=runs/q.txt \
  ./run-matrix-k8s.sh boettiger-lab/geo-agent-template
# fix branch
TAG=tooldesc GEO_AGENT_BRANCH=perf/tool-desc-drop-layer-list-225 QUESTIONS_FILE=runs/q.txt \
  ./run-matrix-k8s.sh boettiger-lab/geo-agent-template
```

Then compare prefill tokens + tool-call correctness across the two `ORIGIN` tags in the proxy logs.

## Companion

First user is boettiger-lab/geo-agent#271 (drops the per-tool layer-list embedding, #225) — this lets us validate that on the open models before cutting a release.

## Validation

`bash -n run-matrix-k8s.sh` and a YAML parse of `matrix-job.yaml` both pass. Cluster run not exercised in this PR.