### PR TITLE
Fix stale NRP model ids in config (glm-4.7→glm-5, gemma-4-e4b→gemma-small-e4b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ See [Releases](README.md#releases) for how a release is cut.
 
 ## [Unreleased]
 
+### Fixed
+- **`config.json`: corrected two stale NRP model ids that 404'd at the gateway.**
+  `ellm.nrp-nautilus.io`'s `/v1/models` no longer serves `glm-4.7` or
+  `gemma-4-e4b`; requests for them returned `404 No matching route found`. Renamed
+  to the currently-served ids `glm-5` and `gemma-small-e4b` (and updated the
+  `thinking_models` key `glm-4.7` → `glm-5`).
+
 ### Added
 - **Query-ready consolidated logs: flattened columns + a materialized session
   view (#31).** The daily consolidation now promotes the hot fields

--- a/config.json
+++ b/config.json
@@ -6,16 +6,16 @@
             "models": [
                 "kimi",
                 "qwen3",
-                "glm-4.7",
+                "glm-5",
                 "minimax-m2",
                 "gpt-oss",
                 "gemma",
-                "gemma-4-e4b"
+                "gemma-small-e4b"
             ],
             "thinking_models": {
                 "kimi":   "thinking",
                 "qwen3":  "enable_thinking",
-                "glm-4.7": "enable_thinking"
+                "glm-5": "enable_thinking"
             }
         },
         "openrouter": {


### PR DESCRIPTION
## What

`ellm.nrp-nautilus.io`'s `/v1/models` no longer serves `glm-4.7` or `gemma-4-e4b` — requests for either returned `404 No matching route found`. Renamed to the currently-served ids:

| old (404) | new (routes) |
|---|---|
| `glm-4.7` | `glm-5` |
| `gemma-4-e4b` | `gemma-small-e4b` |

Also updated the `thinking_models` key `glm-4.7` → `glm-5`.

## Verification

`GET /v1/models` on the gateway lists `glm-5` and `gemma-small-e4b` (not the old ids). Direct chat probes with the new ids route (200 / backend-flap 500), no longer 404.

## Not in scope

The concurrent broad NRP gateway instability (intermittent empty-body 500s across most models) is upstream and reproduces hitting `ellm` directly without the proxy. Tracked separately; see #44 for the related observability gap (proxy drops upstream headers on errors).