### PR TITLE
feat: link z-ai/minimax/moonshotai OpenRouter model families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ See [Releases](README.md#releases) for how a release is cut.
   `thinking_models` key `glm-4.7` → `glm-5`).
 
 ### Added
+- **OpenRouter: link `z-ai/`, `minimax/`, and `moonshotai/` model families.**
+  Added these three vendor prefixes to `config.json`'s OpenRouter `models` list
+  (and the in-code fallback + README provider table), so ids like `z-ai/glm-5.2`,
+  `minimax/minimax-m3`, and `moonshotai/kimi-k2.7-code` route to OpenRouter
+  instead of falling through to the NRP default. Enables an open-model
+  performance/accuracy evaluation across these families. The proxy reads
+  `config.json` from a fresh `git clone` of `main` at pod boot, so this reaches
+  prod on the next `rollout restart`. (Also synced the stale `glm-4.6`→`glm-5`
+  and missing `nvidia/` entries in the in-code fallback default.)
 - **Headless matrix: `GEO_AGENT_BRANCH` to pin the geo-agent framework clone.**
   The matrix Job hard-coded a `main` clone of `boettiger-lab/geo-agent`, which
   supplies the framework (`Agent` / `DatasetCatalog` / `ToolRegistry` /

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Configured in `config.json`. Most deployments only need NRP:
 
 | Provider | Models | Notes |
 |---|---|---|
-| **NRP** (`ellm.nrp-nautilus.io`) | `kimi`, `qwen3`, `glm-4.7`, `minimax-m2`, `gpt-oss`, `gemma` | Default; supports `enable_thinking` for applicable models |
-| **OpenRouter** | `anthropic/…`, `mistralai/…`, `openai/…`, `qwen/…`, `nvidia/…`, `amazon/…` | Prefix match; requires separate API key |
+| **NRP** (`ellm.nrp-nautilus.io`) | `kimi`, `qwen3`, `glm-5`, `minimax-m2`, `gpt-oss`, `gemma` | Default; supports `enable_thinking` for applicable models |
+| **OpenRouter** | `anthropic/…`, `mistralai/…`, `openai/…`, `qwen/…`, `nvidia/…`, `amazon/…`, `z-ai/…`, `minimax/…`, `moonshotai/…` | Prefix match; requires separate API key |
 | **Anthropic** | `claude-…` (default `claude-sonnet-4-6`; `claude-opus-4-8`, `claude-haiku-4-5` also route) | Direct via Anthropic's OpenAI-compatible `/v1/chat/completions`; prefix match. Bills the Developer Platform API (not the Claude.ai Team plan) — set `ANTHROPIC_API_KEY`. The default model is chosen app-side (`llm_model`); the proxy just routes whatever `claude-*` it receives |
 | **Nimbus** | `nemotron` | Private vLLM instance; requires separate API key |
 
@@ -46,7 +46,7 @@ Unknown models fall back to NRP. To customize the model list, edit `config.json`
 
 ### Thinking mode
 
-Set `"enable_thinking": true` in the request body to activate extended reasoning on supported models (`kimi`, `qwen3`, `glm-4.7`). The proxy injects the correct provider-specific parameter based on `config.json`.
+Set `"enable_thinking": true` in the request body to activate extended reasoning on supported models (`kimi`, `qwen3`, `glm-5`). The proxy injects the correct provider-specific parameter based on `config.json`.
 
 ## Logging
 

--- a/config.json
+++ b/config.json
@@ -27,7 +27,10 @@
                 "amazon/",
                 "openai/",
                 "qwen/",
-                "nvidia/"
+                "nvidia/",
+                "z-ai/",
+                "minimax/",
+                "moonshotai/"
             ],
             "extra_headers": {
                 "HTTP-Referer": "https://open-llm-proxy.nrp-nautilus.io",

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -209,12 +209,12 @@ def load_config() -> dict:
             "nrp": {
                 "endpoint": "https://ellm.nrp-nautilus.io/v1/chat/completions",
                 "api_key_env": "NRP_API_KEY",
-                "models": ["kimi", "qwen3", "glm-4.6"]
+                "models": ["kimi", "qwen3", "glm-5"]
             },
             "openrouter": {
                 "endpoint": "https://openrouter.ai/api/v1/chat/completions",
                 "api_key_env": "OPENROUTER_KEY",
-                "models": ["anthropic/", "mistralai/", "amazon/", "openai/", "qwen/"],
+                "models": ["anthropic/", "mistralai/", "amazon/", "openai/", "qwen/", "nvidia/", "z-ai/", "minimax/", "moonshotai/"],
                 "extra_headers": {
                     "HTTP-Referer": "https://wetlands.nrp-nautilus.io",
                     "X-Title": "Wetlands Chatbot"


### PR DESCRIPTION
## What

Adds three vendor prefixes — `z-ai/`, `minimax/`, `moonshotai/` — to the OpenRouter `models` list in [config.json](config.json) (plus the in-code fallback default and the README provider table).

## Why

Without them, ids like `z-ai/glm-5.2`, `minimax/minimax-m3`, and `moonshotai/kimi-k2.7-code` fall through `get_provider_for_model`'s prefix match to the NRP default and fail. These prefixes route them to OpenRouter, enabling an open-model performance/accuracy evaluation across these families (GLM 5.2, MiniMax M3, Kimi K2.7 Code; NVIDIA Nemotron 3 Ultra already routed via the existing `nvidia/`).

All four target models confirmed ZDR-reachable + authenticating against OpenRouter with the updated key.

## Drift swept in passing

- README NRP row + thinking-mode section: `glm-4.7` → `glm-5` (matches #45).
- In-code fallback default: `glm-4.6` → `glm-5`, added missing `nvidia/`.

## Deploy

The proxy `git clone`s `main` at pod boot ([deployment.yaml:89](deployment.yaml#L89)) — no ConfigMap. Reaches prod on the next `kubectl -n biodiversity rollout restart deployment/open-llm-proxy`.

CHANGELOG `[Unreleased]` updated.