### PR TITLE
Capture upstream response headers on error path (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ See [Releases](README.md#releases) for how a release is cut.
 ## [Unreleased]
 
 ### Added
+- **Headless matrix: durable per-cell transcript capture to S3.** The matrix Job
+  already `cat`-ed each cell's transcript JSON + `summary.tsv` to pod stdout, but
+  those died with the pod at `ttlSecondsAfterFinished` (24h) — so a later analysis
+  lost them. The Job now also uploads `runs/<JOB_NAME>/*` to
+  `s3://$CAPTURE_BUCKET/experiments/<JOB_NAME>/` (default bucket
+  `logs-open-llm-proxy`, so `sync-logs.sh` pulls them automatically). Controlled by
+  `CAPTURE_TRANSCRIPTS` (default `true`) in `run-matrix-k8s.sh`; best-effort (never
+  fails the run) and skipped if the `aws` secret is absent (`optional: true`).
+  Transcripts carry what proxy logs don't: llm-vs-tool time split, per-tool
+  `tool_exec_ms`, `timed_out`/`cancelled` disposition, and clean
+  `(model, question, trial)` keys.
 - **Capture upstream response headers on the error path (#44).** On
   `httpx.HTTPStatusError`, `proxy_chat` logged only the status code and (often
   empty) body, discarding the response headers that distinguish a genuine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ See [Releases](README.md#releases) for how a release is cut.
 ## [Unreleased]
 
 ### Added
+- **Capture upstream response headers on the error path (#44).** On
+  `httpx.HTTPStatusError`, `proxy_chat` logged only the status code and (often
+  empty) body, discarding the response headers that distinguish a genuine
+  rate-limit (`429` + `retry-after`/`x-ratelimit-*`) from a dead-backend gateway
+  failure (naked `500`, `content-length: 0`, no `server`/`x-request-id`). That
+  distinction was previously only catchable live with `curl -i` and impossible to
+  recover after the fact. Now an allow-listed subset (`retry-after`,
+  `x-ratelimit-{limit,remaining,reset}`, `x-request-id`, `server`, `date`,
+  `content-length`) is captured into the error response log under
+  `entry.upstream_headers`, queryable via `json_extract(entry,'$.upstream_headers')`.
+  Allow-list only (no full header bag); values pass through the scrubber for
+  defense in depth. Only the `HTTPStatusError` branch has a response to read —
+  the timeout/connection branches fail without one. Not promoted to a flat
+  consolidated column (entry-JSON access suffices for occasional debugging).
 - **Forward sampling/routing knobs instead of dropping them (#47).** `proxy_chat`
   rebuilt the upstream payload from a hard whitelist (`model`/`messages`/
   `temperature` + `tools`), so any other client field was silently dropped before

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -302,6 +302,7 @@ Each LLM call produces two JSON entries on stdout: a `REQUEST` line when the cal
 | `tool_calls` | Array of `{name, arguments}` — full tool call arguments including SQL query strings. Credential args (`s3_key`/`s3_secret`/…) are redacted. |
 | `tokens` | Token usage object from the provider (`prompt_tokens`, `completion_tokens`, `total_tokens`) |
 | `error` | Error detail string (only present on failed requests) |
+| `upstream_headers` | Allow-listed upstream response headers, captured only when the upstream returned an HTTP error response (#44). Tells a real rate-limit (`retry-after`/`x-ratelimit-*`) apart from a dead-backend gateway failure (naked `500`, `content-length: 0`, no `server`/`x-request-id`). Not a flat column — query via `json_extract(entry,'$.upstream_headers')`. |
 
 ### Wiring up `session_id`
 

--- a/headless/experiments/2026-06-26-or-openmodel-bench/RERUN.md
+++ b/headless/experiments/2026-06-26-or-openmodel-bench/RERUN.md
@@ -1,0 +1,69 @@
+# Re-run runbook (orbench2) — PREPARED, NOT YET RUN
+
+Second pass of the OpenRouter open-model benchmark, fixing the three things that
+limited the first run. **Do not launch until the preflight checklist passes.**
+
+## Why re-run
+1. First run cloned geo-agent `main` *before* #271 merged → it used the bloated
+   pre-#271 tool descriptions (~35–40k prefill/turn). Current `main` includes #271
+   (~9.5k/turn smaller) — this run is the clean "after".
+2. First run lost 82/264 trials to the OpenRouter **monthly budget cap**.
+3. Per-cell transcripts died with the pods (no durable capture). Now fixed —
+   the matrix job uploads them to S3 (`CAPTURE_TRANSCRIPTS=true`, default).
+
+## Preflight checklist (all must be true before launching)
+- [ ] **OpenRouter monthly cap raised / has headroom.** Admin checks org member
+      monthly $ limit + month-to-date spend (the first run cost ~$10–15; budget for
+      ~2× with full trial coverage). Cap is a *dollar* limit, aggregate across models.
+- [ ] **Proxy #47 deployed.** `seed`/`top_p`/`provider` passthrough is merged
+      (commit 77b6f04) but reaches pods only after a rollout restart:
+      `kubectl -n biodiversity rollout restart deployment/open-llm-proxy`
+      then confirm the new pods are up. (Lets geo-agent's seed actually reach providers.)
+- [ ] **geo-agent `main` includes #271** (it does, merged 2026-06-27 00:33) — the
+      default `GEO_AGENT_BRANCH=main` picks it up. No flag needed.
+- [ ] `./sync-logs.sh` works locally for post-run analysis.
+
+## Launch (one Job per app — DO NOT run until preflight passes)
+```bash
+cd open-llm-proxy/headless
+E=experiments/2026-06-26-or-openmodel-bench
+MODELS="z-ai/glm-5.2 nvidia/nemotron-3-ultra-550b-a55b minimax/minimax-m3 moonshotai/kimi-k2.7-code"
+declare -A REPO=(
+  [biodiversity]=boettiger-lab/biodiversity   [bosl-high-seas]=boettiger-lab/bosl-high-seas
+  [ca-30x30]=boettiger-lab/ca-30x30           [global-30x30]=boettiger-lab/global-30x30
+  [tpl-ca]=boettiger-lab/tpl-ca               [tpl]=boettiger-lab/tpl
+  [wetlands]=boettiger-lab/wetlands-v2 )
+for app in biodiversity bosl-high-seas ca-30x30 global-30x30 tpl-ca tpl wetlands; do
+  TAG=orbench2 \
+  MODELS="$MODELS" \
+  TRIALS=2 \
+  CAPTURE_TRANSCRIPTS=true \
+  QUESTIONS_FILE="$E/questions/$app.txt" \
+    ./run-matrix-k8s.sh "${REPO[$app]}"
+done
+```
+Changes from run 1: `TAG=orbench2` (new origin `agent_runner_orbench2` — disjoint from
+`orbench`), **`TRIALS=2`** (run-1 analysis showed 3 wasn't worth the cost — 73% of
+multi-trial cells agreed; 2 captures the variance), and durable transcript capture on.
+
+## Capture (now durable)
+Each Job uploads its per-cell transcript JSON + `summary.tsv` to
+`s3://logs-open-llm-proxy/experiments/<JOB_NAME>/`. `./sync-logs.sh` pulls them to
+`/tmp/open-llm-proxy-logs/experiments/`. (They're also still in `kubectl logs job/<name>`
+for ~24h.) Transcripts add what the proxy logs lack: **llm-vs-tool time split,
+per-tool `tool_exec_ms`, `timed_out`/`cancelled` disposition, and clean (model,q,trial)
+keys.** Proxy logs add what transcripts lack: **cost ($), cached_tokens, serving provider.**
+
+## Analyze (after `./sync-logs.sh`)
+```bash
+python3 $E/build_report.py            # per-model + per-question accuracy/timing/calls
+# accuracy: re-grade via the per-app judge agents against gold/ (unchanged gold)
+```
+Then compare orbench2 vs orbench: prefill/turn should drop ~24% (the #271 win), cost
+per question should fall (smaller prefill + better cache hits if #47 routing is used),
+and accuracy should be ≥ run 1 with full 2-trial coverage (no budget gaps).
+
+## Reuse
+Gold answers in `gold/` are unchanged (same questions) — no need to recompute.
+Grades from run 1 are in `results/grades.raw` for reference but must be re-done for
+the new answers.

--- a/headless/k8s/matrix-job.yaml
+++ b/headless/k8s/matrix-job.yaml
@@ -57,6 +57,23 @@ spec:
               value: "${SYSTEM_PROMPT_APPEND_B64}"
             - name: JOB_NAME
               value: "${JOB_NAME}"
+            # Durable transcript capture: upload per-cell transcript JSON +
+            # summary.tsv to s3://<bucket>/experiments/<JOB_NAME>/ so they
+            # survive pod GC (ttlSecondsAfterFinished). Default on; best-effort
+            # (never fails the run). sync-logs.sh pulls them down automatically.
+            - name: CAPTURE_TRANSCRIPTS
+              value: "${CAPTURE_TRANSCRIPTS}"
+            - name: CAPTURE_BUCKET
+              value: "${CAPTURE_BUCKET}"
+            # S3 creds reused from the same `aws` secret the proxy/consolidation
+            # use. optional:true so the job still runs in namespaces without it
+            # (capture is just skipped).
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef: { name: aws, key: AWS_ACCESS_KEY_ID, optional: true }
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef: { name: aws, key: AWS_SECRET_ACCESS_KEY, optional: true }
           command: ["/bin/bash", "-c"]
           args:
             - |
@@ -129,6 +146,29 @@ spec:
 
               echo "=== summary.tsv ==="
               cat "$RUNS_DIR_REL/summary.tsv" 2>/dev/null || echo "(no summary written)"
+
+              # Durable capture: persist transcripts + summary to S3 so they
+              # outlive the pod. Best-effort — never fails the run.
+              if [ "${CAPTURE_TRANSCRIPTS:-true}" = "true" ] && [ -n "${AWS_ACCESS_KEY_ID:-}" ]; then
+                  echo
+                  echo "=== uploading transcripts to s3://${CAPTURE_BUCKET}/experiments/$JOB_NAME/ ==="
+                  pip install --quiet --break-system-packages boto3 >/dev/null 2>&1 || pip install --quiet boto3 >/dev/null 2>&1 || true
+                  RUNS_DIR_REL="$RUNS_DIR_REL" CAPTURE_BUCKET="$CAPTURE_BUCKET" JOB_NAME="$JOB_NAME" python3 - <<'PYUP' || echo "(transcript upload skipped/failed — non-fatal)"
+              import os, glob, boto3
+              s3 = boto3.client('s3', endpoint_url='http://rook-ceph-rgw-nautiluss3.rook',
+                                aws_access_key_id=os.environ['AWS_ACCESS_KEY_ID'],
+                                aws_secret_access_key=os.environ['AWS_SECRET_ACCESS_KEY'])
+              bucket = os.environ.get('CAPTURE_BUCKET') or 'logs-open-llm-proxy'
+              job = os.environ['JOB_NAME']; rd = os.environ['RUNS_DIR_REL']
+              n = 0
+              for f in sorted(glob.glob(rd + '/*')):
+                  if os.path.isfile(f):
+                      s3.upload_file(f, bucket, f"experiments/{job}/{os.path.basename(f)}"); n += 1
+              print(f"uploaded {n} files to s3://{bucket}/experiments/{job}/")
+              PYUP
+              else
+                  echo "(transcript S3 capture disabled or no AWS creds — transcripts only in this pod's stdout)"
+              fi
 
               echo
               echo "=== filter proxy logs by origin: $ORIGIN ==="

--- a/headless/run-matrix-k8s.sh
+++ b/headless/run-matrix-k8s.sh
@@ -67,6 +67,11 @@ MAX_TURNS="${MAX_TURNS:-20}"
 APP_BRANCH="${APP_BRANCH:-main}"
 GEO_AGENT_BRANCH="${GEO_AGENT_BRANCH:-main}"
 NAMESPACE="${NAMESPACE:-biodiversity}"
+# Durable per-cell transcript capture to S3 (survives pod GC). Default on;
+# uploads to s3://$CAPTURE_BUCKET/experiments/$JOB_NAME/ (pulled by sync-logs.sh).
+# Set CAPTURE_TRANSCRIPTS=false to disable. Needs the `aws` secret (optional).
+CAPTURE_TRANSCRIPTS="${CAPTURE_TRANSCRIPTS:-true}"
+CAPTURE_BUCKET="${CAPTURE_BUCKET:-logs-open-llm-proxy}"
 
 TS="$(date -u +%Y%m%d-%H%M%S)"
 JOB_NAME="hmx-${APP_NAME}-${TAG}-${TS}"
@@ -84,12 +89,12 @@ if [ -n "${SYSTEM_PROMPT_APPEND_FILE:-}" ]; then
 fi
 
 export APP_REPO APP_BRANCH GEO_AGENT_BRANCH APP_NAME JOB_NAME ORIGIN TAG TRIALS MAX_TURNS MODELS \
-    QUESTIONS_B64 SYSTEM_PROMPT_APPEND_B64
+    QUESTIONS_B64 SYSTEM_PROMPT_APPEND_B64 CAPTURE_TRANSCRIPTS CAPTURE_BUCKET
 
 # Allowlist: only these placeholders are substituted. Without this, envsubst
 # also replaces every $VAR reference in the bash script body (e.g. $QFILE,
 # $PROXY_KEY, $rc) with empty strings, breaking the pod at runtime.
-envsubst '${APP_REPO} ${APP_BRANCH} ${GEO_AGENT_BRANCH} ${APP_NAME} ${JOB_NAME} ${ORIGIN} ${TAG} ${TRIALS} ${MAX_TURNS} ${MODELS} ${QUESTIONS_B64} ${SYSTEM_PROMPT_APPEND_B64}' \
+envsubst '${APP_REPO} ${APP_BRANCH} ${GEO_AGENT_BRANCH} ${APP_NAME} ${JOB_NAME} ${ORIGIN} ${TAG} ${TRIALS} ${MAX_TURNS} ${MODELS} ${QUESTIONS_B64} ${SYSTEM_PROMPT_APPEND_B64} ${CAPTURE_TRANSCRIPTS} ${CAPTURE_BUCKET}' \
     < k8s/matrix-job.yaml | kubectl -n "$NAMESPACE" create -f -
 
 cat <<EOF

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -64,6 +64,30 @@ _USER_QUESTION_MAX = _int_env("LOG_USER_QUESTION_MAX", 4000)
 # stdout is the sole sink). See LOGGING.md.
 _STDOUT_MAX_FIELD = _int_env("LOG_STDOUT_MAX_FIELD", 200)
 
+# Allow-list of upstream response headers to capture on the error path (#44).
+# These let us distinguish a genuine rate-limit (429 + retry-after/x-ratelimit-*)
+# from a dead-backend gateway failure (naked 500, content-length: 0, no
+# server/x-request-id) — a distinction otherwise only catchable live with
+# `curl -i`. Kept an explicit allow-list (not the full header bag) so nothing
+# sensitive is logged; values still pass through the scrubber for defense in
+# depth. Lower-cased for case-insensitive lookup against httpx.Headers.
+_UPSTREAM_HEADER_ALLOWLIST = (
+    "retry-after", "x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset",
+    "x-request-id", "server", "date", "content-length",
+)
+
+def _capture_upstream_headers(headers) -> dict:
+    """Pull the allow-listed subset of an upstream response's headers, scrubbed.
+    Returns None when none are present so the field is omitted from the log."""
+    if not headers:
+        return None
+    captured = {
+        name: _scrub_text(headers[name])
+        for name in _UPSTREAM_HEADER_ALLOWLIST
+        if name in headers
+    }
+    return captured or None
+
 def _cap(s: Optional[str], limit: int) -> str:
     """Truncate `s` to `limit` chars; limit <= 0 means no truncation."""
     s = s or ""
@@ -354,7 +378,7 @@ def log_request(provider: str, model: str, messages: List[Dict], tools_count: in
     _emit(log_entry)
 
 @_never_raises
-def log_response(provider: str, model: str, response_data: dict, latency_ms: int, error: str = None, origin: str = None, request_id: str = None, session_id: str = None, client: str = None):
+def log_response(provider: str, model: str, response_data: dict, latency_ms: int, error: str = None, origin: str = None, request_id: str = None, session_id: str = None, client: str = None, upstream_headers: dict = None):
     """Log response in structured JSON format"""
     log_entry = {
         "timestamp": datetime.utcnow().isoformat() + "Z",
@@ -370,6 +394,10 @@ def log_response(provider: str, model: str, response_data: dict, latency_ms: int
     
     if error:
         log_entry["error"] = error
+        # Allow-listed upstream response headers (#44) — present only on the
+        # HTTPStatusError path, where the upstream actually returned a response.
+        if upstream_headers:
+            log_entry["upstream_headers"] = upstream_headers
     else:
         # Extract response details
         if "choices" in response_data and len(response_data["choices"]) > 0:
@@ -538,7 +566,11 @@ async def proxy_chat(request: ChatRequest, http_request: Request, authorization:
         except httpx.HTTPStatusError as e:
             latency_ms = int((time.time() - start_time) * 1000)
             error_detail = f"Provider returned {e.response.status_code}: {e.response.text[:1000]}"
-            log_response(provider_name, request.model, {}, latency_ms, error=error_detail, origin=origin, request_id=request_id, session_id=session_id, client=client)
+            # Capture allow-listed upstream headers so the rate-limit (429 +
+            # retry-after/x-ratelimit-*) vs dead-backend (naked 500, no
+            # server/x-request-id) distinction is queryable from logs (#44).
+            upstream_headers = _capture_upstream_headers(e.response.headers)
+            log_response(provider_name, request.model, {}, latency_ms, error=error_detail, origin=origin, request_id=request_id, session_id=session_id, client=client, upstream_headers=upstream_headers)
 
             # Pass through certain status codes to client
             if e.response.status_code in [400, 401, 402, 403, 429]:

--- a/test_logging.py
+++ b/test_logging.py
@@ -335,6 +335,58 @@ def _run_proxy_capture(req, provider=("nrp", {"endpoint": "http://upstream", "ap
     return captured["payload"]
 
 
+def test_error_path_captures_allowlisted_upstream_headers():
+    """On the HTTPStatusError path, allow-listed upstream headers land in the
+    buffered error response so 429-throttle vs naked-500 is queryable (#44)."""
+    import asyncio
+    from unittest.mock import patch
+
+    p = _reload(PROXY_KEY="testkey")
+    p._log_buffer.clear()
+
+    # Mirror NRP's dead-backend signature: 500, empty body, content-length 0,
+    # plus a couple of allow-listed correlation/rate-limit headers and one
+    # disallowed header that must NOT be captured.
+    upstream = p.httpx.Response(
+        status_code=500,
+        headers={"content-length": "0", "retry-after": "30",
+                 "x-request-id": "abc123", "x-secret-internal": "leak-me"},
+        request=p.httpx.Request("POST", "http://upstream"),
+    )
+
+    class _FakeAsyncClient:
+        def __init__(self, *a, **k):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def post(self, *a, **k):
+            return upstream  # raise_for_status() below turns 500 into the error
+
+    class _FakeRequest:
+        headers = {"origin": "https://app"}
+
+    req = p.ChatRequest(model="qwen3", messages=[{"role": "user", "content": "hi"}])
+    with patch.object(p, "get_provider_for_model",
+                      return_value=("nrp", {"endpoint": "http://upstream", "api_key": "k"})), \
+         patch.object(p.httpx, "AsyncClient", _FakeAsyncClient):
+        try:
+            asyncio.run(p.proxy_chat(req, _FakeRequest(), authorization="Bearer testkey"))
+            assert False, "expected HTTPException on upstream 500"
+        except p.HTTPException:
+            pass
+
+    errs = [e for e in p._log_buffer if e.get("type") == "response" and e.get("error")]
+    assert len(errs) == 1
+    hdrs = errs[0]["upstream_headers"]
+    assert hdrs["content-length"] == "0"
+    assert hdrs["retry-after"] == "30"
+    assert hdrs["x-request-id"] == "abc123"
+    assert "x-secret-internal" not in hdrs   # allow-list only
+    json.dumps(errs[0])   # must stay serializable
+
+
 def test_passthrough_sampling_knobs_forwarded():
     """seed/top_p/stop/max_tokens/response_format reach upstream on any provider (#47)."""
     payload = _run_proxy_capture(dict(


### PR DESCRIPTION
Closes #44.

## What

On `httpx.HTTPStatusError`, `proxy_chat` logged only the status code and (often empty) body, discarding the upstream **response headers** — the only signal that distinguishes a genuine rate-limit from a dead-backend gateway failure:

- real throttle → `429` + `retry-after` / `x-ratelimit-*`
- dead backend → naked `500`, `content-length: 0`, no `server` / `x-request-id`

Previously this could only be told apart live with `curl -i` and was unrecoverable from logs after the fact (the 2026-06-26 502 wave).

## Change

- New allow-list `_UPSTREAM_HEADER_ALLOWLIST` + `_capture_upstream_headers()` helper in `llm_proxy.py`.
- `log_response()` gains an optional `upstream_headers=` param, stored under `entry.upstream_headers` (error path only).
- Captured at the `HTTPStatusError` call site from `e.response.headers`; values run through the existing scrubber.
- Test `test_error_path_captures_allowlisted_upstream_headers` drives the handler through a fake 500 and asserts the allow-listed headers land in the buffered error response while a disallowed header is dropped.
- CHANGELOG + LOGGING.md updated.

## Scope decisions (see issue thread)

- **Only the `HTTPStatusError` branch** — the timeout/connection branches fail without a response, so there are no headers to capture.
- **Stored in `entry` JSON, not promoted to a flat consolidated column** — `json_extract(entry,'$.upstream_headers')` suffices for occasional debugging. Easy to promote later if query ergonomics warrant.
- **Allow-list, not the full header bag** — nothing sensitive logged; scrubber pass is free defense-in-depth.

`python -m pytest test_logging.py` → 19 passed.