### PR TITLE
Capture upstream response headers on error path (#44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ See [Releases](README.md#releases) for how a release is cut.
 ## [Unreleased]
 
 ### Added
+- **Capture upstream response headers on the error path (#44).** On
+  `httpx.HTTPStatusError`, `proxy_chat` logged only the status code and (often
+  empty) body, discarding the response headers that distinguish a genuine
+  rate-limit (`429` + `retry-after`/`x-ratelimit-*`) from a dead-backend gateway
+  failure (naked `500`, `content-length: 0`, no `server`/`x-request-id`). That
+  distinction was previously only catchable live with `curl -i` and impossible to
+  recover after the fact. Now an allow-listed subset (`retry-after`,
+  `x-ratelimit-{limit,remaining,reset}`, `x-request-id`, `server`, `date`,
+  `content-length`) is captured into the error response log under
+  `entry.upstream_headers`, queryable via `json_extract(entry,'$.upstream_headers')`.
+  Allow-list only (no full header bag); values pass through the scrubber for
+  defense in depth. Only the `HTTPStatusError` branch has a response to read —
+  the timeout/connection branches fail without one. Not promoted to a flat
+  consolidated column (entry-JSON access suffices for occasional debugging).
 - **Forward sampling/routing knobs instead of dropping them (#47).** `proxy_chat`
   rebuilt the upstream payload from a hard whitelist (`model`/`messages`/
   `temperature` + `tools`), so any other client field was silently dropped before

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -302,6 +302,7 @@ Each LLM call produces two JSON entries on stdout: a `REQUEST` line when the cal
 | `tool_calls` | Array of `{name, arguments}` — full tool call arguments including SQL query strings. Credential args (`s3_key`/`s3_secret`/…) are redacted. |
 | `tokens` | Token usage object from the provider (`prompt_tokens`, `completion_tokens`, `total_tokens`) |
 | `error` | Error detail string (only present on failed requests) |
+| `upstream_headers` | Allow-listed upstream response headers, captured only when the upstream returned an HTTP error response (#44). Tells a real rate-limit (`retry-after`/`x-ratelimit-*`) apart from a dead-backend gateway failure (naked `500`, `content-length: 0`, no `server`/`x-request-id`). Not a flat column — query via `json_extract(entry,'$.upstream_headers')`. |
 
 ### Wiring up `session_id`
 

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -64,6 +64,30 @@ _USER_QUESTION_MAX = _int_env("LOG_USER_QUESTION_MAX", 4000)
 # stdout is the sole sink). See LOGGING.md.
 _STDOUT_MAX_FIELD = _int_env("LOG_STDOUT_MAX_FIELD", 200)
 
+# Allow-list of upstream response headers to capture on the error path (#44).
+# These let us distinguish a genuine rate-limit (429 + retry-after/x-ratelimit-*)
+# from a dead-backend gateway failure (naked 500, content-length: 0, no
+# server/x-request-id) — a distinction otherwise only catchable live with
+# `curl -i`. Kept an explicit allow-list (not the full header bag) so nothing
+# sensitive is logged; values still pass through the scrubber for defense in
+# depth. Lower-cased for case-insensitive lookup against httpx.Headers.
+_UPSTREAM_HEADER_ALLOWLIST = (
+    "retry-after", "x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset",
+    "x-request-id", "server", "date", "content-length",
+)
+
+def _capture_upstream_headers(headers) -> dict:
+    """Pull the allow-listed subset of an upstream response's headers, scrubbed.
+    Returns None when none are present so the field is omitted from the log."""
+    if not headers:
+        return None
+    captured = {
+        name: _scrub_text(headers[name])
+        for name in _UPSTREAM_HEADER_ALLOWLIST
+        if name in headers
+    }
+    return captured or None
+
 def _cap(s: Optional[str], limit: int) -> str:
     """Truncate `s` to `limit` chars; limit <= 0 means no truncation."""
     s = s or ""
@@ -354,7 +378,7 @@ def log_request(provider: str, model: str, messages: List[Dict], tools_count: in
     _emit(log_entry)
 
 @_never_raises
-def log_response(provider: str, model: str, response_data: dict, latency_ms: int, error: str = None, origin: str = None, request_id: str = None, session_id: str = None, client: str = None):
+def log_response(provider: str, model: str, response_data: dict, latency_ms: int, error: str = None, origin: str = None, request_id: str = None, session_id: str = None, client: str = None, upstream_headers: dict = None):
     """Log response in structured JSON format"""
     log_entry = {
         "timestamp": datetime.utcnow().isoformat() + "Z",
@@ -370,6 +394,10 @@ def log_response(provider: str, model: str, response_data: dict, latency_ms: int
     
     if error:
         log_entry["error"] = error
+        # Allow-listed upstream response headers (#44) — present only on the
+        # HTTPStatusError path, where the upstream actually returned a response.
+        if upstream_headers:
+            log_entry["upstream_headers"] = upstream_headers
     else:
         # Extract response details
         if "choices" in response_data and len(response_data["choices"]) > 0:
@@ -538,7 +566,11 @@ async def proxy_chat(request: ChatRequest, http_request: Request, authorization:
         except httpx.HTTPStatusError as e:
             latency_ms = int((time.time() - start_time) * 1000)
             error_detail = f"Provider returned {e.response.status_code}: {e.response.text[:1000]}"
-            log_response(provider_name, request.model, {}, latency_ms, error=error_detail, origin=origin, request_id=request_id, session_id=session_id, client=client)
+            # Capture allow-listed upstream headers so the rate-limit (429 +
+            # retry-after/x-ratelimit-*) vs dead-backend (naked 500, no
+            # server/x-request-id) distinction is queryable from logs (#44).
+            upstream_headers = _capture_upstream_headers(e.response.headers)
+            log_response(provider_name, request.model, {}, latency_ms, error=error_detail, origin=origin, request_id=request_id, session_id=session_id, client=client, upstream_headers=upstream_headers)
 
             # Pass through certain status codes to client
             if e.response.status_code in [400, 401, 402, 403, 429]:

--- a/test_logging.py
+++ b/test_logging.py
@@ -335,6 +335,58 @@ def _run_proxy_capture(req, provider=("nrp", {"endpoint": "http://upstream", "ap
     return captured["payload"]
 
 
+def test_error_path_captures_allowlisted_upstream_headers():
+    """On the HTTPStatusError path, allow-listed upstream headers land in the
+    buffered error response so 429-throttle vs naked-500 is queryable (#44)."""
+    import asyncio
+    from unittest.mock import patch
+
+    p = _reload(PROXY_KEY="testkey")
+    p._log_buffer.clear()
+
+    # Mirror NRP's dead-backend signature: 500, empty body, content-length 0,
+    # plus a couple of allow-listed correlation/rate-limit headers and one
+    # disallowed header that must NOT be captured.
+    upstream = p.httpx.Response(
+        status_code=500,
+        headers={"content-length": "0", "retry-after": "30",
+                 "x-request-id": "abc123", "x-secret-internal": "leak-me"},
+        request=p.httpx.Request("POST", "http://upstream"),
+    )
+
+    class _FakeAsyncClient:
+        def __init__(self, *a, **k):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def post(self, *a, **k):
+            return upstream  # raise_for_status() below turns 500 into the error
+
+    class _FakeRequest:
+        headers = {"origin": "https://app"}
+
+    req = p.ChatRequest(model="qwen3", messages=[{"role": "user", "content": "hi"}])
+    with patch.object(p, "get_provider_for_model",
+                      return_value=("nrp", {"endpoint": "http://upstream", "api_key": "k"})), \
+         patch.object(p.httpx, "AsyncClient", _FakeAsyncClient):
+        try:
+            asyncio.run(p.proxy_chat(req, _FakeRequest(), authorization="Bearer testkey"))
+            assert False, "expected HTTPException on upstream 500"
+        except p.HTTPException:
+            pass
+
+    errs = [e for e in p._log_buffer if e.get("type") == "response" and e.get("error")]
+    assert len(errs) == 1
+    hdrs = errs[0]["upstream_headers"]
+    assert hdrs["content-length"] == "0"
+    assert hdrs["retry-after"] == "30"
+    assert hdrs["x-request-id"] == "abc123"
+    assert "x-secret-internal" not in hdrs   # allow-list only
+    json.dumps(errs[0])   # must stay serializable
+
+
 def test_passthrough_sampling_knobs_forwarded():
     """seed/top_p/stop/max_tokens/response_format reach upstream on any provider (#47)."""
     payload = _run_proxy_capture(dict(


### PR DESCRIPTION
Closes #44.

## What

On `httpx.HTTPStatusError`, `proxy_chat` logged only the status code and (often empty) body, discarding the upstream **response headers** — the only signal that distinguishes a genuine rate-limit from a dead-backend gateway failure:

- real throttle → `429` + `retry-after` / `x-ratelimit-*`
- dead backend → naked `500`, `content-length: 0`, no `server` / `x-request-id`

Previously this could only be told apart live with `curl -i` and was unrecoverable from logs after the fact (the 2026-06-26 502 wave).

## Change

- New allow-list `_UPSTREAM_HEADER_ALLOWLIST` + `_capture_upstream_headers()` helper in `llm_proxy.py`.
- `log_response()` gains an optional `upstream_headers=` param, stored under `entry.upstream_headers` (error path only).
- Captured at the `HTTPStatusError` call site from `e.response.headers`; values run through the existing scrubber.
- Test `test_error_path_captures_allowlisted_upstream_headers` drives the handler through a fake 500 and asserts the allow-listed headers land in the buffered error response while a disallowed header is dropped.
- CHANGELOG + LOGGING.md updated.

## Scope decisions (see issue thread)

- **Only the `HTTPStatusError` branch** — the timeout/connection branches fail without a response, so there are no headers to capture.
- **Stored in `entry` JSON, not promoted to a flat consolidated column** — `json_extract(entry,'$.upstream_headers')` suffices for occasional debugging. Easy to promote later if query ergonomics warrant.
- **Allow-list, not the full header bag** — nothing sensitive logged; scrubber pass is free defense-in-depth.

`python -m pytest test_logging.py` → 19 passed.

---
_Supersedes #50, which got entangled with an unrelated headless commit; this branch contains only the #44 change._