### PR TITLE
baseline: standing golden-answer set for guidance-change regression (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ See [Releases](README.md#releases) for how a release is cut.
 ## [Unreleased]
 
 ### Added
+- **Standing baseline question set for guidance-change regression testing (#40).**
+  New `headless/baseline/`: 22 analytical questions with operator-verified golden
+  answers + authoritative SQL (`gold/`), seeded from the open-model benchmark
+  (`headless/experiments/2026-06-26-or-openmodel-bench`). `golden.json` tags each
+  question with the **trap it guards** (the #42 rule-store key), an `accept` rule,
+  and first-run difficulty (`bench_mean_acc`). This is the durable set the
+  MCP-server guidance-change gate regresses against (per-question/instance-level,
+  not aggregate; gold is operator-verified, never model consensus). Encodes the
+  dev-MCP targeting requirement (validation must hit `dev-duckdb-mcp`, not prod).
+  `build_golden.py` regenerates the manifest; grow-on-fix as new traps are found.
 - **Forward sampling/routing knobs instead of dropping them (#47).** `proxy_chat`
   rebuilt the upstream payload from a hard whitelist (`model`/`messages`/
   `temperature` + `tools`), so any other client field was silently dropped before

--- a/headless/baseline/README.md
+++ b/headless/baseline/README.md
@@ -19,10 +19,21 @@ answer — the failure mode we explicitly guard against).
 > not prod. `headless/run.js` defaults to prod, so pass `--mcp-url` (or set
 > `config.mcp_url`) explicitly for a validation run. Encoded in `golden.json → gate`.
 
+## Two modes (`golden.json` → `mode`)
+- **`answer`** (22) — gold is the computed answer; grade against `accept`. Questions are
+  written to be **precise**: where the first run revealed an *ambiguity* (models reasoned
+  right but differently), the question now specifies the missing axis and `accept` grades
+  the discriminating skill, not an arbitrary modeling choice. See `findings/ambiguity-audit.md`.
+- **`clarify`** (3, `questions/clarify.txt`) — the *original ambiguous* phrasings, where the
+  gold response is to **recognize the ambiguity and ask**, not silently pick. Tests "ask,
+  don't guess." Currently fails for most models (they answer anyway) — a forward-looking gate
+  tied to a clarification-steering guidance change (geo-agent issue, linked in the findings).
+
 ## Files
-- `golden.json` — the manifest: per question → `gold` (checkable answer), `accept`
-  (pass rule), `trap` (the rule it guards — the #42 rule-store key), `sql_ref`
+- `golden.json` — the manifest: per question → `mode`, `gold`/`accept` (or `ambiguity`/`accept`
+  for clarify), `trap` (the rule it guards — the #42 rule-store key), `sql_ref`
   (authoritative SQL in `gold/`), and `bench_mean_acc` (first-run difficulty).
+- `findings/` — per-question root-cause writeups (ambiguity audit, tpl-ca q2).
 - `gold/<app>.md` — verified answers **with authoritative SQL** (so transcripts are
   checked mechanically, not by eye).
 - `questions.txt` — flat question set; `questions/<app>.txt` — per-app (matrix input).

--- a/headless/baseline/README.md
+++ b/headless/baseline/README.md
@@ -1,0 +1,59 @@
+# Standing baseline question set (#40)
+
+The durable, version-controlled golden-answer set that **every guidance change is
+regression-tested against** before it ships to prod. Closes the core of #40; seeded
+from the open-model benchmark in
+[`../experiments/2026-06-26-or-openmodel-bench/`](../experiments/2026-06-26-or-openmodel-bench).
+
+## The gate (two-part "done" for any guidance change)
+1. **The targeted trap is fixed** — the question that exposed it now passes.
+2. **No regression** on this baseline — every other question scores ≥ its prior mark.
+
+Scoring is **per-question (instance-level)**, not an aggregate — aggregate accuracy
+hides the trap questions (see #42). Gold is **operator-verified** via our own
+`duckdb-geo` queries, *never* model consensus (consensus can confirm a shared wrong
+answer — the failure mode we explicitly guard against).
+
+> **Targeting (critical):** validation runs MUST hit **dev** MCP
+> (`dev-duckdb-mcp.nrp-nautilus.io`), which serves the candidate `:main` guidance —
+> not prod. `headless/run.js` defaults to prod, so pass `--mcp-url` (or set
+> `config.mcp_url`) explicitly for a validation run. Encoded in `golden.json → gate`.
+
+## Files
+- `golden.json` — the manifest: per question → `gold` (checkable answer), `accept`
+  (pass rule), `trap` (the rule it guards — the #42 rule-store key), `sql_ref`
+  (authoritative SQL in `gold/`), and `bench_mean_acc` (first-run difficulty).
+- `gold/<app>.md` — verified answers **with authoritative SQL** (so transcripts are
+  checked mechanically, not by eye).
+- `questions.txt` — flat question set; `questions/<app>.txt` — per-app (matrix input).
+- `build_golden.py` — regenerates `golden.json` + `questions.txt` after edits.
+
+## Grow-on-fix
+When a guidance change fixes a *new* trap, add the question that exposed it here
+(with gold + SQL + a `trap` tag) so future changes can't silently reintroduce the
+regression. Each `trap` tag is the link to #42's itemized rule store: one rule ↔ the
+question(s) that justify it.
+
+## Trap-rule seeds (hardest first — prime geo-agent-training targets)
+From the first benchmark, mean accuracy across 4 open models:
+
+| bench acc | question | trap(s) it guards |
+|--:|---|---|
+| 0.19 | wet-top10-hydrobasins-composite | normalization-method; ncp-intensity-vs-extensive; rank-sensitivity |
+| 0.62 | bosl-fishing-displaced | mask-before-aggregate; units-fishing-hours; multi-year-pick |
+| 0.62 | glob-least-represented-ecoregions | area-share-not-count; zero-tie; min-cell-threshold |
+| 0.62 | tplca-cd-ballot-funding-2010 | **statewide-measure-attribution**; dedup-landvote-id |
+| 0.69 | tplca-cd-failed-measures | statewide-measure-attribution; status-fail-filter |
+
+The mid-pack traps (statewide-measure-attribution, multi-year-pick) are prime
+candidates for #42's runtime *result-shape advisories* rather than frozen prose.
+
+## Run
+```bash
+cd headless
+# per app, against DEV mcp; TRIALS small (gate runs on every change)
+TAG=gate TRIALS=2 GEO_AGENT_BRANCH=main \
+QUESTIONS_FILE=baseline/questions/<app>.txt \
+  ./run-matrix-k8s.sh boettiger-lab/<app>   # ensure the app config points at dev MCP
+```
+Grade each model answer against `golden.json` `gold`/`accept`; gold SQL in `gold/`.

--- a/headless/baseline/build_golden.py
+++ b/headless/baseline/build_golden.py
@@ -20,9 +20,10 @@ META = {
  ("biodiversity","q2"): dict(id="bio-ecoregion-vuln-carbon", trap="hex-join-include-h0;carbon-cell-is-total",
    gold="West Siberian taiga ~13.85 Gt C #1; taiga+Amazon+Congo top 10 (Mg C, vulnerable-2024)",
    accept="top ecoregion = West Siberian taiga; values ~±10%; units Mg/Gt C"),
- ("bosl-high-seas","q1"): dict(id="bosl-fishing-displaced", trap="mask-before-aggregate;units-fishing-hours;multi-year-pick;ebsa-coverage-partial",
-   gold="~1.96M fishing hours/yr (2024) in high-seas EBSAs; ~75% drifting longlines, ~14% squid jigger",
-   accept="order ~1–2M hours, dominated by longlines; declares a year; high-seas = EBSA∩not-EEZ"),
+ ("bosl-high-seas","q1"): dict(id="bosl-fishing-displaced", trap="mask-before-aggregate;units-fishing-hours;ebsa-coverage-partial",
+   gold="~1.96M apparent fishing hours (2024) in high-seas EBSAs; ~75% drifting longlines, ~14% squid jigger",
+   accept="~1.96M hours (2024, now specified), dominated by longlines; high-seas = EBSA∩not-EEZ",
+   note="Original (no year) was ambiguous — answers split 2024 vs multi-year avg. Year now specified; the ambiguous twin is in clarify.txt."),
  ("bosl-high-seas","q2"): dict(id="bosl-sargasso-seamounts", trap="intersect-vs-within;feature_type-exact",
    gold="141 seamounts intersecting Sargasso EBSA (135 fully within)",
    accept="135–141 (intersect or within both ok)"),
@@ -105,7 +106,7 @@ for app in ["biodiversity","bosl-high-seas","ca-30x30","global-30x30","tpl-ca","
     for i, q in enumerate(qs, 1):
         m = META[(app, f"q{i}")]
         rec = {
-            "id": m["id"], "app": app, "q_idx": f"q{i}", "question": q,
+            "id": m["id"], "app": app, "q_idx": f"q{i}", "question": q, "mode": "answer",
             "gold": m["gold"], "accept": m["accept"],
             "trap": m["trap"].split(";"),
             "sql_ref": f"gold/{app}.md (q{i})",
@@ -113,6 +114,33 @@ for app in ["biodiversity","bosl-high-seas","ca-30x30","global-30x30","tpl-ca","
         }
         if m.get("note"): rec["note"] = m["note"]
         records.append(rec)
+
+# mode=clarify: gold response = recognize the ambiguity and ask, NOT answer.
+# These are the original ambiguous phrasings of the precise answer-variants above.
+CLARIFY = [
+ dict(id="clarify-bosl-fishing-year", app="bosl-high-seas",
+   question="How much and what type of industrial fishing would be displaced by designating all EBSAs in the high seas as MPAs, closed to fishing?",
+   ambiguity="year unspecified (GFW effort spans 2012–2024; single year vs multi-year average changes the number)",
+   accept="recognizes the year is unspecified and asks which year / whether to average (GFW 2012–2024); does NOT silently pick one and present a single number as definitive",
+   pairs_with="bosl-fishing-displaced"),
+ dict(id="clarify-tplca-attribution", app="tpl-ca",
+   question="Which congressional district has raised the most conservation funding through ballot measures since 2010?",
+   ambiguity="(1) statewide vs local measures; (2) how to attribute a multi-district measure's funds (full-overlap vs apportioned)",
+   accept="surfaces the statewide-vs-local and/or attribution-method ambiguity and asks how to handle it; does NOT silently pick one attribution and rank",
+   pairs_with="tplca-cd-ballot-funding-2010"),
+ dict(id="clarify-wetlands-composite", app="wetlands",
+   question="Rank the top 10 level-3 hydrobasins by wetland extent, carbon, and NCP, normalized.",
+   ambiguity="normalization method and weighting unspecified (min-max vs z-score vs rank; equal vs custom weights; NCP is an intensity mixed with extensive sums)",
+   accept="asks how to normalize/weight the composite (and flags the intensity-vs-extensive mismatch) before ranking; does NOT silently choose a method",
+   pairs_with="wet-top10-hydrobasins-composite"),
+]
+for c in CLARIFY:
+    records.append({
+        "id": c["id"], "app": c["app"], "q_idx": "clarify", "question": c["question"],
+        "mode": "clarify", "ambiguity": c["ambiguity"], "accept": c["accept"],
+        "pairs_with": c["pairs_with"],
+        "note": "Gold = identify the ambiguity and ask; NOT a data answer. Currently fails for most models (they answer anyway) — gated on a clarification-steering guidance change (geo-agent issue).",
+    })
 
 manifest = {
     "version": "2026-06-27",
@@ -124,6 +152,12 @@ manifest = {
         "pass": "targeted trap fixed AND no regression vs this baseline (per-question, instance-level)."
     },
     "n_questions": len(records),
+    "n_answer": sum(1 for r in records if r["mode"] == "answer"),
+    "n_clarify": sum(1 for r in records if r["mode"] == "clarify"),
+    "modes": {
+        "answer": "gold = the computed answer; grade against `accept`.",
+        "clarify": "gold = recognize the ambiguity and ask; grade on whether the model asks rather than silently picks. Tied to a clarification-steering guidance change.",
+    },
     "questions": records,
 }
 out = os.path.join(HERE, "golden.json")
@@ -137,6 +171,9 @@ with open(os.path.join(HERE, "questions.txt"), "w") as fh:
         fh.write("\n")
 print("wrote questions.txt")
 # difficulty summary
-hard = sorted(records, key=lambda r: r["bench_mean_acc"])[:5]
-print("hardest (trap-rule seeds):")
+ans = [r for r in records if r["mode"] == "answer"]
+clar = [r for r in records if r["mode"] == "clarify"]
+print(f"  modes: {len(ans)} answer, {len(clar)} clarify")
+hard = sorted(ans, key=lambda r: r["bench_mean_acc"])[:5]
+print("hardest answer-mode (trap-rule seeds):")
 for r in hard: print(f"  {r['bench_mean_acc']:.2f}  {r['id']:32} traps={r['trap']}")

--- a/headless/baseline/build_golden.py
+++ b/headless/baseline/build_golden.py
@@ -48,8 +48,9 @@ META = {
    gold="~$36.1M CD16: Prop40 $11.75M, Prop12 $7.61M, Property Tax $6.15M, LWCF (USFWS+NPS) ~$5.6M …",
    accept="programs incl. state bonds + LWCF; total ~$30–40M"),
  ("tpl-ca","q2"): dict(id="tplca-cd-ballot-funding-2010", trap="statewide-measure-attribution;dedup-landvote-id",
-   gold="Local-only (meaningful): CD30/29 ~$665M, CD36/32 ~$527M, CD15 ~$509M (statewide props add a ~$4.5B baseline to every CD)",
-   accept="SEPARATES statewide measures from local; CD30/29 top local"),
+   gold="Discriminating skill = SEPARATE statewide props (jurisdiction='State', ~$4.5B baseline touching every CD) from local. Local top is the LA/coastal cluster — full-overlap: CD30/29 ~$665M, CD36/32 ~$527M, CD15 ~$509M; apportioned: CA-11 ~$170M (both defensible).",
+   accept="MUST separate statewide from local measures (the graded skill). Local ranking by EITHER full-overlap OR apportioned attribution accepted; top local districts in the LA/coastal cluster. Do NOT require the full-overlap dollar figures — attribution method is unspecified by the question.",
+   note="Most models self-handled the statewide trap; the 0.5 spread was full-overlap vs apportioned attribution (an unspecified, defensible fork) — an assessment-design issue, not a guidance bug. See findings/tpl-ca-q2-statewide.md."),
  ("tpl-ca","q3"): dict(id="tplca-cd-failed-measures", trap="statewide-measure-attribution;status-fail-filter",
    gold="All 52 CDs have failed measures; local-only top CD49 ~$2.15B, CD50 ~$2.13B, CD48 ~$2.12B (San Diego ~$2B driver)",
    accept="separates statewide ~$7.7B baseline; San Diego-region CDs top local"),
@@ -103,13 +104,15 @@ for app in ["biodiversity","bosl-high-seas","ca-30x30","global-30x30","tpl-ca","
     qs = qtext(app)
     for i, q in enumerate(qs, 1):
         m = META[(app, f"q{i}")]
-        records.append({
+        rec = {
             "id": m["id"], "app": app, "q_idx": f"q{i}", "question": q,
             "gold": m["gold"], "accept": m["accept"],
             "trap": m["trap"].split(";"),
             "sql_ref": f"gold/{app}.md (q{i})",
             "bench_mean_acc": BENCH_FLAT[m["id"]],
-        })
+        }
+        if m.get("note"): rec["note"] = m["note"]
+        records.append(rec)
 
 manifest = {
     "version": "2026-06-27",

--- a/headless/baseline/build_golden.py
+++ b/headless/baseline/build_golden.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Build golden.json — the #40 standing baseline manifest — from the per-app
+question files + the verified gold/*.md (answers + authoritative SQL).
+
+Each record ties a question to: the checkable gold, the authoritative SQL
+(in gold/<app>.md), the *trap it guards* (the #42 rule-store key), an accept
+rule, and the first-run benchmark accuracy. Re-run after editing TRAPS/ACCEPT
+or adding questions. Source: headless/experiments/2026-06-26-or-openmodel-bench.
+"""
+import json, os
+HERE = os.path.dirname(os.path.abspath(__file__))
+QDIR = os.path.join(HERE, "questions")
+
+# (app, qN) -> metadata. gold/accept kept concise + checkable; full SQL lives in
+# gold/<app>.md (sql_ref). trap = the rule each question guards (rule-store key).
+META = {
+ ("biodiversity","q1"): dict(id="bio-ramsar-countries", trap="count-distinct-sites-not-parcels",
+   gold="Top by distinct site: UK 176, Mexico 144, India 94, China 82 …",
+   accept="top country = UK; COUNT(DISTINCT ramsarid), not COUNT(*) (which wrongly puts USA #1)"),
+ ("biodiversity","q2"): dict(id="bio-ecoregion-vuln-carbon", trap="hex-join-include-h0;carbon-cell-is-total",
+   gold="West Siberian taiga ~13.85 Gt C #1; taiga+Amazon+Congo top 10 (Mg C, vulnerable-2024)",
+   accept="top ecoregion = West Siberian taiga; values ~±10%; units Mg/Gt C"),
+ ("bosl-high-seas","q1"): dict(id="bosl-fishing-displaced", trap="mask-before-aggregate;units-fishing-hours;multi-year-pick;ebsa-coverage-partial",
+   gold="~1.96M fishing hours/yr (2024) in high-seas EBSAs; ~75% drifting longlines, ~14% squid jigger",
+   accept="order ~1–2M hours, dominated by longlines; declares a year; high-seas = EBSA∩not-EEZ"),
+ ("bosl-high-seas","q2"): dict(id="bosl-sargasso-seamounts", trap="intersect-vs-within;feature_type-exact",
+   gold="141 seamounts intersecting Sargasso EBSA (135 fully within)",
+   accept="135–141 (intersect or within both ok)"),
+ ("ca-30x30","q1"): dict(id="ca-gap12-acres", trap="use-gap-acre-columns-not-final_g_p;units-acres",
+   gold="26.47M acres GAP1+2 (GAP1 17.73M, GAP2 8.74M)",
+   accept="~24–28M acres; not the 52M all-units extent"),
+ ("ca-30x30","q2"): dict(id="ca-ecoregion-most-conserved", trap="group-by-native-ecoregion-field",
+   gold="Mojave Desert ~7.37M acres #1",
+   accept="top ecoregion = Mojave Desert"),
+ ("global-30x30","q1"): dict(id="glob-pct-land-protected", trap="dedup-protected-hexes;land-mask-denominator",
+   gold="~16.5% of global land inside WDPA",
+   accept="~15–18%"),
+ ("global-30x30","q2"): dict(id="glob-people-in-pas", trap="dedup-hexes-before-sum-population",
+   gold="~357M people (GHS-POP 2020)",
+   accept="~300–420M"),
+ ("global-30x30","q3"): dict(id="glob-least-represented-ecoregions", trap="area-share-not-count;zero-tie;min-cell-threshold",
+   gold="~32 ecoregions at ~0% protected; arid/steppe/desert/dry-forest (Horn of Africa, Ordos, Qaidam, Narmada, Chhota-Nagpur …)",
+   accept="names any of the ~0% set or the arid/dry-forest character"),
+ ("global-30x30","q4"): dict(id="glob-top5-pa-mammal-richness", trap="single-cell-richness-artifact-threshold;APP-LACKS-DATASET",
+   gold="Albertine Rift/Rwenzori + Guianas/W-Amazon top (≥3-cell threshold)",
+   accept="correct hotspot geography; OR graceful 'no mammal-richness layer configured' (catalog gap)"),
+ ("tpl-ca","q1"): dict(id="tplca-cd16-funders", trap="hex-district-attribution;sum-amount-safe",
+   gold="~$36.1M CD16: Prop40 $11.75M, Prop12 $7.61M, Property Tax $6.15M, LWCF (USFWS+NPS) ~$5.6M …",
+   accept="programs incl. state bonds + LWCF; total ~$30–40M"),
+ ("tpl-ca","q2"): dict(id="tplca-cd-ballot-funding-2010", trap="statewide-measure-attribution;dedup-landvote-id",
+   gold="Local-only (meaningful): CD30/29 ~$665M, CD36/32 ~$527M, CD15 ~$509M (statewide props add a ~$4.5B baseline to every CD)",
+   accept="SEPARATES statewide measures from local; CD30/29 top local"),
+ ("tpl-ca","q3"): dict(id="tplca-cd-failed-measures", trap="statewide-measure-attribution;status-fail-filter",
+   gold="All 52 CDs have failed measures; local-only top CD49 ~$2.15B, CD50 ~$2.13B, CD48 ~$2.12B (San Diego ~$2B driver)",
+   accept="separates statewide ~$7.7B baseline; San Diego-region CDs top local"),
+ ("tpl-ca","q4"): dict(id="tplca-assembly-acreage", trap="acres-from-geoparquet-not-hex;sldl-zero-pad",
+   gold="AD34 563,641 ac, AD36 451,429, AD02 207,738, AD47 152,443",
+   accept="AD34 top; acres from sites GeoParquet (not SUM on hex)"),
+ ("tpl-ca","q5"): dict(id="tplca-lwcf-sd2", trap="program-like-lwcf;hex-district-attribution",
+   gold="~$285.5M LWCF in Senate District 2 (BLM-dominated, 48 sites)",
+   accept="~$250–320M; BLM-led"),
+ ("tpl","q1"): dict(id="tpl-almanac-landcover", trap="mask-before-aggregate;dominant-class-per-cell;cell-count-units",
+   gold="Composition by res-9 cells: herbaceous veg / needleleaf+deciduous forest / agriculture top; state leaders herb→CO, needleleaf→MT, decid→NY, ag→PA, shrubs→CA, wetland→FL",
+   accept="dominant classes ~match + plausible state leaders"),
+ ("tpl","q2"): dict(id="tpl-tx-cd-federal-funding", trap="sponsor_type-FED-filter;dominant-cd-assignment",
+   gold="CD-34 ≈ CD-14 ~$29.5M top; CD-36 $17.0M; CD-31 $15.6M",
+   accept="CD-34/CD-14 top, ~$29M"),
+ ("tpl","q3"): dict(id="tpl-nj-municipalities", trap="jurisdiction-municipal-filter;dedup-landvote-id",
+   gold="~261 NJ municipalities, 444 passed measures (~$1.95B); 1998–2004 wave; north-central concentration",
+   accept="~261 munis / ~444 passed; 1998–2004 peak; north-central"),
+ ("tpl","q4"): dict(id="tpl-boulder-funders", trap="county-name-filter;sum-amount-safe",
+   gold="Boulder County sales-tax ~$321M dominant; +NRCS ~$6.3M, USFS ~$4.9M, GOCO ~$3.1M",
+   accept="Boulder County local sales-tax dominant + federal/state"),
+ ("wetlands","q1"): dict(id="wet-india-vuln-carbon", trap="mask-before-aggregate;dominant-class;h8-h9-join",
+   gold="~1.1 Pg C (1.1e9 Mg C) total in India wetlands; top classes riverine-forested / rice paddies / temperate peatland",
+   accept="~0.8–1.4e9 Mg C with by-class breakdown"),
+ ("wetlands","q2"): dict(id="wet-ramsar-criterion9", trap="count-distinct-ramsarid;criterion9-nonavian-definition",
+   gold="64 Ramsar sites meet Criterion 9; Criterion 9 = supports ≥1% of a population of a wetland-dependent NON-AVIAN animal species",
+   accept="~60–68 sites AND correct non-avian definition (NOT waterbirds)"),
+ ("wetlands","q3"): dict(id="wet-top10-hydrobasins-composite", trap="normalization-method;ncp-intensity-vs-extensive;rank-sensitivity",
+   gold="L3 basin 6030007000 clear #1 (max wetland extent + carbon); top set ~as in gold (rank-sensitive tail)",
+   accept="sound min-max-normalize+composite method; basin 6030007000 #1"),
+}
+# first-run benchmark mean accuracy (across 4 models) — the trap difficulty signal
+BENCH = {"q1":{}, } # filled below from a flat dict
+BENCH_FLAT = {
+ "bio-ramsar-countries":0.96,"bio-ecoregion-vuln-carbon":1.0,"bosl-fishing-displaced":0.62,
+ "bosl-sargasso-seamounts":1.0,"ca-gap12-acres":1.0,"ca-ecoregion-most-conserved":1.0,
+ "glob-pct-land-protected":1.0,"glob-people-in-pas":0.88,"glob-least-represented-ecoregions":0.62,
+ "glob-top5-pa-mammal-richness":0.75,"tplca-cd16-funders":1.0,"tplca-cd-ballot-funding-2010":0.625,
+ "tplca-cd-failed-measures":0.69,"tplca-assembly-acreage":1.0,"tplca-lwcf-sd2":1.0,
+ "tpl-almanac-landcover":0.94,"tpl-tx-cd-federal-funding":0.88,"tpl-nj-municipalities":0.69,
+ "tpl-boulder-funders":1.0,"wet-india-vuln-carbon":0.88,"wet-ramsar-criterion9":0.69,
+ "wet-top10-hydrobasins-composite":0.19,
+}
+
+def qtext(app):
+    p = os.path.join(QDIR, f"{app}.txt")
+    return [l.strip() for l in open(p) if l.strip()]
+
+records = []
+for app in ["biodiversity","bosl-high-seas","ca-30x30","global-30x30","tpl-ca","tpl","wetlands"]:
+    qs = qtext(app)
+    for i, q in enumerate(qs, 1):
+        m = META[(app, f"q{i}")]
+        records.append({
+            "id": m["id"], "app": app, "q_idx": f"q{i}", "question": q,
+            "gold": m["gold"], "accept": m["accept"],
+            "trap": m["trap"].split(";"),
+            "sql_ref": f"gold/{app}.md (q{i})",
+            "bench_mean_acc": BENCH_FLAT[m["id"]],
+        })
+
+manifest = {
+    "version": "2026-06-27",
+    "source_experiment": "headless/experiments/2026-06-26-or-openmodel-bench",
+    "gate": {
+        "mcp_target": "dev-duckdb-mcp.nrp-nautilus.io",
+        "note": "Guidance-change validation runs MUST hit dev MCP (serves candidate :main guidance), not prod. The runner defaults to prod — pass --mcp-url explicitly.",
+        "grading": "judge each model answer vs `gold`/`accept`; gold is operator-verified via own duckdb-geo queries (NOT model consensus).",
+        "pass": "targeted trap fixed AND no regression vs this baseline (per-question, instance-level)."
+    },
+    "n_questions": len(records),
+    "questions": records,
+}
+out = os.path.join(HERE, "golden.json")
+json.dump(manifest, open(out, "w"), indent=2)
+print(f"wrote {out}: {len(records)} questions")
+# also (re)write questions.txt grouped by app
+with open(os.path.join(HERE, "questions.txt"), "w") as fh:
+    for app in ["biodiversity","bosl-high-seas","ca-30x30","global-30x30","tpl-ca","tpl","wetlands"]:
+        fh.write(f"# {app}\n")
+        for q in qtext(app): fh.write(q + "\n")
+        fh.write("\n")
+print("wrote questions.txt")
+# difficulty summary
+hard = sorted(records, key=lambda r: r["bench_mean_acc"])[:5]
+print("hardest (trap-rule seeds):")
+for r in hard: print(f"  {r['bench_mean_acc']:.2f}  {r['id']:32} traps={r['trap']}")

--- a/headless/baseline/findings/ambiguity-audit.md
+++ b/headless/baseline/findings/ambiguity-audit.md
@@ -25,9 +25,10 @@ baseline questions (the original ambiguous wordings) whose **gold answer is iden
 ambiguity and asking a focused clarifying question** — NOT producing a data answer.
 
 Current models almost always silently pick an interpretation, so these will *fail* until the
-harness steers clarification (proposed in geo-agent — see issue link in README). That makes
-them a forward-looking gate item tied to a specific guidance change, validated the same way
-as any other guidance change.
+harness steers clarification — proposed in **boettiger-lab/geo-agent#274**. That makes them a
+forward-looking gate item tied to a specific guidance change, validated the same way as any
+other guidance change (and per geo-agent#42, the higher-leverage form is a runtime
+request-shape check, not prose).
 
 ## Generalizable rule (carry into assessment design)
 Before treating an all-wrong question as a guidance trap: **check whether models reasoned

--- a/headless/baseline/findings/ambiguity-audit.md
+++ b/headless/baseline/findings/ambiguity-audit.md
@@ -1,0 +1,36 @@
+# Ambiguity audit of the hard benchmark questions
+
+For each all/most-models-wrong question we asked: did models **reason correctly but
+differently** (→ ambiguity, fix the question/gold), or **fail** (→ real trap / capability)?
+Evidence = the `agent_runner_orbench` transcripts + judge notes.
+
+| question | mean acc | classification | evidence | action |
+|---|--:|---|---|---|
+| **tpl-ca q2** ballot funding | 0.62 | **ambiguity** (attribution method) | most separated statewide; spread = full-overlap vs apportioned | precise gold/accept (done); clarify-variant |
+| **bosl-high-seas q1** fishing displaced | 0.62 | **ambiguity** (year) | completed answers used 2024 / 2012–2022 avg / 2021–2024 — all defensible; gold locked 2024 | **specify year**; clarify-variant |
+| **wetlands q3** hydrobasins composite | 0.19 | **hard + rank-sensitive** (mild spec-gap) | answerers converged on min-max; failures were no-answer/loops + unstable tail | specify equal-weight to remove residual DOF; stays genuinely hard |
+| **global-30x30 q3** least-represented ecoregions | 0.62 | **capability + tie** | 1.0s named the 0% set; 0.5/0 were truncated/no-answer; ~32-way 0% tie | phrase the tie ("list those at ~0%") |
+| **global-30x30 q4** top-5 PA mammal richness | 0.75 | **catalog gap** | app lacks a mammal-richness layer | metadata, not reasoning (separate) |
+
+## Revisions applied (answer-variant questions → precise)
+- **bosl-q1:** added "Use the most recent year (2024) of Global Fishing Watch effort, in apparent fishing hours."
+- **glob-q3:** "...lowest share of their area inside a protected area? List those at approximately 0%."
+- **wetlands-q3:** added "(min-max normalize each metric to [0,1] across basins, then rank by the equal-weighted mean)."
+- **tpl-ca q2:** accept now grades the discriminating skill (statewide separation), accepts either attribution method (see `tpl-ca-q2-statewide.md`).
+
+## The clarification-seeking track (new)
+The *original* ambiguous phrasings are valuable as a **different test**: a good agent should
+**recognize the under-specification and ask**, not silently pick. We add `mode:"clarify"`
+baseline questions (the original ambiguous wordings) whose **gold answer is identifying the
+ambiguity and asking a focused clarifying question** — NOT producing a data answer.
+
+Current models almost always silently pick an interpretation, so these will *fail* until the
+harness steers clarification (proposed in geo-agent — see issue link in README). That makes
+them a forward-looking gate item tied to a specific guidance change, validated the same way
+as any other guidance change.
+
+## Generalizable rule (carry into assessment design)
+Before treating an all-wrong question as a guidance trap: **check whether models reasoned
+right but differently.** If so it's ambiguity — fix the *question* (specify the missing axis)
+and grade the *discriminating skill* via an `accept` rule, not exact-match to one gold number.
+And keep an ambiguous twin as a `clarify`-mode test of "ask, don't guess."

--- a/headless/baseline/findings/tpl-ca-q2-statewide.md
+++ b/headless/baseline/findings/tpl-ca-q2-statewide.md
@@ -1,0 +1,58 @@
+# Root-cause: tpl-ca q2 — "CDs that raised the most conservation funding via ballot measures since 2010"
+
+Diagnosed via the `geo-agent-training` workflow against the `agent_runner_orbench`
+sessions (12 sessions, 37 `query` calls across 4 models).
+
+## What we expected (the hypothesis)
+Models attribute *statewide* CA propositions (`jurisdiction='State'`, which touch every
+congressional district) fully to each CD, flattening the ranking. → a guidance/metadata
+trap about the landvote `jurisdiction` field.
+
+## What the logs actually show
+**Most models found the statewide trap on their own.** Queries referencing
+`jurisdiction != 'State'` / statewide: glm 3/4, kimi 14/20, minimax 3/3, nemotron 8/10.
+They explored (`get_schema landvote` → query jurisdiction) and self-corrected. The
+statewide trap is *real but largely self-handled* — it is **not** the main source of the
+0.5–0.75 scores.
+
+The real discriminator is a **second, genuinely ambiguous methodology fork the question
+doesn't specify: how to attribute a multi-district measure's funding.**
+- **Full-overlap** (gold's choice): attribute each measure's *full* `conservation_funds_approved`
+  to every CD it overlaps. → CD30/29 ~$665M top. Scored 1.0 (matches gold).
+- **Apportioned**: divide a measure's funds across the districts/cells it spans (area- or
+  cell-weighted). → e.g. CA-11 ~$169–179M top. Scored 0.5 ("wrong magnitude/ranking").
+
+Apportionment is arguably the *more* correct interpretation of "which district raised the
+funding," yet it was penalized because the gold locked full-overlap. A few answers also
+reframed `approved` vs `at_stake` — another unspecified axis.
+
+## Layer attribution
+- **Primary cause: the assessment, not any of the 4 geo-agent layers.** The question is
+  under-specified on attribution method, and the gold over-specified it — penalizing
+  defensible answers. This is an **assessment-design** problem (baseline question/gold),
+  fixable in *this* repo.
+- **Secondary (real but minor): landvote `jurisdiction` semantics.** The minority of
+  queries that didn't separate statewide measures would benefit from the dataset
+  documenting that `jurisdiction='State'` measures span all districts. Canonical home =
+  **STAC dataset description (Layer 1, data-workflows)**. Per geo-agent#42, the
+  higher-leverage version is a **runtime result-shape advisory**: when landvote rows with
+  `jurisdiction='State'` are being joined to districts, attach a note — "statewide measures
+  touch every district; separate them or apportion." → geo-agent framework (surface #1).
+
+## Fixes applied / proposed
+1. **Assessment (done here):** the baseline `accept` for this question now tests the *real*
+   skill — **did the model separate statewide from local measures?** — and accepts *either*
+   full-overlap or apportioned local attribution, as long as statewide is separated and the
+   top local districts land in the LA/coastal cluster. `gold` documents both methods.
+2. **Layer 1 (issue):** data-workflows — add `jurisdiction` field semantics to the landvote
+   STAC description (State vs County vs Municipal; statewide measures span all districts).
+3. **#42 (tracked):** a runtime statewide-measure advisory is the higher-leverage alternative
+   to prose; logged against geo-agent#42's surface-#1 list.
+
+## Generalizable lesson for training/assessment
+Some "hard questions" are hard because they are **ambiguous and the gold locks one
+defensible interpretation**. Before treating an all/most-models-wrong question as a guidance
+trap, check whether the models *reasoned correctly but differently*. The gate's `accept`
+rule should test the **discriminating skill** (here: statewide separation), not an arbitrary
+modeling choice (here: attribution method). This is why the baseline grades on
+`accept`-rules, not exact-match to a single gold number.

--- a/headless/baseline/gold/biodiversity.md
+++ b/headless/baseline/gold/biodiversity.md
@@ -1,0 +1,25 @@
+# Gold — biodiversity
+
+## Q1. Which countries have the most Ramsar wetland sites?
+- **Answer (top 10 by distinct site count):** UK 176, Mexico 144, India 94, China 82, Spain 76, Sweden 68, Australia 67, Norway 63, Italy 61, Netherlands 58. (next: France 55, Japan 54)
+- **Dataset:** `wetlands-ramsar` — `read_parquet('s3://public-wetlands/ramsar/ramsar_wetlands.parquet')`
+- **SQL:**
+```sql
+SELECT "Country" AS country, COUNT(DISTINCT ramsarid) AS n_sites
+FROM read_parquet('s3://public-wetlands/ramsar/ramsar_wetlands.parquet')
+GROUP BY "Country" ORDER BY n_sites DESC LIMIT 12;
+```
+- **Confidence:** HIGH. **Trap:** 8,347 polygon parcels vs 2,551 distinct sites → must `COUNT(DISTINCT ramsarid)`. `COUNT(*)` wrongly puts USA on top (most parcels); correct #1 is UK. `Country` is single-valued (no transboundary double-count).
+
+## Q2. Top 10 ecoregions by vulnerable carbon
+- **Answer (Mg C, 2024):** 1 West Siberian taiga 13.85 Gt; 2 Scandinavian & Russian taiga 13.72 Gt; 3 Southwest Amazon moist forests 10.78 Gt; 4 Madeira-Tapajós moist forests 8.09 Gt; 5 Guianan lowland moist forests 7.67 Gt; 6 Uatumã-Trombetas moist forests 7.06 Gt; 7 East Siberian taiga 6.42 Gt; 8 NW Congolian lowland forests 6.42 Gt; 9 Central Congolian lowland forests 6.19 Gt; 10 NE Congolian lowland forests 6.13 Gt.
+- **Datasets:** `irrecoverable-carbon` (vulnerable) `s3://public-carbon/vulnerable-carbon-2024/hex/h0=*/data_0.parquet` (carbon in Mg C, total per cell); `wwf-ecoregions-2017` `s3://public-ecoregion/ecoregion/hex/h0=*/data_0.parquet` (carries ECO_NAME, native h8).
+- **SQL:**
+```sql
+SELECT e.ECO_NAME, ROUND(SUM(c.carbon)) AS vulnerable_carbon_MgC
+FROM read_parquet('s3://public-carbon/vulnerable-carbon-2024/hex/h0=*/data_0.parquet') c
+JOIN read_parquet('s3://public-ecoregion/ecoregion/hex/h0=*/data_0.parquet') e
+  ON c.h0 = e.h0 AND c.h8 = e.h8
+GROUP BY e.ECO_NAME ORDER BY vulnerable_carbon_MgC DESC LIMIT 10;
+```
+- **Confidence:** HIGH. Units Mg C (=tonnes). Used vulnerable-carbon-2024 (latest); ranking stable across years, absolute values shift. h0 included in hex join.

--- a/headless/baseline/gold/bosl-high-seas.md
+++ b/headless/baseline/gold/bosl-high-seas.md
@@ -1,0 +1,28 @@
+# Gold — bosl-high-seas
+
+## Q1. Industrial fishing displaced by designating all high-seas EBSAs as no-take MPAs
+- **Answer:** ≈ **1,961,219 fishing hours/year** (2024) inside high-seas EBSAs. By gear: drifting_longlines 1,464,490 (~75%); squid_jigger 278,597 (~14%); fishing (unclassified) 133,699; trawlers 37,980; pole_and_line 27,729; tuna_purse_seines 10,890; set_longlines 3,593; fixed_gear 3,138; rest <500. Dominated by pelagic high-seas fleets. (multi-year context: 2022 2.08M, 2023 2.14M, 2024 1.96M hrs)
+- **Datasets:** `gfw-fishing-effort` h6 `s3://public-gfw/gfw-fishing-effort/hex/h0=*/*.parquet`; `ebsa` h6 `s3://public-high-seas/ebsa/hex/h0=*/data_0.parquet`; `iho-maritime-boundaries` EEZ h6 `s3://public-high-seas/iho/eez/hex/h0=*/data_00.parquet`.
+- **SQL:**
+```sql
+WITH ebsa_h6 AS (SELECT DISTINCT h0,h6 FROM read_parquet('s3://public-high-seas/ebsa/hex/h0=*/data_0.parquet')),
+     eez_h6 AS (SELECT DISTINCT h6 FROM read_parquet('s3://public-high-seas/iho/eez/hex/h0=*/data_00.parquet')),
+     highseas_ebsa_h6 AS (SELECT e.h0,e.h6 FROM ebsa_h6 e ANTI JOIN eez_h6 z ON e.h6=z.h6)
+SELECT g.geartype, ROUND(SUM(g.fishing_hours),1) AS fishing_hours_2024
+FROM read_parquet('s3://public-gfw/gfw-fishing-effort/hex/h0=*/*.parquet') g
+SEMI JOIN highseas_ebsa_h6 m ON g.h0=m.h0 AND g.h6=m.h6
+WHERE g.year=2024 GROUP BY g.geartype ORDER BY fishing_hours_2024 DESC;
+```
+- **Confidence:** HIGH method / MED absolute. Units = GFW apparent **fishing hours**, 2024. High seas = EBSA ∩ NOT-in-EEZ (67% of EBSA cells). **Caveat:** EBSA coverage incomplete (203 EBSAs, 9 of ~15 CBD workshops) → floor, not full repository.
+
+## Q2. How many seamounts in the Sargasso Sea EBSA?
+- **Answer:** **141 seamounts** intersecting (135 fully within). Confirmed two ways (H3 hex join + exact `ST_Intersects` polygon join both = 141).
+- **Datasets:** `seafloor-geomorphology` polygon `s3://public-high-seas/seafloor-geomorphology.parquet` (feature_type='Seamounts'); `ebsa` polygon `s3://public-high-seas/ebsa.parquet` (GLOBAL_ID='WC_13' = Sargasso Sea).
+- **SQL:**
+```sql
+WITH sarg AS (SELECT ST_SetCRS(geom,'OGC:CRS84') AS sgeom FROM read_parquet('s3://public-high-seas/ebsa.parquet') WHERE GLOBAL_ID='WC_13'),
+     sm AS (SELECT geometry AS mgeom FROM read_parquet('s3://public-high-seas/seafloor-geomorphology.parquet') WHERE feature_type='Seamounts')
+SELECT COUNT(*) AS intersecting, COUNT(*) FILTER (WHERE ST_Within(sm.mgeom,sarg.sgeom)) AS fully_within
+FROM sm, sarg WHERE ST_Intersects(sm.mgeom, sarg.sgeom);
+```
+- **Confidence:** HIGH. Standard "features in area" = intersection = 141 (135 "within" also defensible). Excludes Guyots (flat-topped seamounts, separate class).

--- a/headless/baseline/gold/ca-30x30.md
+++ b/headless/baseline/gold/ca-30x30.md
@@ -1,0 +1,22 @@
+# Gold — ca-30x30
+
+## Q1. How many acres of California land are conserved at GAP status 1 or 2?
+- **Answer:** **26,471,459 acres GAP 1+2** (GAP 1 = 17,728,246; GAP 2 = 8,743,213). (context: GAP 3+4 = 25.90M; all units = 52.38M — NOT part of answer)
+- **Dataset:** `ca30x30-conserved-areas-terrestrial-2025` — `read_parquet('s3://public-ca30x30/conserved-areas-terrestrial-2025.parquet')` (flat, one row/feature; 45,811 rows).
+- **SQL:**
+```sql
+SELECT SUM(Gap1_acres) gap1, SUM(Gap2_acres) gap2, SUM(Gap1_acres+Gap2_acres) gap1_2
+FROM read_parquet('s3://public-ca30x30/conserved-areas-terrestrial-2025.parquet');
+```
+- **Confidence:** HIGH. Units ACRES. Used dataset's own per-GAP acre columns (avoids the `Final_g*_p × Acres` double-discount trap). Matches metadata's 26.47M statewide.
+
+## Q2. Which ecoregion has the most conserved acreage?
+- **Answer:** **Mojave Desert — 7,373,398 ac** (GAP 1+2). Top 5: Mojave 7.37M, Sierra Nevada 4.64M, S. California Mountains & Valleys 2.48M, Southeastern Great Basin 1.99M, Sonoran Desert 1.63M.
+- **Dataset:** same as Q1, grouped by `CA_Ecoregi`.
+- **SQL:**
+```sql
+SELECT CA_Ecoregi AS ecoregion, SUM(Acres) AS gap1_2_acres
+FROM read_parquet('s3://public-ca30x30/conserved-areas-terrestrial-2025.parquet')
+GROUP BY CA_Ecoregi ORDER BY gap1_2_acres DESC;
+```
+- **Confidence:** HIGH. "Conserved" = GAP 1+2 (`Acres` col). Mojave #1 by wide margin (robust even if "conserved"=full extent: Mojave still leads at 10.94M). Ecoregion from native `CA_Ecoregi` field.

--- a/headless/baseline/gold/global-30x30.md
+++ b/headless/baseline/gold/global-30x30.md
@@ -1,0 +1,36 @@
+# Gold — global-30x30
+
+## Q1. What % of global land is inside a designated protected area?
+- **Answer:** **16.48%** (29,263,682 protected land h8 cells / 177,521,782 total land h8 cells). Matches Protected Planet ~16–17% terrestrial.
+- **Datasets:** `wdpa` `s3://public-wdpa/wdpa/hex/h0=*/data_0.parquet`; land mask `cgls-lc100-2019` `s3://public-land-cover/cgls-lc100-2019/hex/h0=*/data_0.parquet` (land = lc_class NOT IN (0,80,200)).
+- **SQL:**
+```sql
+WITH wdpa AS (SELECT DISTINCT h8 FROM read_parquet('s3://public-wdpa/wdpa/hex/h0=*/data_0.parquet')),
+     land AS (SELECT DISTINCT h8 FROM read_parquet('s3://public-land-cover/cgls-lc100-2019/hex/h0=*/data_0.parquet') WHERE lc_class NOT IN (0,80,200))
+SELECT 100.0*COUNT(*)/(SELECT COUNT(*) FROM land) FROM land WHERE h8 IN (SELECT h8 FROM wdpa);
+```
+- **Confidence:** HIGH. Deduped at h8 (PA overlaps not double-counted). Land-only as asked.
+
+## Q2. How many people live inside existing protected areas?
+- **Answer:** **≈ 357 million** (357,331,494; GHS-POP 2020). ~4.6% of world population.
+- **Datasets:** `ghs-pop-2020` `s3://public-population/ghs-pop-2020/hex/h0=*/data_0.parquet`; `wdpa` hex.
+- **SQL:**
+```sql
+WITH wdpa AS (SELECT DISTINCT h8 FROM read_parquet('s3://public-wdpa/wdpa/hex/h0=*/data_0.parquet'))
+SELECT CAST(ROUND(SUM(p.population)) AS BIGINT)
+FROM read_parquet('s3://public-population/ghs-pop-2020/hex/h0=*/data_0.parquet') p
+SEMI JOIN wdpa ON p.h8=wdpa.h8;
+```
+- **Confidence:** MED-HIGH. Persons (2020). WDPA deduped before join. h8 matching slightly over-attributes at PA edges → true value modestly lower.
+
+## Q3. Which ecoregions are least represented in the protected-area network?
+- **Answer:** **~32 ecoregions at ~0% protected** (a tie, not a clean bottom-10). Largest 0%: Horn of Africa xeric bushlands, Ordos Plateau steppe, Qaidam Basin semi-desert, Narmada Valley dry deciduous forests, Chhota-Nagpur dry deciduous forests, N. Anatolian conifer/deciduous forests, Somali montane xeric woodlands, E. Anatolian deciduous forests, Tarim Basin deciduous forests & steppe, Helanshan montane conifer forests — all 0.000%. Just above 0: Central Deccan Plateau 0.004%, Yarlung Zanbo arid steppe 0.010%, Central Anatolian steppe 0.013%. Pattern: arid steppe/desert/dry-deciduous forest, mostly Palearctic + Indomalayan + Horn of Africa.
+- **Datasets:** `wwf-ecoregions-2017` hex + names `s3://public-ecoregion/ecoregion.parquet` (join `_cng_fid=OBJECTID`); `wdpa` hex.
+- **SQL:** % = protected h8 / total h8 per ecoregion, filter total_cells>=50. (full query in run log)
+- **Confidence:** HIGH. Area-weighted overall = 16.69% (consistent w/ Q1). Truthful structure is a 0% tie of ~32 ecoregions; a single ordered bottom-10 is acceptable but the tie is the real answer.
+
+## Q4. Top 5 protected areas by mean mammal richness
+- **Answer (≥3 h5 cells, defensible gold):** 1 Rwenzori Mountains, Uganda 210.0; 2 Estuaire du fleuve Sinnamary, FGuiana 201.5; 3 Crique et Pripri Yiyi, FGuiana 201.3; 4 Galibi, Suriname 200.3; 5 Basse-Mana, FGuiana 199.8. Geography = Albertine Rift + Guianas/W-Amazon (known mammal hotspots).
+- **Datasets:** `iucn-richness-2025` mammals `s3://public-iucn/hex/mammals_sr/h0=*/data_0.parquet` (native h5); `wdpa` hex (h8→h5); names `s3://public-wdpa/wdpa.parquet`.
+- **SQL:** AVG(mammals_sr) per WDPA `_cng_fid` over h5 cells, filter n_h5_cells>=3. (full query in run log)
+- **Confidence:** MED. **Trap:** without a min-cell threshold, top is 3 single-cell tiny PAs reading exactly 213 (one PA on the global hotspot cell) — an artifact. ≥3-cell threshold gives the meaningful answer. Either accepted, thresholded is gold. **App-coverage caveat:** global-30x30's configured layers don't include a mammal-richness dataset — models may not have had this data.

--- a/headless/baseline/gold/tpl-ca.md
+++ b/headless/baseline/gold/tpl-ca.md
@@ -1,0 +1,30 @@
+# Gold — tpl-ca
+
+District attribution: Almanac/landvote carry no district id → assigned by H3 hex intersection
+(sites/census res-10; landvote/census-CD res-8). Boundary-spanning features attributed in full
+to each district they touch (no apportionment). All $ nominal USD. Almanac CA currency ~through 2017.
+
+## Q1. Programs/agencies funding conservation in Congressional District 16, + how much
+- **Answer (CA CD16, 2024 boundaries; total ≈ $36.1M):** State Bonds Prop 40 $11.75M; Prop 12 $7.61M; Property Tax Funds (Santa Clara Co) $6.15M; Prop 117 $3.46M; LWCF/USFWS $3.21M; LWCF/NPS $2.43M; State Parks bonds $0.80M; General Fund $0.49M; Prop 70 $0.21M.
+- **Datasets:** `conservation-almanac-2024-funding` `s3://public-tpl/conservation-almanac-2024-funding.parquet`; sites hex `s3://public-tpl/conservation-almanac-2024-sites/hex/h0=*/data_0.parquet`; `census-2024-cd` hex `s3://public-census/census-2024/cd/hex/h0=*/data_0.parquet` (STATEFP='06', CD119FP='16'). Join sites→CD on h10, funding→sites on tpl_id.
+- **Confidence:** HIGH. SUM(amount) safe (one row/txn). LWCF appears under two federal sponsors.
+
+## Q2. CDs that raised the most conservation funding via ballot measures since 2010
+- **Answer:** Top CD30/CD29 ~$5.161B; CD36/CD32 ~$5.023B; CD15 ~$5.005B. **Caveat:** ~$4.496B of every CD's total is 3 statewide CA props (2018 $1.796B, 2014 $1.5B, 2024 $1.2B) touching all CDs. Local-only ranking (meaningful): CD30/29 ~$665M, CD36/32 ~$527M, CD15 ~$509M.
+- **Dataset:** `landvote` `s3://public-tpl/landvote.parquet` + hex; status IN ('Pass','Pass*'), year>=2010, conservation_funds_approved. Deduped by landvote_id per CD.
+- **Confidence:** MED. "Raised"=funds_approved on passed. Statewide measures attributed identically to all CDs (correct but dominates). Top ranking robust.
+
+## Q3. CDs with failed conservation ballot measures + $ at stake
+- **Answer:** Essentially **all 52 CA CDs** have failed measures. ~$7.717B baseline = 6 failed statewide props touching all CDs. By total at stake: CD49 ~$9.86B, CD50 ~$9.84B, CD48 ~$9.83B, CD51/52 ~$9.82B. Local-only (meaningful): CD49 ~$2.15B, CD50 ~$2.13B, CD48 ~$2.12B (driven by a ~$2B failed San Diego County measure).
+- **Dataset:** `landvote` (same), status='Fail', conservation_funds_at_stake, deduped by landvote_id.
+- **Confidence:** MED. All-CD result correct but uninformative w/o separating statewide; local-only (San Diego region) is the meaningful answer.
+
+## Q4. Assembly districts with the most Almanac protected acreage
+- **Answer (acres):** AD34 563,641 (586 sites); AD36 451,429; AD02 207,738; AD47 152,443; AD75 48,747; then AD01 46,402, AD30 29,059, AD27 24,496.
+- **Datasets:** `conservation-almanac-2024-sites` (acres from `s3://public-tpl/conservation-almanac-2024-sites.parquet`, geom from hex); `census-2025-sldl` hex `s3://public-census/census-2025/sldl/hex/h0=*/data_0.parquet` (STATEFP='06'). Join on h10.
+- **Confidence:** HIGH ranking / MED absolute. Acres from sites GeoParquet (one row/tpl_id, SUM-safe — never SUM on hex). SLDLST zero-padded (034=AD34). Boundary-spanning sites attributed full acreage to each AD. ~79% hex coverage + ~2017 currency → absolute undercount.
+
+## Q5. LWCF investment in State Senate District 2
+- **Answer:** **≈ $285,516,180** (~$285.5M) across 48 sites. By sponsor: BLM $260.31M, USFS $16.48M, NPS $7.67M, USFWS $1.05M.
+- **Datasets:** `conservation-almanac-2024-funding` (program LIKE '%LWCF%'); sites hex; `census-2025-sldu` hex `s3://public-census/census-2025/sldu/hex/h0=*/data_0.parquet` (STATEFP='06', SLDUST='002').
+- **Confidence:** HIGH. Nominal USD, SUM-safe. SD2 = large North Coast seat → BLM-dominated total is consistent.

--- a/headless/baseline/gold/tpl.md
+++ b/headless/baseline/gold/tpl.md
@@ -1,0 +1,24 @@
+# Gold — tpl (national)
+
+All $ nominal USD. Almanac currency ~through 2017. Sites hex covers ~79% of sites
+(small/complex geometries dropped) → site-count totals slightly undercount.
+
+## Q1. Land-cover composition of Almanac protected areas nationwide + states leading each cover type
+- **Answer:** Composition by H3 res-9 cell (≈0.105 km²/cell; dominant class per cell, land classes only). Top: Herbaceous veg (30) 173,997; Closed evergreen-needleleaf forest (111) 144,604; Closed deciduous-broadleaf (114) 139,474; Agriculture (40) 82,039; Open forest unknown (126) 65,220; Closed forest unknown (116) 55,346; Closed mixed (115) 49,873; Shrubs (20) 37,481; Herbaceous wetland (90) 16,907. **State leaders:** Herbaceous veg→CO; Closed needleleaf→MT; Closed mixed forest→ME; Shrubs→CA; Deciduous-broadleaf→NY; Agriculture→PA; Bare/sparse→CA; Closed unknown forest→FL; Herbaceous wetland→FL; Permanent water→ND; Urban→FL; Snow/ice→AK.
+- **Datasets:** `conservation-almanac-2024-sites` hex (h9 mask + state_id); `cgls-lc100-2019` `s3://public-land-cover/cgls-lc100-2019/hex/h0=*/data_0.parquet`. SEMI JOIN land cover onto site-hex mask, group by lc_class; per-state via ROW_NUMBER over (state, class).
+- **Confidence:** MED. Units = res-9 **cell counts** (×0.105 km² for area), dominant-class (within-cell mixes discarded). ~79% site coverage. Border cells counted for both states (minor). Leaders robust given margins.
+
+## Q2. Texas CDs receiving the most federal conservation funding
+- **Answer:** CD-34 ~$29.5M (71 sites); CD-14 ~$29.5M (68); CD-36 ~$17.0M (45); CD-31 ~$15.6M (25); CD-10 ~$8.9M (20); CD-6 ~$7.1M. (TX federal total ~$126.8M/312 sites; ~$124M placed.)
+- **Datasets:** `conservation-almanac-2024-funding` (sponsor_type='FED', amount>0); sites + hex; `census-2024-cd` hex (STATEFP='48'). Site→dominant-CD by max hex-cell count.
+- **Confidence:** MED. USD. 119th-Congress CDs vs ~2017 sites. Spatial assignment via res-10; ~$3M unplaced. CD-34 ≈ CD-14 (tied top).
+
+## Q3. New Jersey municipalities that passed conservation ballot measures + pattern
+- **Answer:** **261 distinct NJ municipalities**, 444 passed municipal measures (1988–2025, ~$1.95B approved). **Temporal:** sharp wave 1998–2004 (peak 47 in 1998; Garden State Preservation Trust era), lull 2009–2015, modest 2016–2025 resurgence. **Spatial:** concentrated in north-central suburban/exurban corridor — Bergen (30 munis), Burlington (22, ~$307M highest $), Monmouth (23), Morris (27), Hunterdon, Warren, Essex; sparse in south + urban core.
+- **Dataset:** `landvote` `s3://public-tpl/landvote.parquet`; state='NJ', status IN ('Pass','Pass*'), jurisdiction='Municipal', municipal<>'nan'. Dedup by landvote_id.
+- **Confidence:** HIGH.
+
+## Q4. Who has funded land conservation in Boulder County, Colorado?
+- **Answer:** **Boulder County, CO (LOC) ~$321.2M** across 530 sites — almost all its **Sales Tax Funds** ($321.3M). Federal: NRCS ~$6.30M (Farm & Ranch Lands Protection), USFS ~$4.9M (Forest Legacy). State: Colorado/GOCO ~$3.13M. Local: Longmont ~$2.10M. Private ~$1.0M.
+- **Datasets:** `conservation-almanac-2024-funding` + `conservation-almanac-2024-sites` (state_id='CO', county='Boulder County'). Join on tpl_id.
+- **Confidence:** HIGH. USD, SUM-safe. Dominated by Boulder County's local sales-tax open-space program.

--- a/headless/baseline/gold/wetlands.md
+++ b/headless/baseline/gold/wetlands.md
@@ -1,0 +1,21 @@
+# Gold — wetlands (wetlands-v2)
+
+## Q1. Vulnerable carbon stored in different wetlands of India
+- **Answer:** **≈ 1.095 × 10⁹ Mg C (~1.10 Pg C)** total vulnerable carbon (2024) in Indian wetlands. Top GLWD-v2 classes (Mg C): Riverine seasonally-saturated forested (14) 2.07e8; Rice paddies (33) 1.75e8; Temperate peatland forested (24) 1.72e8; Small streams (7) 8.75e7; Riverine seasonally-saturated non-forested (15) 8.43e7; Mangrove (28) 6.85e7; Salt pan/saline (32) 5.03e7; Other coastal (31) 3.83e7; Tropical peatland forested (26) 3.12e7; Temperate peatland non-forested (25) 2.35e7.
+- **Datasets:** `irrecoverable-carbon` `s3://public-carbon/vulnerable-carbon-2024/hex/h0=*/data_0.parquet`; `wetlands-glwd-v2` `s3://public-wetlands/glwd/hex/h0=*/data_0.parquet` (class Z, codes 1–33); `overture-divisions-countries` `s3://public-overturemaps/2026-02-18.0/countries/hex/h0=*/data_0.parquet` (country='IN'). SEMI JOIN carbon onto India h8 mask BEFORE aggregating, then join GLWD class on h8.
+- **Confidence:** MED-HIGH. Units Mg C. **Trap handled:** mask-before-aggregate (DPP). Wetland = GLWD dominant class per h8 (mode). vulnerable-carbon-2024 (latest).
+
+## Q2. Ramsar sites meeting Criterion 9 + explain the criterion
+- **Answer:** **64 Ramsar sites** meet Criterion 9 (of 2,551 distinct). Examples: Aldabra Atoll (SC), Bas Ogooué & Akanda (GA), Elkhorn Slough & Corkscrew Swamp & Cache River (US), Dafeng NNR (CN), Dojran Lake (MK), Basse-Mana (FR). **Criterion 9 (definition):** a wetland is internationally important if it regularly supports **1% of the individuals in a population of one species/subspecies of wetland-dependent NON-AVIAN animal** (the non-avian analogue of Criterion 6 for waterbirds; Group B species criterion).
+- **Dataset:** `wetlands-ramsar` `s3://public-wetlands/ramsar/ramsar_wetlands.parquet` (boolean `Criterion9`).
+- **SQL:**
+```sql
+SELECT COUNT(*) FILTER (WHERE "Criterion9") AS crit9, COUNT(*) AS total
+FROM (SELECT DISTINCT ramsarid,"Criterion9" FROM read_parquet('s3://public-wetlands/ramsar/ramsar_wetlands.parquet'));
+```
+- **Confidence:** HIGH. `COUNT(DISTINCT ramsarid)` (parcels vs sites trap). Definition matches official Ramsar criteria.
+
+## Q3. Top 10 level-3 hydrobasins by wetland extent, carbon, NCP (normalized)
+- **Answer (equal-weight mean of min-max-normalized extent/carbon/NCP):** 1 `6030007000` (0.866, max on extent & carbon); 2 `3030001840` 0.452; 3 `1030020040` 0.407; 4 `4030025450` 0.386; 5 `5030040360` 0.382; 6–9 `1030040050`/`5030055010`/`5030087540`/`6030040020` ~0.333 (NCP=max-tied, near-0 extent/carbon); 10 `5030054880` 0.331. Basin 6030007000 is the clear #1.
+- **Datasets:** `hydrobasins-v1c` L3 `s3://public-hydrobasins/L3/**`; `wetlands-glwd-v2` area `s3://public-wetlands/glwd/area-hex/h0=*/data_0.parquet` (area_ha_x10/10); `irrecoverable-carbon` vulnerable-2024; `ncp-biodiversity` `s3://public-ncp/hex/ncp_biod_nathab/h0=*/data_0.parquet` (AVG, h7). Min-max normalize each metric across basins, composite = unweighted mean.
+- **Confidence:** MED. Method sound + reproducible but **rank-sensitive**: #1 and top-5 robust; ranks 6–9 driven entirely by NCP=20 tie (small basins, ~0 extent/carbon). Different normalization/weighting reorders the NCP-saturated tail. NCP is an intensity (mean) combined with extensive (summed) metrics — inherent to the "normalized composite" framing.

--- a/headless/baseline/golden.json
+++ b/headless/baseline/golden.json
@@ -7,13 +7,20 @@
     "grading": "judge each model answer vs `gold`/`accept`; gold is operator-verified via own duckdb-geo queries (NOT model consensus).",
     "pass": "targeted trap fixed AND no regression vs this baseline (per-question, instance-level)."
   },
-  "n_questions": 22,
+  "n_questions": 25,
+  "n_answer": 22,
+  "n_clarify": 3,
+  "modes": {
+    "answer": "gold = the computed answer; grade against `accept`.",
+    "clarify": "gold = recognize the ambiguity and ask; grade on whether the model asks rather than silently picks. Tied to a clarification-steering guidance change."
+  },
   "questions": [
     {
       "id": "bio-ramsar-countries",
       "app": "biodiversity",
       "q_idx": "q1",
       "question": "Which countries have the most Ramsar wetland sites?",
+      "mode": "answer",
       "gold": "Top by distinct site: UK 176, Mexico 144, India 94, China 82 \u2026",
       "accept": "top country = UK; COUNT(DISTINCT ramsarid), not COUNT(*) (which wrongly puts USA #1)",
       "trap": [
@@ -27,6 +34,7 @@
       "app": "biodiversity",
       "q_idx": "q2",
       "question": "What are the top 10 ecoregions by vulnerable carbon?",
+      "mode": "answer",
       "gold": "West Siberian taiga ~13.85 Gt C #1; taiga+Amazon+Congo top 10 (Mg C, vulnerable-2024)",
       "accept": "top ecoregion = West Siberian taiga; values ~\u00b110%; units Mg/Gt C",
       "trap": [
@@ -40,23 +48,25 @@
       "id": "bosl-fishing-displaced",
       "app": "bosl-high-seas",
       "q_idx": "q1",
-      "question": "How much and what type of industrial fishing would be displaced by designating all EBSAs in the high seas as MPAs, closed to fishing?",
-      "gold": "~1.96M fishing hours/yr (2024) in high-seas EBSAs; ~75% drifting longlines, ~14% squid jigger",
-      "accept": "order ~1\u20132M hours, dominated by longlines; declares a year; high-seas = EBSA\u2229not-EEZ",
+      "question": "How much and what type of industrial fishing would be displaced by designating all EBSAs in the high seas as MPAs, closed to fishing? Use the most recent year (2024) of Global Fishing Watch effort, reported in apparent fishing hours.",
+      "mode": "answer",
+      "gold": "~1.96M apparent fishing hours (2024) in high-seas EBSAs; ~75% drifting longlines, ~14% squid jigger",
+      "accept": "~1.96M hours (2024, now specified), dominated by longlines; high-seas = EBSA\u2229not-EEZ",
       "trap": [
         "mask-before-aggregate",
         "units-fishing-hours",
-        "multi-year-pick",
         "ebsa-coverage-partial"
       ],
       "sql_ref": "gold/bosl-high-seas.md (q1)",
-      "bench_mean_acc": 0.62
+      "bench_mean_acc": 0.62,
+      "note": "Original (no year) was ambiguous \u2014 answers split 2024 vs multi-year avg. Year now specified; the ambiguous twin is in clarify.txt."
     },
     {
       "id": "bosl-sargasso-seamounts",
       "app": "bosl-high-seas",
       "q_idx": "q2",
       "question": "How many seamounts are there in the Sargasso Sea \"Ecologically or Biologically Significant Marine Area\" that was designated on the high seas?",
+      "mode": "answer",
       "gold": "141 seamounts intersecting Sargasso EBSA (135 fully within)",
       "accept": "135\u2013141 (intersect or within both ok)",
       "trap": [
@@ -71,6 +81,7 @@
       "app": "ca-30x30",
       "q_idx": "q1",
       "question": "How many acres of California land are conserved at GAP status 1 or 2?",
+      "mode": "answer",
       "gold": "26.47M acres GAP1+2 (GAP1 17.73M, GAP2 8.74M)",
       "accept": "~24\u201328M acres; not the 52M all-units extent",
       "trap": [
@@ -85,6 +96,7 @@
       "app": "ca-30x30",
       "q_idx": "q2",
       "question": "Which ecoregion has the most conserved acreage?",
+      "mode": "answer",
       "gold": "Mojave Desert ~7.37M acres #1",
       "accept": "top ecoregion = Mojave Desert",
       "trap": [
@@ -98,6 +110,7 @@
       "app": "global-30x30",
       "q_idx": "q1",
       "question": "What percentage of global land is currently inside a designated protected area?",
+      "mode": "answer",
       "gold": "~16.5% of global land inside WDPA",
       "accept": "~15\u201318%",
       "trap": [
@@ -112,6 +125,7 @@
       "app": "global-30x30",
       "q_idx": "q2",
       "question": "How many people live inside existing protected areas?",
+      "mode": "answer",
       "gold": "~357M people (GHS-POP 2020)",
       "accept": "~300\u2013420M",
       "trap": [
@@ -124,7 +138,8 @@
       "id": "glob-least-represented-ecoregions",
       "app": "global-30x30",
       "q_idx": "q3",
-      "question": "Which ecoregions are least represented in the current protected-area network?",
+      "question": "Which ecoregions have the lowest share of their area inside a protected area? List those at approximately 0%.",
+      "mode": "answer",
       "gold": "~32 ecoregions at ~0% protected; arid/steppe/desert/dry-forest (Horn of Africa, Ordos, Qaidam, Narmada, Chhota-Nagpur \u2026)",
       "accept": "names any of the ~0% set or the arid/dry-forest character",
       "trap": [
@@ -140,6 +155,7 @@
       "app": "global-30x30",
       "q_idx": "q4",
       "question": "Show me species richness for mammals and identify the top 5 protected areas by mean richness.",
+      "mode": "answer",
       "gold": "Albertine Rift/Rwenzori + Guianas/W-Amazon top (\u22653-cell threshold)",
       "accept": "correct hotspot geography; OR graceful 'no mammal-richness layer configured' (catalog gap)",
       "trap": [
@@ -154,6 +170,7 @@
       "app": "tpl-ca",
       "q_idx": "q1",
       "question": "Which programs and agencies have funded land conservation in Congressional District 16, and how much?",
+      "mode": "answer",
       "gold": "~$36.1M CD16: Prop40 $11.75M, Prop12 $7.61M, Property Tax $6.15M, LWCF (USFWS+NPS) ~$5.6M \u2026",
       "accept": "programs incl. state bonds + LWCF; total ~$30\u201340M",
       "trap": [
@@ -168,6 +185,7 @@
       "app": "tpl-ca",
       "q_idx": "q2",
       "question": "Which congressional districts have raised the most conservation funding through ballot measures since 2010?",
+      "mode": "answer",
       "gold": "Discriminating skill = SEPARATE statewide props (jurisdiction='State', ~$4.5B baseline touching every CD) from local. Local top is the LA/coastal cluster \u2014 full-overlap: CD30/29 ~$665M, CD36/32 ~$527M, CD15 ~$509M; apportioned: CA-11 ~$170M (both defensible).",
       "accept": "MUST separate statewide from local measures (the graded skill). Local ranking by EITHER full-overlap OR apportioned attribution accepted; top local districts in the LA/coastal cluster. Do NOT require the full-overlap dollar figures \u2014 attribution method is unspecified by the question.",
       "trap": [
@@ -183,6 +201,7 @@
       "app": "tpl-ca",
       "q_idx": "q3",
       "question": "Which CA congressional districts have had failed conservation ballot measures, and how much funding was at stake?",
+      "mode": "answer",
       "gold": "All 52 CDs have failed measures; local-only top CD49 ~$2.15B, CD50 ~$2.13B, CD48 ~$2.12B (San Diego ~$2B driver)",
       "accept": "separates statewide ~$7.7B baseline; San Diego-region CDs top local",
       "trap": [
@@ -197,6 +216,7 @@
       "app": "tpl-ca",
       "q_idx": "q4",
       "question": "Which Assembly districts have the most protected acreage recorded in the Conservation Almanac?",
+      "mode": "answer",
       "gold": "AD34 563,641 ac, AD36 451,429, AD02 207,738, AD47 152,443",
       "accept": "AD34 top; acres from sites GeoParquet (not SUM on hex)",
       "trap": [
@@ -211,6 +231,7 @@
       "app": "tpl-ca",
       "q_idx": "q5",
       "question": "How much has the Land and Water Conservation Fund invested in Senate District 2?",
+      "mode": "answer",
       "gold": "~$285.5M LWCF in Senate District 2 (BLM-dominated, 48 sites)",
       "accept": "~$250\u2013320M; BLM-led",
       "trap": [
@@ -225,6 +246,7 @@
       "app": "tpl",
       "q_idx": "q1",
       "question": "Compute the land cover composition of areas protected in the Conservation Almanac nationwide, and which states lead in protecting each cover type?",
+      "mode": "answer",
       "gold": "Composition by res-9 cells: herbaceous veg / needleleaf+deciduous forest / agriculture top; state leaders herb\u2192CO, needleleaf\u2192MT, decid\u2192NY, ag\u2192PA, shrubs\u2192CA, wetland\u2192FL",
       "accept": "dominant classes ~match + plausible state leaders",
       "trap": [
@@ -240,6 +262,7 @@
       "app": "tpl",
       "q_idx": "q2",
       "question": "Which Texas congressional districts recieve the mose federal funding for land conservation? Show on map",
+      "mode": "answer",
       "gold": "CD-34 \u2248 CD-14 ~$29.5M top; CD-36 $17.0M; CD-31 $15.6M",
       "accept": "CD-34/CD-14 top, ~$29M",
       "trap": [
@@ -254,6 +277,7 @@
       "app": "tpl",
       "q_idx": "q3",
       "question": "Which New Jersey municipalities have passed conservation ballot measures, and how does the pattern of successful measures vary across the state?",
+      "mode": "answer",
       "gold": "~261 NJ municipalities, 444 passed measures (~$1.95B); 1998\u20132004 wave; north-central concentration",
       "accept": "~261 munis / ~444 passed; 1998\u20132004 peak; north-central",
       "trap": [
@@ -268,6 +292,7 @@
       "app": "tpl",
       "q_idx": "q4",
       "question": "Who has funded land conservation in Boulder County, Colorado? show areas on the map.",
+      "mode": "answer",
       "gold": "Boulder County sales-tax ~$321M dominant; +NRCS ~$6.3M, USFS ~$4.9M, GOCO ~$3.1M",
       "accept": "Boulder County local sales-tax dominant + federal/state",
       "trap": [
@@ -282,6 +307,7 @@
       "app": "wetlands",
       "q_idx": "q1",
       "question": "Calculate vulnerable carbon stored in different wetlands of India?",
+      "mode": "answer",
       "gold": "~1.1 Pg C (1.1e9 Mg C) total in India wetlands; top classes riverine-forested / rice paddies / temperate peatland",
       "accept": "~0.8\u20131.4e9 Mg C with by-class breakdown",
       "trap": [
@@ -297,6 +323,7 @@
       "app": "wetlands",
       "q_idx": "q2",
       "question": "Show Ramsar sites meeting Criterion 9; explain the criterion",
+      "mode": "answer",
       "gold": "64 Ramsar sites meet Criterion 9; Criterion 9 = supports \u22651% of a population of a wetland-dependent NON-AVIAN animal species",
       "accept": "~60\u201368 sites AND correct non-avian definition (NOT waterbirds)",
       "trap": [
@@ -310,7 +337,8 @@
       "id": "wet-top10-hydrobasins-composite",
       "app": "wetlands",
       "q_idx": "q3",
-      "question": "Rank the top 10 level-3 hydrobasins by wetland extent, carbon, and NCP, normalized. Explain methodology and show them on map.",
+      "question": "Rank the top 10 level-3 hydrobasins by wetland extent, carbon, and NCP (min-max normalize each metric to [0,1] across basins, then rank by the equal-weighted mean). Explain methodology.",
+      "mode": "answer",
       "gold": "L3 basin 6030007000 clear #1 (max wetland extent + carbon); top set ~as in gold (rank-sensitive tail)",
       "accept": "sound min-max-normalize+composite method; basin 6030007000 #1",
       "trap": [
@@ -320,6 +348,39 @@
       ],
       "sql_ref": "gold/wetlands.md (q3)",
       "bench_mean_acc": 0.19
+    },
+    {
+      "id": "clarify-bosl-fishing-year",
+      "app": "bosl-high-seas",
+      "q_idx": "clarify",
+      "question": "How much and what type of industrial fishing would be displaced by designating all EBSAs in the high seas as MPAs, closed to fishing?",
+      "mode": "clarify",
+      "ambiguity": "year unspecified (GFW effort spans 2012\u20132024; single year vs multi-year average changes the number)",
+      "accept": "recognizes the year is unspecified and asks which year / whether to average (GFW 2012\u20132024); does NOT silently pick one and present a single number as definitive",
+      "pairs_with": "bosl-fishing-displaced",
+      "note": "Gold = identify the ambiguity and ask; NOT a data answer. Currently fails for most models (they answer anyway) \u2014 gated on a clarification-steering guidance change (geo-agent issue)."
+    },
+    {
+      "id": "clarify-tplca-attribution",
+      "app": "tpl-ca",
+      "q_idx": "clarify",
+      "question": "Which congressional district has raised the most conservation funding through ballot measures since 2010?",
+      "mode": "clarify",
+      "ambiguity": "(1) statewide vs local measures; (2) how to attribute a multi-district measure's funds (full-overlap vs apportioned)",
+      "accept": "surfaces the statewide-vs-local and/or attribution-method ambiguity and asks how to handle it; does NOT silently pick one attribution and rank",
+      "pairs_with": "tplca-cd-ballot-funding-2010",
+      "note": "Gold = identify the ambiguity and ask; NOT a data answer. Currently fails for most models (they answer anyway) \u2014 gated on a clarification-steering guidance change (geo-agent issue)."
+    },
+    {
+      "id": "clarify-wetlands-composite",
+      "app": "wetlands",
+      "q_idx": "clarify",
+      "question": "Rank the top 10 level-3 hydrobasins by wetland extent, carbon, and NCP, normalized.",
+      "mode": "clarify",
+      "ambiguity": "normalization method and weighting unspecified (min-max vs z-score vs rank; equal vs custom weights; NCP is an intensity mixed with extensive sums)",
+      "accept": "asks how to normalize/weight the composite (and flags the intensity-vs-extensive mismatch) before ranking; does NOT silently choose a method",
+      "pairs_with": "wet-top10-hydrobasins-composite",
+      "note": "Gold = identify the ambiguity and ask; NOT a data answer. Currently fails for most models (they answer anyway) \u2014 gated on a clarification-steering guidance change (geo-agent issue)."
     }
   ]
 }

--- a/headless/baseline/golden.json
+++ b/headless/baseline/golden.json
@@ -1,0 +1,324 @@
+{
+  "version": "2026-06-27",
+  "source_experiment": "headless/experiments/2026-06-26-or-openmodel-bench",
+  "gate": {
+    "mcp_target": "dev-duckdb-mcp.nrp-nautilus.io",
+    "note": "Guidance-change validation runs MUST hit dev MCP (serves candidate :main guidance), not prod. The runner defaults to prod \u2014 pass --mcp-url explicitly.",
+    "grading": "judge each model answer vs `gold`/`accept`; gold is operator-verified via own duckdb-geo queries (NOT model consensus).",
+    "pass": "targeted trap fixed AND no regression vs this baseline (per-question, instance-level)."
+  },
+  "n_questions": 22,
+  "questions": [
+    {
+      "id": "bio-ramsar-countries",
+      "app": "biodiversity",
+      "q_idx": "q1",
+      "question": "Which countries have the most Ramsar wetland sites?",
+      "gold": "Top by distinct site: UK 176, Mexico 144, India 94, China 82 \u2026",
+      "accept": "top country = UK; COUNT(DISTINCT ramsarid), not COUNT(*) (which wrongly puts USA #1)",
+      "trap": [
+        "count-distinct-sites-not-parcels"
+      ],
+      "sql_ref": "gold/biodiversity.md (q1)",
+      "bench_mean_acc": 0.96
+    },
+    {
+      "id": "bio-ecoregion-vuln-carbon",
+      "app": "biodiversity",
+      "q_idx": "q2",
+      "question": "What are the top 10 ecoregions by vulnerable carbon?",
+      "gold": "West Siberian taiga ~13.85 Gt C #1; taiga+Amazon+Congo top 10 (Mg C, vulnerable-2024)",
+      "accept": "top ecoregion = West Siberian taiga; values ~\u00b110%; units Mg/Gt C",
+      "trap": [
+        "hex-join-include-h0",
+        "carbon-cell-is-total"
+      ],
+      "sql_ref": "gold/biodiversity.md (q2)",
+      "bench_mean_acc": 1.0
+    },
+    {
+      "id": "bosl-fishing-displaced",
+      "app": "bosl-high-seas",
+      "q_idx": "q1",
+      "question": "How much and what type of industrial fishing would be displaced by designating all EBSAs in the high seas as MPAs, closed to fishing?",
+      "gold": "~1.96M fishing hours/yr (2024) in high-seas EBSAs; ~75% drifting longlines, ~14% squid jigger",
+      "accept": "order ~1\u20132M hours, dominated by longlines; declares a year; high-seas = EBSA\u2229not-EEZ",
+      "trap": [
+        "mask-before-aggregate",
+        "units-fishing-hours",
+        "multi-year-pick",
+        "ebsa-coverage-partial"
+      ],
+      "sql_ref": "gold/bosl-high-seas.md (q1)",
+      "bench_mean_acc": 0.62
+    },
+    {
+      "id": "bosl-sargasso-seamounts",
+      "app": "bosl-high-seas",
+      "q_idx": "q2",
+      "question": "How many seamounts are there in the Sargasso Sea \"Ecologically or Biologically Significant Marine Area\" that was designated on the high seas?",
+      "gold": "141 seamounts intersecting Sargasso EBSA (135 fully within)",
+      "accept": "135\u2013141 (intersect or within both ok)",
+      "trap": [
+        "intersect-vs-within",
+        "feature_type-exact"
+      ],
+      "sql_ref": "gold/bosl-high-seas.md (q2)",
+      "bench_mean_acc": 1.0
+    },
+    {
+      "id": "ca-gap12-acres",
+      "app": "ca-30x30",
+      "q_idx": "q1",
+      "question": "How many acres of California land are conserved at GAP status 1 or 2?",
+      "gold": "26.47M acres GAP1+2 (GAP1 17.73M, GAP2 8.74M)",
+      "accept": "~24\u201328M acres; not the 52M all-units extent",
+      "trap": [
+        "use-gap-acre-columns-not-final_g_p",
+        "units-acres"
+      ],
+      "sql_ref": "gold/ca-30x30.md (q1)",
+      "bench_mean_acc": 1.0
+    },
+    {
+      "id": "ca-ecoregion-most-conserved",
+      "app": "ca-30x30",
+      "q_idx": "q2",
+      "question": "Which ecoregion has the most conserved acreage?",
+      "gold": "Mojave Desert ~7.37M acres #1",
+      "accept": "top ecoregion = Mojave Desert",
+      "trap": [
+        "group-by-native-ecoregion-field"
+      ],
+      "sql_ref": "gold/ca-30x30.md (q2)",
+      "bench_mean_acc": 1.0
+    },
+    {
+      "id": "glob-pct-land-protected",
+      "app": "global-30x30",
+      "q_idx": "q1",
+      "question": "What percentage of global land is currently inside a designated protected area?",
+      "gold": "~16.5% of global land inside WDPA",
+      "accept": "~15\u201318%",
+      "trap": [
+        "dedup-protected-hexes",
+        "land-mask-denominator"
+      ],
+      "sql_ref": "gold/global-30x30.md (q1)",
+      "bench_mean_acc": 1.0
+    },
+    {
+      "id": "glob-people-in-pas",
+      "app": "global-30x30",
+      "q_idx": "q2",
+      "question": "How many people live inside existing protected areas?",
+      "gold": "~357M people (GHS-POP 2020)",
+      "accept": "~300\u2013420M",
+      "trap": [
+        "dedup-hexes-before-sum-population"
+      ],
+      "sql_ref": "gold/global-30x30.md (q2)",
+      "bench_mean_acc": 0.88
+    },
+    {
+      "id": "glob-least-represented-ecoregions",
+      "app": "global-30x30",
+      "q_idx": "q3",
+      "question": "Which ecoregions are least represented in the current protected-area network?",
+      "gold": "~32 ecoregions at ~0% protected; arid/steppe/desert/dry-forest (Horn of Africa, Ordos, Qaidam, Narmada, Chhota-Nagpur \u2026)",
+      "accept": "names any of the ~0% set or the arid/dry-forest character",
+      "trap": [
+        "area-share-not-count",
+        "zero-tie",
+        "min-cell-threshold"
+      ],
+      "sql_ref": "gold/global-30x30.md (q3)",
+      "bench_mean_acc": 0.62
+    },
+    {
+      "id": "glob-top5-pa-mammal-richness",
+      "app": "global-30x30",
+      "q_idx": "q4",
+      "question": "Show me species richness for mammals and identify the top 5 protected areas by mean richness.",
+      "gold": "Albertine Rift/Rwenzori + Guianas/W-Amazon top (\u22653-cell threshold)",
+      "accept": "correct hotspot geography; OR graceful 'no mammal-richness layer configured' (catalog gap)",
+      "trap": [
+        "single-cell-richness-artifact-threshold",
+        "APP-LACKS-DATASET"
+      ],
+      "sql_ref": "gold/global-30x30.md (q4)",
+      "bench_mean_acc": 0.75
+    },
+    {
+      "id": "tplca-cd16-funders",
+      "app": "tpl-ca",
+      "q_idx": "q1",
+      "question": "Which programs and agencies have funded land conservation in Congressional District 16, and how much?",
+      "gold": "~$36.1M CD16: Prop40 $11.75M, Prop12 $7.61M, Property Tax $6.15M, LWCF (USFWS+NPS) ~$5.6M \u2026",
+      "accept": "programs incl. state bonds + LWCF; total ~$30\u201340M",
+      "trap": [
+        "hex-district-attribution",
+        "sum-amount-safe"
+      ],
+      "sql_ref": "gold/tpl-ca.md (q1)",
+      "bench_mean_acc": 1.0
+    },
+    {
+      "id": "tplca-cd-ballot-funding-2010",
+      "app": "tpl-ca",
+      "q_idx": "q2",
+      "question": "Which congressional districts have raised the most conservation funding through ballot measures since 2010?",
+      "gold": "Local-only (meaningful): CD30/29 ~$665M, CD36/32 ~$527M, CD15 ~$509M (statewide props add a ~$4.5B baseline to every CD)",
+      "accept": "SEPARATES statewide measures from local; CD30/29 top local",
+      "trap": [
+        "statewide-measure-attribution",
+        "dedup-landvote-id"
+      ],
+      "sql_ref": "gold/tpl-ca.md (q2)",
+      "bench_mean_acc": 0.625
+    },
+    {
+      "id": "tplca-cd-failed-measures",
+      "app": "tpl-ca",
+      "q_idx": "q3",
+      "question": "Which CA congressional districts have had failed conservation ballot measures, and how much funding was at stake?",
+      "gold": "All 52 CDs have failed measures; local-only top CD49 ~$2.15B, CD50 ~$2.13B, CD48 ~$2.12B (San Diego ~$2B driver)",
+      "accept": "separates statewide ~$7.7B baseline; San Diego-region CDs top local",
+      "trap": [
+        "statewide-measure-attribution",
+        "status-fail-filter"
+      ],
+      "sql_ref": "gold/tpl-ca.md (q3)",
+      "bench_mean_acc": 0.69
+    },
+    {
+      "id": "tplca-assembly-acreage",
+      "app": "tpl-ca",
+      "q_idx": "q4",
+      "question": "Which Assembly districts have the most protected acreage recorded in the Conservation Almanac?",
+      "gold": "AD34 563,641 ac, AD36 451,429, AD02 207,738, AD47 152,443",
+      "accept": "AD34 top; acres from sites GeoParquet (not SUM on hex)",
+      "trap": [
+        "acres-from-geoparquet-not-hex",
+        "sldl-zero-pad"
+      ],
+      "sql_ref": "gold/tpl-ca.md (q4)",
+      "bench_mean_acc": 1.0
+    },
+    {
+      "id": "tplca-lwcf-sd2",
+      "app": "tpl-ca",
+      "q_idx": "q5",
+      "question": "How much has the Land and Water Conservation Fund invested in Senate District 2?",
+      "gold": "~$285.5M LWCF in Senate District 2 (BLM-dominated, 48 sites)",
+      "accept": "~$250\u2013320M; BLM-led",
+      "trap": [
+        "program-like-lwcf",
+        "hex-district-attribution"
+      ],
+      "sql_ref": "gold/tpl-ca.md (q5)",
+      "bench_mean_acc": 1.0
+    },
+    {
+      "id": "tpl-almanac-landcover",
+      "app": "tpl",
+      "q_idx": "q1",
+      "question": "Compute the land cover composition of areas protected in the Conservation Almanac nationwide, and which states lead in protecting each cover type?",
+      "gold": "Composition by res-9 cells: herbaceous veg / needleleaf+deciduous forest / agriculture top; state leaders herb\u2192CO, needleleaf\u2192MT, decid\u2192NY, ag\u2192PA, shrubs\u2192CA, wetland\u2192FL",
+      "accept": "dominant classes ~match + plausible state leaders",
+      "trap": [
+        "mask-before-aggregate",
+        "dominant-class-per-cell",
+        "cell-count-units"
+      ],
+      "sql_ref": "gold/tpl.md (q1)",
+      "bench_mean_acc": 0.94
+    },
+    {
+      "id": "tpl-tx-cd-federal-funding",
+      "app": "tpl",
+      "q_idx": "q2",
+      "question": "Which Texas congressional districts recieve the mose federal funding for land conservation? Show on map",
+      "gold": "CD-34 \u2248 CD-14 ~$29.5M top; CD-36 $17.0M; CD-31 $15.6M",
+      "accept": "CD-34/CD-14 top, ~$29M",
+      "trap": [
+        "sponsor_type-FED-filter",
+        "dominant-cd-assignment"
+      ],
+      "sql_ref": "gold/tpl.md (q2)",
+      "bench_mean_acc": 0.88
+    },
+    {
+      "id": "tpl-nj-municipalities",
+      "app": "tpl",
+      "q_idx": "q3",
+      "question": "Which New Jersey municipalities have passed conservation ballot measures, and how does the pattern of successful measures vary across the state?",
+      "gold": "~261 NJ municipalities, 444 passed measures (~$1.95B); 1998\u20132004 wave; north-central concentration",
+      "accept": "~261 munis / ~444 passed; 1998\u20132004 peak; north-central",
+      "trap": [
+        "jurisdiction-municipal-filter",
+        "dedup-landvote-id"
+      ],
+      "sql_ref": "gold/tpl.md (q3)",
+      "bench_mean_acc": 0.69
+    },
+    {
+      "id": "tpl-boulder-funders",
+      "app": "tpl",
+      "q_idx": "q4",
+      "question": "Who has funded land conservation in Boulder County, Colorado? show areas on the map.",
+      "gold": "Boulder County sales-tax ~$321M dominant; +NRCS ~$6.3M, USFS ~$4.9M, GOCO ~$3.1M",
+      "accept": "Boulder County local sales-tax dominant + federal/state",
+      "trap": [
+        "county-name-filter",
+        "sum-amount-safe"
+      ],
+      "sql_ref": "gold/tpl.md (q4)",
+      "bench_mean_acc": 1.0
+    },
+    {
+      "id": "wet-india-vuln-carbon",
+      "app": "wetlands",
+      "q_idx": "q1",
+      "question": "Calculate vulnerable carbon stored in different wetlands of India?",
+      "gold": "~1.1 Pg C (1.1e9 Mg C) total in India wetlands; top classes riverine-forested / rice paddies / temperate peatland",
+      "accept": "~0.8\u20131.4e9 Mg C with by-class breakdown",
+      "trap": [
+        "mask-before-aggregate",
+        "dominant-class",
+        "h8-h9-join"
+      ],
+      "sql_ref": "gold/wetlands.md (q1)",
+      "bench_mean_acc": 0.88
+    },
+    {
+      "id": "wet-ramsar-criterion9",
+      "app": "wetlands",
+      "q_idx": "q2",
+      "question": "Show Ramsar sites meeting Criterion 9; explain the criterion",
+      "gold": "64 Ramsar sites meet Criterion 9; Criterion 9 = supports \u22651% of a population of a wetland-dependent NON-AVIAN animal species",
+      "accept": "~60\u201368 sites AND correct non-avian definition (NOT waterbirds)",
+      "trap": [
+        "count-distinct-ramsarid",
+        "criterion9-nonavian-definition"
+      ],
+      "sql_ref": "gold/wetlands.md (q2)",
+      "bench_mean_acc": 0.69
+    },
+    {
+      "id": "wet-top10-hydrobasins-composite",
+      "app": "wetlands",
+      "q_idx": "q3",
+      "question": "Rank the top 10 level-3 hydrobasins by wetland extent, carbon, and NCP, normalized. Explain methodology and show them on map.",
+      "gold": "L3 basin 6030007000 clear #1 (max wetland extent + carbon); top set ~as in gold (rank-sensitive tail)",
+      "accept": "sound min-max-normalize+composite method; basin 6030007000 #1",
+      "trap": [
+        "normalization-method",
+        "ncp-intensity-vs-extensive",
+        "rank-sensitivity"
+      ],
+      "sql_ref": "gold/wetlands.md (q3)",
+      "bench_mean_acc": 0.19
+    }
+  ]
+}

--- a/headless/baseline/golden.json
+++ b/headless/baseline/golden.json
@@ -168,14 +168,15 @@
       "app": "tpl-ca",
       "q_idx": "q2",
       "question": "Which congressional districts have raised the most conservation funding through ballot measures since 2010?",
-      "gold": "Local-only (meaningful): CD30/29 ~$665M, CD36/32 ~$527M, CD15 ~$509M (statewide props add a ~$4.5B baseline to every CD)",
-      "accept": "SEPARATES statewide measures from local; CD30/29 top local",
+      "gold": "Discriminating skill = SEPARATE statewide props (jurisdiction='State', ~$4.5B baseline touching every CD) from local. Local top is the LA/coastal cluster \u2014 full-overlap: CD30/29 ~$665M, CD36/32 ~$527M, CD15 ~$509M; apportioned: CA-11 ~$170M (both defensible).",
+      "accept": "MUST separate statewide from local measures (the graded skill). Local ranking by EITHER full-overlap OR apportioned attribution accepted; top local districts in the LA/coastal cluster. Do NOT require the full-overlap dollar figures \u2014 attribution method is unspecified by the question.",
       "trap": [
         "statewide-measure-attribution",
         "dedup-landvote-id"
       ],
       "sql_ref": "gold/tpl-ca.md (q2)",
-      "bench_mean_acc": 0.625
+      "bench_mean_acc": 0.625,
+      "note": "Most models self-handled the statewide trap; the 0.5 spread was full-overlap vs apportioned attribution (an unspecified, defensible fork) \u2014 an assessment-design issue, not a guidance bug. See findings/tpl-ca-q2-statewide.md."
     },
     {
       "id": "tplca-cd-failed-measures",

--- a/headless/baseline/questions.txt
+++ b/headless/baseline/questions.txt
@@ -3,7 +3,7 @@ Which countries have the most Ramsar wetland sites?
 What are the top 10 ecoregions by vulnerable carbon?
 
 # bosl-high-seas
-How much and what type of industrial fishing would be displaced by designating all EBSAs in the high seas as MPAs, closed to fishing?
+How much and what type of industrial fishing would be displaced by designating all EBSAs in the high seas as MPAs, closed to fishing? Use the most recent year (2024) of Global Fishing Watch effort, reported in apparent fishing hours.
 How many seamounts are there in the Sargasso Sea "Ecologically or Biologically Significant Marine Area" that was designated on the high seas?
 
 # ca-30x30
@@ -13,7 +13,7 @@ Which ecoregion has the most conserved acreage?
 # global-30x30
 What percentage of global land is currently inside a designated protected area?
 How many people live inside existing protected areas?
-Which ecoregions are least represented in the current protected-area network?
+Which ecoregions have the lowest share of their area inside a protected area? List those at approximately 0%.
 Show me species richness for mammals and identify the top 5 protected areas by mean richness.
 
 # tpl-ca
@@ -32,5 +32,5 @@ Who has funded land conservation in Boulder County, Colorado? show areas on the 
 # wetlands
 Calculate vulnerable carbon stored in different wetlands of India?
 Show Ramsar sites meeting Criterion 9; explain the criterion
-Rank the top 10 level-3 hydrobasins by wetland extent, carbon, and NCP, normalized. Explain methodology and show them on map.
+Rank the top 10 level-3 hydrobasins by wetland extent, carbon, and NCP (min-max normalize each metric to [0,1] across basins, then rank by the equal-weighted mean). Explain methodology.
 

--- a/headless/baseline/questions.txt
+++ b/headless/baseline/questions.txt
@@ -1,0 +1,36 @@
+# biodiversity
+Which countries have the most Ramsar wetland sites?
+What are the top 10 ecoregions by vulnerable carbon?
+
+# bosl-high-seas
+How much and what type of industrial fishing would be displaced by designating all EBSAs in the high seas as MPAs, closed to fishing?
+How many seamounts are there in the Sargasso Sea "Ecologically or Biologically Significant Marine Area" that was designated on the high seas?
+
+# ca-30x30
+How many acres of California land are conserved at GAP status 1 or 2?
+Which ecoregion has the most conserved acreage?
+
+# global-30x30
+What percentage of global land is currently inside a designated protected area?
+How many people live inside existing protected areas?
+Which ecoregions are least represented in the current protected-area network?
+Show me species richness for mammals and identify the top 5 protected areas by mean richness.
+
+# tpl-ca
+Which programs and agencies have funded land conservation in Congressional District 16, and how much?
+Which congressional districts have raised the most conservation funding through ballot measures since 2010?
+Which CA congressional districts have had failed conservation ballot measures, and how much funding was at stake?
+Which Assembly districts have the most protected acreage recorded in the Conservation Almanac?
+How much has the Land and Water Conservation Fund invested in Senate District 2?
+
+# tpl
+Compute the land cover composition of areas protected in the Conservation Almanac nationwide, and which states lead in protecting each cover type?
+Which Texas congressional districts recieve the mose federal funding for land conservation? Show on map
+Which New Jersey municipalities have passed conservation ballot measures, and how does the pattern of successful measures vary across the state?
+Who has funded land conservation in Boulder County, Colorado? show areas on the map.
+
+# wetlands
+Calculate vulnerable carbon stored in different wetlands of India?
+Show Ramsar sites meeting Criterion 9; explain the criterion
+Rank the top 10 level-3 hydrobasins by wetland extent, carbon, and NCP, normalized. Explain methodology and show them on map.
+

--- a/headless/baseline/questions/biodiversity.txt
+++ b/headless/baseline/questions/biodiversity.txt
@@ -1,0 +1,2 @@
+Which countries have the most Ramsar wetland sites?
+What are the top 10 ecoregions by vulnerable carbon?

--- a/headless/baseline/questions/bosl-high-seas.txt
+++ b/headless/baseline/questions/bosl-high-seas.txt
@@ -1,0 +1,2 @@
+How much and what type of industrial fishing would be displaced by designating all EBSAs in the high seas as MPAs, closed to fishing?
+How many seamounts are there in the Sargasso Sea "Ecologically or Biologically Significant Marine Area" that was designated on the high seas?

--- a/headless/baseline/questions/bosl-high-seas.txt
+++ b/headless/baseline/questions/bosl-high-seas.txt
@@ -1,2 +1,2 @@
-How much and what type of industrial fishing would be displaced by designating all EBSAs in the high seas as MPAs, closed to fishing?
+How much and what type of industrial fishing would be displaced by designating all EBSAs in the high seas as MPAs, closed to fishing? Use the most recent year (2024) of Global Fishing Watch effort, reported in apparent fishing hours.
 How many seamounts are there in the Sargasso Sea "Ecologically or Biologically Significant Marine Area" that was designated on the high seas?

--- a/headless/baseline/questions/ca-30x30.txt
+++ b/headless/baseline/questions/ca-30x30.txt
@@ -1,0 +1,2 @@
+How many acres of California land are conserved at GAP status 1 or 2?
+Which ecoregion has the most conserved acreage?

--- a/headless/baseline/questions/clarify.txt
+++ b/headless/baseline/questions/clarify.txt
@@ -1,0 +1,12 @@
+# mode=clarify — the GOLD response is to identify the ambiguity and ask a focused
+# clarifying question, NOT to silently pick an interpretation and answer.
+# These are the original ambiguous phrasings of questions whose precise variants
+# live in the per-app files. They test "ask, don't guess" and currently fail for
+# most models (they answer anyway) — a forward-looking gate tied to a guidance change.
+#
+# app=bosl-high-seas
+How much and what type of industrial fishing would be displaced by designating all EBSAs in the high seas as MPAs, closed to fishing?
+# app=tpl-ca
+Which congressional district has raised the most conservation funding through ballot measures since 2010?
+# app=wetlands
+Rank the top 10 level-3 hydrobasins by wetland extent, carbon, and NCP, normalized.

--- a/headless/baseline/questions/global-30x30.txt
+++ b/headless/baseline/questions/global-30x30.txt
@@ -1,0 +1,4 @@
+What percentage of global land is currently inside a designated protected area?
+How many people live inside existing protected areas?
+Which ecoregions are least represented in the current protected-area network?
+Show me species richness for mammals and identify the top 5 protected areas by mean richness.

--- a/headless/baseline/questions/global-30x30.txt
+++ b/headless/baseline/questions/global-30x30.txt
@@ -1,4 +1,4 @@
 What percentage of global land is currently inside a designated protected area?
 How many people live inside existing protected areas?
-Which ecoregions are least represented in the current protected-area network?
+Which ecoregions have the lowest share of their area inside a protected area? List those at approximately 0%.
 Show me species richness for mammals and identify the top 5 protected areas by mean richness.

--- a/headless/baseline/questions/tpl-ca.txt
+++ b/headless/baseline/questions/tpl-ca.txt
@@ -1,0 +1,5 @@
+Which programs and agencies have funded land conservation in Congressional District 16, and how much?
+Which congressional districts have raised the most conservation funding through ballot measures since 2010?
+Which CA congressional districts have had failed conservation ballot measures, and how much funding was at stake?
+Which Assembly districts have the most protected acreage recorded in the Conservation Almanac?
+How much has the Land and Water Conservation Fund invested in Senate District 2?

--- a/headless/baseline/questions/tpl.txt
+++ b/headless/baseline/questions/tpl.txt
@@ -1,0 +1,4 @@
+Compute the land cover composition of areas protected in the Conservation Almanac nationwide, and which states lead in protecting each cover type?
+Which Texas congressional districts recieve the mose federal funding for land conservation? Show on map
+Which New Jersey municipalities have passed conservation ballot measures, and how does the pattern of successful measures vary across the state?
+Who has funded land conservation in Boulder County, Colorado? show areas on the map.

--- a/headless/baseline/questions/wetlands.txt
+++ b/headless/baseline/questions/wetlands.txt
@@ -1,0 +1,3 @@
+Calculate vulnerable carbon stored in different wetlands of India?
+Show Ramsar sites meeting Criterion 9; explain the criterion
+Rank the top 10 level-3 hydrobasins by wetland extent, carbon, and NCP, normalized. Explain methodology and show them on map.

--- a/headless/baseline/questions/wetlands.txt
+++ b/headless/baseline/questions/wetlands.txt
@@ -1,3 +1,3 @@
 Calculate vulnerable carbon stored in different wetlands of India?
 Show Ramsar sites meeting Criterion 9; explain the criterion
-Rank the top 10 level-3 hydrobasins by wetland extent, carbon, and NCP, normalized. Explain methodology and show them on map.
+Rank the top 10 level-3 hydrobasins by wetland extent, carbon, and NCP (min-max normalize each metric to [0,1] across basins, then rank by the equal-weighted mean). Explain methodology.


### PR DESCRIPTION
Closes the core of #40. Seeds `headless/baseline/` from the open-model benchmark.

## What
- **22 analytical questions** across 7 apps, each with an **operator-verified golden answer + authoritative SQL** (`gold/<app>.md`).
- **`golden.json`** — per question: `gold` (checkable answer), `accept` (pass rule), `trap` (the rule it guards — the #42 rule-store key), `sql_ref`, and `bench_mean_acc` (first-run difficulty across 4 open models).
- `questions.txt` / `questions/<app>.txt`, `build_golden.py` (regenerator), `README.md` (gate semantics).

## Why this shape
- **Gold is operator-verified** via our own `duckdb-geo` queries — never model consensus (which can confirm a shared wrong answer).
- **Instance-level (per-question) gate**, not aggregate — aggregate hides the trap questions (#42).
- **Trap tags** link each question to #42's itemized rule store (one rule ↔ guarding question(s)).
- Encodes the **dev-MCP targeting** requirement from #40 (validation must hit `dev-duckdb-mcp`, not prod; the runner defaults to prod).

## Trap-rule seeds (hardest first)
`wet-top10-hydrobasins-composite` (0.19) · `bosl-fishing-displaced` (0.62) · `glob-least-represented-ecoregions` (0.62) · `tplca-cd-ballot-funding-2010` (0.62, statewide-measure-attribution) — the mid-pack ones are prime candidates for #42 runtime result-shape advisories.

Source: `headless/experiments/2026-06-26-or-openmodel-bench`. Grow-on-fix as new traps are found.