### PR TITLE
feat(headless): prefill/decode measurement scripts (Prometheus + OpenRouter)

### DIFF
--- a/headless/README.md
+++ b/headless/README.md
@@ -139,3 +139,31 @@ FROM read_parquet('/tmp/open-llm-proxy-logs/consolidated/**/*.parquet')
 WHERE origin = 'https://tpl.nrp-nautilus.io/agent_runner'
 ORDER BY ts;
 ```
+
+## Prefill vs. decode split from Prometheus (`prom_prefill_decode.py`)
+
+vLLM exports per-`model_name` histograms for prefill and decode time, plus
+prefix-cache counters, to `prometheus.nrp-nautilus.io`. That means the
+prefill-vs-decode **time** split is answerable straight from **production
+traffic** — no `PROXY_KEY`, no runs. `prom_prefill_decode.py` pulls the summed
+prefill/decode seconds, prompt/generation tokens, and cache hits per model over
+a window and derives the split:
+
+```bash
+python3 prom_prefill_decode.py 7d     # window; defaults to 24h
+```
+
+Columns: avg prefill/decode seconds per request, `decode ÷ prefill`,
+aggregate prefill and decode tok/s, their ratio (`rate_x` — the prefill-is-much-
+faster-than-decode factor), decode's share of LLM compute time, and prefix-cache
+hit rate. Uses only the Python stdlib (no deps).
+
+Key finding (geo-agent#282): despite prompt tokens outnumbering completion
+~43:1, **72–98% of LLM compute *time* is decode** fleet-wide, because prefill
+runs 20–500× faster per token. The workload is decode-latency-bound, not
+prefill-bound — so prefix-caching wins on *cost*, while *latency* levers are
+fewer round-trips, smaller outputs, and disabling unnecessary reasoning.
+
+Metrics used: `vllm:request_{prefill,decode}_time_seconds_{sum,count}`,
+`vllm:{prompt,generation}_tokens_total`, `vllm:prefix_cache_{hits,queries}_total`.
+Models on a non-vLLM stack (e.g. nemotron on the gb10) won't appear.

--- a/headless/README.md
+++ b/headless/README.md
@@ -167,3 +167,29 @@ fewer round-trips, smaller outputs, and disabling unnecessary reasoning.
 Metrics used: `vllm:request_{prefill,decode}_time_seconds_{sum,count}`,
 `vllm:{prompt,generation}_tokens_total`, `vllm:prefix_cache_{hits,queries}_total`.
 Models on a non-vLLM stack (e.g. nemotron on the gb10) won't appear.
+
+### Per-call split for OpenRouter models (`bench_openrouter_split.py`)
+
+Prometheus only covers our own serving stack and reports aggregates. For an
+OpenRouter-hosted model, `bench_openrouter_split.py` gets a **clean per-call**
+split from OpenRouter's `/api/v1/generation` stats — and, unlike vLLM
+Prometheus, breaks out **reasoning tokens** (the largest decode component, and
+the #283 lever):
+
+```bash
+OPENROUTER_KEY=... python3 bench_openrouter_split.py z-ai/glm-5.2
+```
+
+It sends the real geo-agent system prompt + a few analytical questions, reads
+`latency` (prefill/TTFT), `generation_time` (decode), `native_tokens_reasoning`,
+and `native_tokens_cached` per call, and runs one question reasoning-ON vs -OFF.
+
+- **Costs money** (hits OpenRouter). Keep the question list short.
+- `OPENROUTER_KEY` on-cluster = the `openrouter-key` secret. `SYS_PROMPT` overrides
+  the prompt path (defaults to the sibling `../../geo-agent/app/system-prompt.md`).
+- The generic `reasoning:{enabled:false}` flag is **provider-dependent** — it did
+  not reliably disable reasoning on glm-5.2. Verify per model.
+
+Confirms the Prometheus finding independently (57–97% of glm-5.2 wall time is
+decode) and shows reasoning is **36–106%** of output tokens — i.e. the dominant
+latency component is mostly thinking. See geo-agent#282.

--- a/headless/bench_openrouter_split.py
+++ b/headless/bench_openrouter_split.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Per-call prefill/decode split from OpenRouter generation stats (geo-agent#282).
+
+Our vLLM Prometheus metrics (`prom_prefill_decode.py`) give the fleet split, but
+only in aggregate and only for models on our own serving stack. This script gets
+a **clean per-call** split for any OpenRouter-hosted model, and — unlike vLLM
+Prometheus — breaks out **reasoning tokens**, the largest decode component:
+
+  latency                  -> time to first token   (prefill + queue)
+  generation_time          -> decode wall time
+  native_tokens_reasoning  -> hidden reasoning tokens (the #283 lever)
+  native_tokens_cached     -> prompt-cache hit
+
+It sends the real geo-agent system prompt + a few real analytical questions, then
+reads OpenRouter's `/api/v1/generation?id=` for each. Also runs one question with
+reasoning ON vs OFF to size the #283 lever (note: the generic
+`reasoning:{enabled:false}` flag is provider-dependent and may not disable on all
+models — verify per model).
+
+COST: this hits OpenRouter (paid). Keep the question list short; each call is
+~$0.001-0.01 on glm-5.2. Skips nothing silently.
+
+Env:
+  OPENROUTER_KEY   required. On-cluster: mounted from the `openrouter-key` secret.
+  SYS_PROMPT       optional path to a system prompt (default: ../../geo-agent/app/system-prompt.md).
+  MAX_TOKENS       optional completion cap (default 4000; raise to avoid truncating reasoning).
+
+Usage:  OPENROUTER_KEY=... python3 bench_openrouter_split.py [model]   # default z-ai/glm-5.2
+"""
+import os, sys, json, time, urllib.request, urllib.error
+
+KEY = os.environ.get("OPENROUTER_KEY")
+if not KEY:
+    print("OPENROUTER_KEY required (on-cluster: from the `openrouter-key` secret)", file=sys.stderr)
+    sys.exit(2)
+MODEL = sys.argv[1] if len(sys.argv) > 1 else "z-ai/glm-5.2"
+MAX_TOKENS = int(os.environ.get("MAX_TOKENS", "4000"))
+BASE = "https://openrouter.ai/api/v1"
+
+_here = os.path.dirname(os.path.abspath(__file__))
+_sys_path = os.environ.get("SYS_PROMPT", os.path.join(_here, "..", "..", "geo-agent", "app", "system-prompt.md"))
+try:
+    SYS = open(_sys_path).read()
+except OSError:
+    SYS = "You are a geospatial data analyst agent."  # fallback so the script still runs
+
+QUESTIONS = [
+    "How many acres of California land are conserved at GAP status 1 or 2?",
+    "Which ecoregion has the most conserved acreage?",
+    "Rank the top hydrobasins by species richness, normalized by basin area.",
+]
+
+def post(messages, reasoning=None):
+    body = {"model": MODEL, "messages": messages, "temperature": 0,
+            "max_tokens": MAX_TOKENS, "usage": {"include": True}}
+    if reasoning is not None:
+        body["reasoning"] = reasoning
+    req = urllib.request.Request(f"{BASE}/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"Authorization": f"Bearer {KEY}", "Content-Type": "application/json"})
+    t0 = time.time()
+    with urllib.request.urlopen(req, timeout=600) as r:
+        d = json.load(r)
+    return d, (time.time() - t0) * 1000
+
+def gen_stats(gid):
+    time.sleep(1.5)                    # let OpenRouter finalize the record
+    for _ in range(12):
+        try:
+            req = urllib.request.Request(f"{BASE}/generation?id={gid}",
+                headers={"Authorization": f"Bearer {KEY}"})
+            with urllib.request.urlopen(req, timeout=30) as r:
+                return json.load(r).get("data", {})
+        except urllib.error.HTTPError as e:
+            if e.code in (404, 429):   # not populated yet / rate-limited
+                time.sleep(3); continue
+            raise
+    return {}
+
+def run(label, messages, reasoning=None):
+    d, wall = post(messages, reasoning)
+    s = gen_stats(d["id"]) if d.get("id") else {}
+    lat = s.get("latency"); gt = s.get("generation_time")
+    pt = s.get("native_tokens_prompt") or s.get("tokens_prompt")
+    ct = s.get("native_tokens_completion") or s.get("tokens_completion")
+    rt = s.get("native_tokens_reasoning")
+    return {
+        "label": label, "wall_ms": round(wall), "prefill_ms": lat, "decode_ms": gt,
+        "decode_%time": round(100*gt/(lat+gt)) if (lat and gt) else None,
+        "prompt_tok": pt, "completion_tok": ct, "reasoning_tok": rt,
+        "reasoning_%out": round(100*rt/ct) if (rt and ct) else None,
+        "cached_tok": s.get("native_tokens_cached"),
+        "decode_tok/s": round(ct/(gt/1000), 1) if (ct and gt) else None,
+        "prefill_tok/s": round(pt/(lat/1000)) if (pt and lat) else None,
+        "cost": s.get("total_cost"),
+    }
+
+def main():
+    print(f"model: {MODEL}   max_tokens: {MAX_TOKENS}\n")
+    rows = [run(f"q{i+1}", [{"role":"system","content":SYS},{"role":"user","content":q}])
+            for i, q in enumerate(QUESTIONS)]
+    hard = [{"role":"system","content":SYS},{"role":"user","content":QUESTIONS[-1]}]
+    rows.append(run("q3-reasoning-off", hard, reasoning={"enabled": False}))
+
+    cols = ["label","prefill_ms","decode_ms","decode_%time","prompt_tok","completion_tok",
+            "reasoning_tok","reasoning_%out","cached_tok","decode_tok/s","prefill_tok/s","cost"]
+    w = {c: max(len(c), 10) for c in cols}
+    print("  ".join(c.rjust(w[c]) for c in cols))
+    print("  ".join("-"*w[c] for c in cols))
+    for r in rows:
+        print("  ".join(str(r.get(c, "")).rjust(w[c]) for c in cols))
+
+if __name__ == "__main__":
+    main()

--- a/headless/prom_prefill_decode.py
+++ b/headless/prom_prefill_decode.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Issue #282: per-model prefill-vs-decode TIME split from vLLM Prometheus metrics.
+
+Pulls, per model_name over a window, the summed prefill/decode time, prompt/gen
+tokens, and prefix-cache hits/queries, then derives the time split and the
+prefill-vs-decode *rate* ratio (the 10-100x hypothesis) and cache-hit rate.
+
+No PROXY_KEY needed — reads production serving metrics directly.
+"""
+import sys, json, urllib.parse, urllib.request
+
+PROM = "https://prometheus.nrp-nautilus.io/api/v1/query"
+WINDOW = sys.argv[1] if len(sys.argv) > 1 else "24h"
+
+def q(expr):
+    url = PROM + "?" + urllib.parse.urlencode({"query": expr})
+    with urllib.request.urlopen(url, timeout=30) as r:
+        d = json.load(r)
+    out = {}
+    for res in d.get("data", {}).get("result", []):
+        m = res["metric"].get("model_name", "?")
+        try:
+            out[m] = float(res["value"][1])
+        except (ValueError, TypeError):
+            pass
+    return out
+
+def series(metric):
+    return q(f'sum by (model_name)(increase({metric}{{}}[{WINDOW}]))')
+
+prefill_s   = series("vllm:request_prefill_time_seconds_sum")
+prefill_n   = series("vllm:request_prefill_time_seconds_count")
+decode_s    = series("vllm:request_decode_time_seconds_sum")
+decode_n    = series("vllm:request_decode_time_seconds_count")
+prompt_tok  = series("vllm:prompt_tokens_total")
+gen_tok     = series("vllm:generation_tokens_total")
+cache_hit   = series("vllm:prefix_cache_hits_total")
+cache_qry   = series("vllm:prefix_cache_queries_total")
+
+models = sorted(set(prefill_s) | set(decode_s), key=lambda m: -(decode_s.get(m, 0)))
+
+def g(d, m):
+    return d.get(m, 0.0)
+
+hdr = ("model", "reqs", "prefill_s", "decode_s", "dec/pre",
+       "prefill_tok/s", "decode_tok/s", "rate_x", "decode_%time", "cache_hit%")
+w = [34, 6, 9, 9, 7, 13, 12, 7, 12, 10]
+def row(vals):
+    print("  ".join(str(v).rjust(w[i]) for i, v in enumerate(vals)))
+
+print(f"\nvLLM prefill-vs-decode split — window={WINDOW}  (source: prometheus.nrp-nautilus.io)\n")
+row(hdr)
+row(["-"*x for x in w])
+for m in models:
+    ps, pn = g(prefill_s, m), g(prefill_n, m)
+    ds, dn = g(decode_s, m), g(decode_n, m)
+    pt, gt = g(prompt_tok, m), g(gen_tok, m)
+    ch, cq = g(cache_hit, m), g(cache_qry, m)
+    if pn < 1 and dn < 1:
+        continue
+    pre_avg = ps/pn if pn else 0
+    dec_avg = ds/dn if dn else 0
+    pre_rate = pt/ps if ps else 0          # prompt tokens processed / prefill sec
+    dec_rate = gt/ds if ds else 0          # generated tokens / decode sec
+    rate_x = pre_rate/dec_rate if dec_rate else 0
+    dec_time_pct = 100*ds/(ps+ds) if (ps+ds) else 0
+    hit = 100*ch/cq if cq else 0
+    dpr = dec_avg/pre_avg if pre_avg else 0
+    row([m[:34], int(max(pn, dn)),
+         f"{pre_avg:.2f}", f"{dec_avg:.2f}", f"{dpr:.1f}",
+         f"{pre_rate:.0f}", f"{dec_rate:.1f}", f"{rate_x:.0f}",
+         f"{dec_time_pct:.0f}%", f"{hit:.0f}%"])
+
+print("""
+Legend:
+  prefill_s / decode_s = avg seconds per request in each phase
+  dec/pre              = decode time ÷ prefill time (how decode-bound per request)
+  prefill_tok/s        = prompt tokens ÷ total prefill seconds (aggregate prefill throughput)
+  decode_tok/s         = generated tokens ÷ total decode seconds (aggregate decode throughput)
+  rate_x               = prefill_tok/s ÷ decode_tok/s  (the "10-100x" hypothesis)
+  decode_%time         = share of LLM compute time spent decoding
+  cache_hit%           = vLLM prefix-cache hit rate (prefill work we already avoid)
+""")


### PR DESCRIPTION
## What

Two scripts under `headless/` that answer the prefill-vs-decode split for [geo-agent#282](https://github.com/boettiger-lab/geo-agent/issues/282), from real traffic — no harness runs needed.

**`prom_prefill_decode.py`** — per-model split from vLLM Prometheus (`prometheus.nrp-nautilus.io`). No `PROXY_KEY`. Aggregate over a window; covers our own serving stack.
```bash
python3 headless/prom_prefill_decode.py 7d   # defaults to 24h
```

**`bench_openrouter_split.py`** — clean **per-call** split for an OpenRouter-hosted model from OpenRouter's `/generation` stats, and (unlike vLLM Prometheus) breaks out **reasoning tokens**. Costs OpenRouter credits; keep it short.
```bash
OPENROUTER_KEY=... python3 headless/bench_openrouter_split.py z-ai/glm-5.2
```

Both documented in `headless/README.md`.

## Finding (geo-agent#282)

The workload is **decode-latency-bound, not prefill-bound.**

- Prometheus, 7-day fleet: **72–98% of LLM compute *time* is decode**, despite prompt tokens outnumbering completion ~43:1 — prefill runs **20–500× faster per token**.
- OpenRouter cross-check on glm-5.2: **57–97%** of wall time is decode, and **reasoning is 36–106% of output tokens** — the dominant latency component is mostly thinking.
- Consequence: prefix-caching / memoization are **cost** levers (prefill tokens); **latency** levers are fewer round-trips, smaller outputs, and disabling unnecessary reasoning.

Models on a non-vLLM stack (nemotron/gb10) don't appear in the Prometheus path (intentionally out of scope here).