### PR TITLE
feat(headless): ENABLE_THINKING env to A/B reasoning on/off

### DIFF
--- a/headless/README.md
+++ b/headless/README.md
@@ -193,3 +193,22 @@ and `native_tokens_cached` per call, and runs one question reasoning-ON vs -OFF.
 Confirms the Prometheus finding independently (57–97% of glm-5.2 wall time is
 decode) and shows reasoning is **36–106%** of output tokens — i.e. the dominant
 latency component is mostly thinking. See geo-agent#282.
+
+### Reasoning ON/OFF runs (`ENABLE_THINKING`)
+
+Since decode (mostly reasoning) dominates latency, the payoff question is: how
+much does reasoning actually *help accuracy*, per model? To A/B it against the
+baseline, set `ENABLE_THINKING` on any `run.js` invocation — the fetch wrapper
+injects the proxy's top-level `enable_thinking` flag, which the proxy translates
+per-model (only `qwen3` / `glm-5` / `kimi` have a `thinking_key` in
+`config.json`; others silently ignore it):
+
+```bash
+ENABLE_THINKING=false node run.js "…" --model qwen3 --config … --system-prompt …   # reasoning off
+ENABLE_THINKING=true  node run.js "…" --model qwen3 …                              # reasoning on
+# unset → model default
+```
+
+Pair each mode with gold grading (`baseline/`) for an accuracy-vs-latency table.
+Pilot (qwen3, bosl seamounts Q, geo-agent#283): both modes answered correctly
+(141), reasoning-off cut LLM time ~2× (198s→98s). See geo-agent#283.

--- a/headless/run.js
+++ b/headless/run.js
@@ -86,6 +86,18 @@ function installFetchWrapper(proxyEndpoint, origin, onProxyFetch, perFetchTimeou
             headers.set('Origin', origin);
             init = { ...init, headers };
         }
+        // Reasoning on/off assessment (geo-agent#282/#283): inject the proxy's
+        // top-level `enable_thinking` flag when ENABLE_THINKING is set, so a run
+        // can be driven reasoning-ON vs -OFF without touching the agent. The
+        // proxy translates it per-model (qwen3/glm-5/kimi have a thinking_key).
+        // Unset → omit the field → model default. Only applied to proxy calls.
+        if (isProxy && process.env.ENABLE_THINKING !== undefined && init.body) {
+            try {
+                const b = JSON.parse(init.body);
+                b.enable_thinking = process.env.ENABLE_THINKING === 'true';
+                init = { ...init, body: JSON.stringify(b) };
+            } catch { /* non-JSON body; leave as-is */ }
+        }
         if (!isProxy) return originalFetch(input, init);
         const t0 = Date.now();
         try {


### PR DESCRIPTION
## What

Adds an `ENABLE_THINKING` env knob to the headless runner. When set, `run.js`'s fetch wrapper injects the proxy's top-level `enable_thinking` flag on proxy calls; the proxy translates it per-model via `thinking_key` (`qwen3`/`glm-5`/`kimi` are wired in `config.json`; others silently ignore it). Unset = model default. No change to the agent.

```bash
ENABLE_THINKING=false node run.js "…" --model qwen3 --config … --system-prompt …
ENABLE_THINKING=true  node run.js "…" --model qwen3 …
```

## Why

Decode dominates latency and decode is mostly reasoning (geo-agent#282), so the payoff question is **how much reasoning actually helps accuracy, per model**. This is the enabler for that A/B against the gold baseline (`baseline/`), feeding geo-agent#283 (opt-in disable-thinking).

## Pilot

`qwen3`, bosl-high-seas seamounts question, ON vs OFF:

| mode | answer | correct? (gold 141) | LLM time | out tok | tool calls |
|---|---|---|--:|--:|--:|
| reasoning ON | 141 | ✅ | 198.4s | 2746 | 7 |
| reasoning OFF | 141 | ✅ | 97.9s | 1751 | 7 |

Same correct answer, **~2× less LLM time** with reasoning off. n=1 — the full per-model × baseline × on/off matrix (gold-graded) is the next step; this PR just makes it runnable.

Note: gemma/gemma-small disable per the NRP docs but are **not** in the proxy's `thinking_models` config — a separate proxy-config gap worth filing.