### PR TITLE
fix(config): add gemma/gemma-small-e4b to nrp.thinking_models (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ See [Releases](README.md#releases) for how a release is cut.
 
 ## [Unreleased]
 
+### Fixed
+- **gemma/gemma-small-e4b `enable_thinking` was silently ignored (#57).** These
+  NRP models support disabling reasoning via `chat_template_kwargs={"enable_thinking":
+  false}`, but they were absent from `config.json`'s `nrp.thinking_models`, so
+  `proxy_chat` found no `thinking_key` and dropped the client's top-level
+  `enable_thinking` flag (logging `no thinking_key configured — ignoring`) — the
+  toggle appeared to work client-side but had no effect. Added `gemma` and
+  `gemma-small-e4b` with the `enable_thinking` key. Unblocks including gemma in the
+  reasoning ON/OFF assessment (#58).
+
 ### Added
 - **Standing baseline question set for guidance-change regression testing (#40).**
   New `headless/baseline/`: 22 analytical questions with operator-verified golden

--- a/config.json
+++ b/config.json
@@ -15,7 +15,9 @@
             "thinking_models": {
                 "kimi":   "thinking",
                 "qwen3":  "enable_thinking",
-                "glm-5": "enable_thinking"
+                "glm-5": "enable_thinking",
+                "gemma": "enable_thinking",
+                "gemma-small-e4b": "enable_thinking"
             }
         },
         "openrouter": {


### PR DESCRIPTION
## Fix #57

`gemma` and `gemma-small-e4b` support disabling reasoning via `chat_template_kwargs={"enable_thinking": false}` (per NRP model docs), but were absent from `config.json`'s `nrp.thinking_models`. So when a client sent the top-level `enable_thinking` flag for these models, `proxy_chat` found no `thinking_key` and **silently ignored it** (logging `no thinking_key configured — ignoring`) — the toggle appeared to work client-side but had no effect.

### Change
Added the two entries with the `enable_thinking` key:
```json
"gemma": "enable_thinking",
"gemma-small-e4b": "enable_thinking"
```

### Verification
- Keys match the exact client-sent model names the lookup uses — `thinking_models.get(request.model)` at `llm_proxy.py:510`, and `config.json`'s `nrp.models` lists `gemma` / `gemma-small-e4b`.
- `minimax-m2` / `gpt-oss` / `nemotron` are correctly left out (no toggle per the docs).
- `config.json` still parses as valid JSON.

Config-only change; no code path modified — just the lookup table `proxy_chat` reads. The proxy reads `config.json` from a fresh clone of `main` at pod boot, so this reaches prod on the next `rollout restart`.

Unblocks including gemma in the reasoning ON/OFF assessment (#58).

Closes #57.