### PR TITLE
feat(headless): ENABLE_THINKING passthrough in the k8s matrix runner (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ See [Releases](README.md#releases) for how a release is cut.
 
 ## [Unreleased]
 
+### Added
+- **`ENABLE_THINKING` passthrough in the k8s matrix runner (#58).**
+  `run-matrix-k8s.sh` now forwards an `ENABLE_THINKING` env (added to the export
+  set, the `envsubst` allowlist, and the pod env in `matrix-job.yaml`), so a
+  matrix sweep can pin reasoning on or off per pass. `run.js` (#56) turns it into
+  the top-level `enable_thinking` flag, which the proxy maps to each model's
+  `chat_template_kwargs` (qwen3/glm-5/kimi wired; gemma added in #57). Default
+  `true` is behavior-preserving (reasoning-on is already the default; models
+  without a `thinking_key` ignore it); the value is validated to `true`/`false`
+  and never left empty (an empty-but-set value would read as an explicit `false`).
+  Enables the two-pass reasoning ON/OFF assessment against the gold baseline (#58).
+
 ### Fixed
 - **gemma/gemma-small-e4b `enable_thinking` was silently ignored (#57).** These
   NRP models support disabling reasoning via `chat_template_kwargs={"enable_thinking":

--- a/headless/k8s/matrix-job.yaml
+++ b/headless/k8s/matrix-job.yaml
@@ -51,6 +51,8 @@ spec:
               value: "${MAX_TURNS}"
             - name: MODELS
               value: "${MODELS}"
+            - name: ENABLE_THINKING
+              value: "${ENABLE_THINKING}"
             - name: QUESTIONS_B64
               value: "${QUESTIONS_B64}"
             - name: SYSTEM_PROMPT_APPEND_B64

--- a/headless/run-matrix-k8s.sh
+++ b/headless/run-matrix-k8s.sh
@@ -64,6 +64,13 @@ fi
 MODELS="${MODELS:-}"
 TRIALS="${TRIALS:-2}"
 MAX_TURNS="${MAX_TURNS:-20}"
+# Reasoning on/off (open-llm-proxy#58). "true"/"false" → the proxy injects the
+# per-model enable_thinking chat_template_kwargs (qwen3/glm-5/kimi wired). Default
+# "true" is behavior-preserving: reasoning-on is already the default for those
+# models, and models without a thinking_key ignore it. Never leave empty — run.js
+# treats a set-but-empty value as an explicit (false) override.
+ENABLE_THINKING="${ENABLE_THINKING:-true}"
+case "$ENABLE_THINKING" in true|false) ;; *) echo "ERROR: ENABLE_THINKING must be 'true' or 'false' (got: '$ENABLE_THINKING')" >&2; exit 2;; esac
 APP_BRANCH="${APP_BRANCH:-main}"
 GEO_AGENT_BRANCH="${GEO_AGENT_BRANCH:-main}"
 NAMESPACE="${NAMESPACE:-biodiversity}"
@@ -84,12 +91,12 @@ if [ -n "${SYSTEM_PROMPT_APPEND_FILE:-}" ]; then
 fi
 
 export APP_REPO APP_BRANCH GEO_AGENT_BRANCH APP_NAME JOB_NAME ORIGIN TAG TRIALS MAX_TURNS MODELS \
-    QUESTIONS_B64 SYSTEM_PROMPT_APPEND_B64
+    QUESTIONS_B64 SYSTEM_PROMPT_APPEND_B64 ENABLE_THINKING
 
 # Allowlist: only these placeholders are substituted. Without this, envsubst
 # also replaces every $VAR reference in the bash script body (e.g. $QFILE,
 # $PROXY_KEY, $rc) with empty strings, breaking the pod at runtime.
-envsubst '${APP_REPO} ${APP_BRANCH} ${GEO_AGENT_BRANCH} ${APP_NAME} ${JOB_NAME} ${ORIGIN} ${TAG} ${TRIALS} ${MAX_TURNS} ${MODELS} ${QUESTIONS_B64} ${SYSTEM_PROMPT_APPEND_B64}' \
+envsubst '${APP_REPO} ${APP_BRANCH} ${GEO_AGENT_BRANCH} ${APP_NAME} ${JOB_NAME} ${ORIGIN} ${TAG} ${TRIALS} ${MAX_TURNS} ${MODELS} ${QUESTIONS_B64} ${SYSTEM_PROMPT_APPEND_B64} ${ENABLE_THINKING}' \
     < k8s/matrix-job.yaml | kubectl -n "$NAMESPACE" create -f -
 
 cat <<EOF


### PR DESCRIPTION
## Enabler for the reasoning ON/OFF assessment (#58)

Prerequisite #2 of #58: wire `ENABLE_THINKING` through the cluster matrix runner so a sweep can pin reasoning on or off per pass.

### Change
- `run-matrix-k8s.sh`: read `ENABLE_THINKING` (default `true`), validate it's `true`/`false`, add it to the `export` set **and the `envsubst` allowlist**.
- `matrix-job.yaml`: add `ENABLE_THINKING` to the pod env.

`run.js` (#56, merged) turns the env into the top-level `enable_thinking` flag; the proxy maps it to each model's `chat_template_kwargs` (qwen3/glm-5/kimi wired; gemma added in #57/#59).

### Safety
- **Behavior-preserving default.** `true` = reasoning-on, already the default for these models; models without a `thinking_key` ignore the flag.
- **Never empty.** `run.js` treats a *set-but-empty* value as an explicit `false` override, so the runner defaults to `true` and rejects anything other than `true`/`false` (exit 2).
- The `envsubst` allowlist addition is required — otherwise envsubst would blank every `$VAR` in the pod script body.

### Notes
- Cherry-picked from the local `feat/reasoning-matrix` WIP branch (rebased clean onto current `main`); no dependency on the closed #50 transcript-capture branch, which edits the same two lines and will need a trivial allowlist merge if it's ever revived.
- `bash -n` clean.

Usage (two passes, distinct tags):
```bash
ENABLE_THINKING=true  TAG=think-on  QUESTIONS_FILE=baseline/questions/<app>.txt MODELS="qwen3 glm-5 kimi" ./headless/run-matrix-k8s.sh boettiger-lab/<app>
ENABLE_THINKING=false TAG=think-off QUESTIONS_FILE=baseline/questions/<app>.txt MODELS="qwen3 glm-5 kimi" ./headless/run-matrix-k8s.sh boettiger-lab/<app>
```

Part of #58.