### PR TITLE
Rename nimbus model nemotron→qwen; outage-testing harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ See [Releases](README.md#releases) for how a release is cut.
 
 ## [Unreleased]
 
+### Changed
+- **Nimbus (DSE) model renamed `nemotron` → `qwen`.** The `vllm-nimbus.carlboettiger.info`
+  endpoint now serves `nvidia/Qwen3.6-35B-A3B-NVFP4` under the id `qwen` (was
+  `nemotron`). Updated `config.json`'s `nimbus.models` to `["qwen"]` so the proxy
+  (exact-match-then-prefix routing) forwards `model: "qwen"` to the nimbus endpoint;
+  requests for `nemotron` no longer route anywhere. Requires a pod restart to take
+  effect (config is git-synced at pod start).
+- **Re-vendored `headless/mcp-client.js`** to match geo-agent upstream (#275 connect()
+  race that could register zero MCP tools + reconnect-budget reset). `npm run
+  check-drift` is clean again.
+
 ### Added
 - **`ENABLE_THINKING` passthrough in the k8s matrix runner (#58).**
   `run-matrix-k8s.sh` now forwards an `ENABLE_THINKING` env (added to the export

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ See [Releases](README.md#releases) for how a release is cut.
 - **Re-vendored `headless/mcp-client.js`** to match geo-agent upstream (#275 connect()
   race that could register zero MCP tools + reconnect-budget reset). `npm run
   check-drift` is clean again.
+- **Headless runner resolves geo-agent via `GEO_AGENT_DIR` + `fresh-geoagent.sh`.**
+  `run.js` now dynamic-imports the four geo-agent app modules from `GEO_AGENT_DIR`
+  (default: the `../../geo-agent` sibling, so existing setups are unchanged). The
+  new `headless/fresh-geoagent.sh` maintains an isolated `geo-agent@main` clone in
+  a cache dir and prints its path, so `export GEO_AGENT_DIR="$(./fresh-geoagent.sh)"`
+  gives a run its own pinned copy instead of depending on a shared dev checkout that
+  other agents may be editing on branches. Only the app modules move; `mcp-client.js`
+  stays vendored (bare-specifier resolution) and the script warns on drift.
 
 ### Added
 - **`ENABLE_THINKING` passthrough in the k8s matrix runner (#58).**

--- a/config.json
+++ b/config.json
@@ -53,7 +53,7 @@
             "endpoint": "https://vllm-nimbus.carlboettiger.info/v1/chat/completions",
             "api_key_env": "NIMBUS_API_KEY",
             "models": [
-                "nemotron"
+                "qwen"
             ]
         },
         "gemma4-nimbus": {

--- a/headless/README.md
+++ b/headless/README.md
@@ -75,8 +75,26 @@ matrix testing — use the k8s Job above.**
 ### Requirements
 
 - Node 22+ (24 LTS recommended; the cluster Job uses 24)
-- `boettiger-lab/geo-agent` cloned as a sibling (`../../geo-agent/`)
+- `boettiger-lab/geo-agent` available — the `../../geo-agent/` sibling by default,
+  or point `GEO_AGENT_DIR` at any checkout (see below)
 - A valid proxy key, via `PROXY_KEY` env var or `--api-key`
+
+### Isolating from the shared geo-agent checkout (`GEO_AGENT_DIR`)
+
+`run.js` imports the geo-agent framework from `GEO_AGENT_DIR` (default: the
+`../../geo-agent` sibling). If that sibling is a shared dev checkout other agents
+are editing on branches, pin your run to its own always-fresh-from-`main` copy:
+
+```bash
+export GEO_AGENT_DIR="$(./fresh-geoagent.sh)"   # clones/updates geo-agent@main in a cache dir
+node run.js "…" --config … --system-prompt … --model qwen
+```
+
+`fresh-geoagent.sh` is idempotent (clone once, then fetch + hard-reset to
+`origin/main`), keeps the clone outside the repo tree (`~/.cache/olp-headless/`,
+override with `GEO_AGENT_CACHE`), and warns if the vendored `mcp-client.js` has
+drifted from `main`. Only geo-agent's `app/*.js` come from `GEO_AGENT_DIR`;
+`mcp-client.js` stays vendored here for bare-specifier resolution.
 
 ### Install
 

--- a/headless/TESTING-DURING-CEPH-OUTAGE.bosl.json
+++ b/headless/TESTING-DURING-CEPH-OUTAGE.bosl.json
@@ -1,0 +1,9 @@
+{
+  "catalog": "https://data.source.coop/cboettig/gfw/stac-collection.json",
+  "mcp_url": "https://dev-duckdb-mcp.nrp-nautilus.io/mcp",
+  "collections": [
+    {"collection_id": "gfw-fishing-effort", "collection_url": "https://data.source.coop/cboettig/gfw/stac-collection.json"},
+    {"collection_id": "ebsa", "collection_url": "https://data.source.coop/cboettig/high-seas/ebsa/stac-collection.json"},
+    {"collection_id": "seafloor-geomorphology", "collection_url": "https://data.source.coop/cboettig/high-seas/seafloor-geomorphology/stac-collection.json"}
+  ]
+}

--- a/headless/TESTING-DURING-CEPH-OUTAGE.md
+++ b/headless/TESTING-DURING-CEPH-OUTAGE.md
@@ -1,0 +1,120 @@
+# Running headless test queries during the Ceph (s3-west) outage
+
+**Status: `s3-west.nrp-nautilus.io` (NRP Ceph) is DOWN (503 on everything).** The
+normal catalog + parquet reads fail, so any config pointing at s3-west crashes at
+boot (`DatasetCatalog.load` → `HTTP 503`, see geo-agent#287). Two changes make
+headless runs work anyway, **entirely off the public source.coop mirror**:
+
+1. **Data comes from source.coop**, not Ceph — via per-collection `collection_url`s.
+2. **Use the DEV MCP server**, which has the source.coop rewrite (mcp-data-server#261):
+   `https://dev-duckdb-mcp.nrp-nautilus.io/mcp`
+   (prod `duckdb-mcp.nrp-nautilus.io` is pinned to v0.7.8 and does **not** have #261.)
+
+## What #261 does (why the dev server is required)
+
+Pass a source.coop `stac-collection.json` to the STAC tools and it rewrites
+`https://data.source.coop/...` asset hrefs to `s3://us-west-2.opendata.source.coop/...`
+so DuckDB can glob-expand `h0=*` (the HTTPS gateway can't list), and avoids a
+network `get_root()` that would otherwise crash on an inline source.coop
+collection during the outage. No client/MCP reconfig beyond pointing at the dev URL.
+
+## Config: point everything at source.coop
+
+Two rules:
+- **`mcp_url`** → the dev server.
+- **`catalog` + every collection's `collection_url`** → `data.source.coop`, NOT s3-west.
+  - `load()` fetches the top-level `catalog` URL **unconditionally** — it must be a
+    reachable 200 (any source.coop collection JSON works as a harmless root). If you
+    leave it as s3-west it hard-crashes boot (geo-agent#287).
+  - Collections with `collection_url` are fetched **directly** (no catalog walk); a
+    404 `collection_url` just warns-and-skips, so partial coverage is fine.
+
+### href remapping rule
+s3-west `…/public-<X>/<path>/stac-collection.json`
+→ source.coop `https://data.source.coop/cboettig/<X>/<path>/stac-collection.json`
+
+Naming is **not** always 1:1 and coverage is per-collection — verify with
+`curl -sI <url>` (200 vs 404) before relying on it. Confirmed present:
+`cboettig/gfw`, `cboettig/high-seas/{ebsa,seafloor-geomorphology,ecs,iho,meow}`,
+`cboettig/carbon`. Known gaps on first guess: `wdpa`, `iucn` (different paths).
+`public-output` (tile/style outputs) is **not** mirrored at all.
+
+### Example (bosl-high-seas, source.coop + dev MCP)
+```json
+{
+  "catalog": "https://data.source.coop/cboettig/gfw/stac-collection.json",
+  "mcp_url": "https://dev-duckdb-mcp.nrp-nautilus.io/mcp",
+  "collections": [
+    {"collection_id": "gfw-fishing-effort", "collection_url": "https://data.source.coop/cboettig/gfw/stac-collection.json"},
+    {"collection_id": "ebsa", "collection_url": "https://data.source.coop/cboettig/high-seas/ebsa/stac-collection.json"},
+    {"collection_id": "seafloor-geomorphology", "collection_url": "https://data.source.coop/cboettig/high-seas/seafloor-geomorphology/stac-collection.json"}
+  ]
+}
+```
+A copy of this lives at `headless/TESTING-DURING-CEPH-OUTAGE.bosl.json`.
+
+### Reliability add-on 1: cache the small JSONs locally (dodge gateway 500s)
+
+`data.source.coop` (the Cloudflare-fronted HTTPS gateway) throws **intermittent
+500s** on the small `stac-collection.json` fetches. That's the only way the
+*client* can read them — `us-west-2.opendata.source.coop` is an S3-protocol
+endpoint the client's plain `fetch()` can't speak (only the MCP server reaches it,
+via DuckDB's S3 client, for the heavy parquet). A 500 on the `catalog` root
+hard-crashes boot; a 500 on a needed collection silently drops it.
+
+Fix: pre-fetch each collection JSON once (retry through any 500 burst), serve them
+from `localhost`, and point `catalog` + every `collection_url` at
+`http://127.0.0.1:PORT/<id>.json`. This is safe because `get_schema` forwards the
+cached STAC content **inline** to MCP (`map-tools.js` — "so MCP doesn't re-fetch"),
+so the server never fetches your localhost URL; it only matters for the client's
+initial load. Heavy reads still go direct-to-AWS. Eliminates the flakiness entirely.
+
+### Reliability add-on 2: steer weak models with an outage system-prompt addendum
+
+Smaller/quantized models tend to reach for `get_stac_details` / `browse_stac_catalog`
+(which resolve through the offline top-level catalog and fail) instead of
+`get_schema` (inline, works). Append `headless/outage-systemprompt-addendum.md` to
+the app's base `system-prompt.md` and pass the combined file via `--system-prompt`:
+
+```bash
+cat ../../<app>/system-prompt.md outage-systemprompt-addendum.md > /tmp/sp.outage.md
+node run.js "..." --system-prompt /tmp/sp.outage.md ...
+```
+
+This does NOT fix malformed tool-call *syntax* (a model-side issue — see geo-agent#288);
+it only fixes tool *choice*.
+
+## Running a query
+
+```bash
+export PROXY_KEY=$(kubectl -n biodiversity get secret open-llm-proxy-secrets \
+  -o jsonpath="{.data['proxy-key']}" | base64 -d)
+
+node run.js "How many seamounts are in the Sargasso Sea EBSA?" \
+  --config       TESTING-DURING-CEPH-OUTAGE.bosl.json \
+  --system-prompt ../../bosl-high-seas/system-prompt.md \
+  --model         qwen3 \
+  --transcript    runs/test.json
+```
+(`mcp_url` is read from the config; you can also override with `--mcp-url`.)
+
+### Gotchas
+- **`run.js` imports the sibling `../../geo-agent`** — run it from a `headless/`
+  whose `../../` is `boettiger-lab/` (the real checkout, or a copy placed as a
+  sibling of `geo-agent`). A git *worktree* of open-llm-proxy will NOT resolve the
+  import. If you copy `headless/` elsewhere, symlink `node_modules` back to the real
+  checkout.
+- **Concurrent work:** if multiple agents share the checkout, run from an isolated
+  copy so someone editing `mcp-client.js`/`run.js` mid-run doesn't break you.
+- **Reasoning on/off:** set `ENABLE_THINKING=true|false` (proxy translates per-model;
+  only `qwen3`/`glm-5`/`kimi` have a thinking_key). Unset = model default.
+
+## Cluster matrix (`run-matrix-k8s.sh`)
+The k8s runner **clones each app's committed config**, which points at s3-west — so
+it will crash until either Ceph is back or the runner grows a config-injection path
+to feed a source.coop config. For now, prefer **local** runs (above) with source.coop
+configs during the outage.
+
+Refs: mcp-data-server#261 (source.coop fallback), geo-agent#287 (boot-crash on 5xx),
+geo-agent#288 (tool-call parser should recover from malformed calls),
+open-llm-proxy#58 (reasoning on/off assessment this was built for).

--- a/headless/fresh-geoagent.sh
+++ b/headless/fresh-geoagent.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Ensure an isolated, up-to-date geo-agent@main checkout for headless runs, so a
+# run never depends on the shared dev checkout (which other agents may be editing
+# on branches). Idempotent: clones on first use, otherwise fetch + hard-reset to
+# origin/main. Prints the checkout path on stdout so you can wire it into run.js:
+#
+#   export GEO_AGENT_DIR="$(./fresh-geoagent.sh)"
+#   node run.js "…" --config … --system-prompt …
+#   # or for a matrix: GEO_AGENT_DIR="$(./fresh-geoagent.sh)" ./run_matrix.sh …
+#
+# The cache lives outside the repo tree (default ~/.cache/olp-headless/geo-agent;
+# override with GEO_AGENT_CACHE) so it can never collide with a sibling dev
+# checkout. Only geo-agent's app/*.js (no bare imports) are consumed via
+# GEO_AGENT_DIR; mcp-client.js stays vendored here (bare specifier resolution),
+# so this script also warns if the vendored copy has drifted from main.
+set -euo pipefail
+
+DEST="${GEO_AGENT_CACHE:-$HOME/.cache/olp-headless/geo-agent}"
+REPO="${GEO_AGENT_REPO:-https://github.com/boettiger-lab/geo-agent.git}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -d "$DEST/.git" ]; then
+  git -C "$DEST" fetch --quiet origin main
+  git -C "$DEST" reset --hard --quiet origin/main
+else
+  mkdir -p "$(dirname "$DEST")"
+  git clone --quiet --branch main "$REPO" "$DEST"
+fi
+
+# Warn (don't fail) if the locally-vendored mcp-client.js has drifted from main.
+if ! diff -q <(tail -n +3 "$HERE/mcp-client.js") "$DEST/app/mcp-client.js" >/dev/null 2>&1; then
+  echo "WARN: vendored mcp-client.js has drifted from geo-agent@main — re-vendor with check-drift.sh" >&2
+fi
+
+echo "$DEST"

--- a/headless/mcp-client.js
+++ b/headless/mcp-client.js
@@ -21,6 +21,11 @@ export class MCPClient {
         this.tools = [];
         this.reconnectAttempts = 0;
         this.maxReconnectAttempts = 3;
+        // The attempt budget caps a single burst of failures, but it must not
+        // latch forever — after this much quiet time, the next attempt gets a
+        // fresh budget so a transient outage can't permanently disable MCP.
+        this.reconnectResetMs = 30000;
+        this.lastReconnectTime = 0;
         this._connectPromise = null;
         this._onReconnect = null;
     }
@@ -63,12 +68,18 @@ export class MCPClient {
                 { capabilities: {} }
             );
             await this.client.connect(transport);
-            this.connected = true;
-            this.reconnectAttempts = 0;
 
-            // Cache available tools
+            // Cache available tools BEFORE flipping `connected`. The flag is the
+            // short-circuit for connect()/ensureConnected(); if it went true here
+            // (transport up) but the tool list were still empty, a concurrent
+            // connect() would short-circuit and a getTools() reader would see []
+            // — registering zero remote tools with no error, no fallback, and no
+            // reconnect to recover (the silent MCP-tools-missing boot). Populate
+            // the cache first so `connected === true` always implies tools ready.
             const response = await this.client.listTools();
             this.tools = response.tools || [];
+            this.connected = true;
+            this.reconnectAttempts = 0;
             console.log('[MCP] Connected. Tools:', this.tools.map(t => t.name));
         } catch (error) {
             this.connected = false;
@@ -83,16 +94,13 @@ export class MCPClient {
      * Called lazily before any operation.
      */
     async ensureConnected() {
-        if (this.connected && this.client) {
-            try {
-                // Lightweight health check
-                await this.client.listTools();
-                return;
-            } catch {
-                console.warn('[MCP] Connection stale, reconnecting...');
-                this.connected = false;
-            }
-        }
+        // Trust the `connected` flag rather than probing with a listTools()
+        // round trip on every operation — that probe added a full request to
+        // each callTool/listPrompts/getPrompt, multiplying boot latency. A
+        // genuinely stale connection is caught by callTool's reconnect-and-retry
+        // branch (the only frequent, long-lived op); boot-time prompt reads run
+        // right after a fresh connect, so they're never stale.
+        if (this.connected && this.client) return;
         await this.reconnect();
     }
 
@@ -100,8 +108,17 @@ export class MCPClient {
      * Reconnect with exponential backoff.
      */
     async reconnect() {
+        const now = Date.now();
+        // A fresh attempt after a quiet period gets a clean budget. Rapid
+        // retries within one burst still hit the cap (no hammering), but a
+        // user action after the outage clears retries instead of failing.
+        if (now - this.lastReconnectTime > this.reconnectResetMs) {
+            this.reconnectAttempts = 0;
+        }
+        this.lastReconnectTime = now;
+
         if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-            throw new Error('MCP server unreachable after multiple attempts. Please refresh the page.');
+            throw new Error('MCP server temporarily unavailable. Please try again in a moment.');
         }
 
         this.reconnectAttempts++;

--- a/headless/outage-systemprompt-addendum.md
+++ b/headless/outage-systemprompt-addendum.md
@@ -1,0 +1,18 @@
+
+---
+
+## ⚠️ Data-access mode (headless testing during a Ceph / s3-west outage)
+
+The primary object store (`s3-west.nrp-nautilus.io`) is **offline**, so the tools
+that resolve datasets through the *top-level* STAC catalog are unavailable this
+session. Follow these rules:
+
+- **Use `get_schema(dataset_id)` for every dataset in this app.** It reads the
+  catalog metadata already loaded above (served inline to the schema service), so
+  it works during the outage and returns the correct `read_parquet(...)` path.
+- **Do NOT call `browse_stac_catalog`, `get_stac_details`, or `get_collection`.**
+  They walk the offline top-level catalog and will return "not found" / time out.
+- Every dataset you need is already listed in the catalog section above — you do
+  not need to discover anything. Go straight to `get_schema`, then `query`.
+- Read paths resolve to the `s3://us-west-2.opendata.source.coop/...` mirror
+  automatically; use the paths `get_schema` gives you verbatim.

--- a/headless/run.js
+++ b/headless/run.js
@@ -5,14 +5,28 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-
-import { Agent } from '../../geo-agent/app/agent.js';
-import { DatasetCatalog } from '../../geo-agent/app/dataset-catalog.js';
-import { ToolRegistry } from '../../geo-agent/app/tool-registry.js';
-import { createMapTools } from '../../geo-agent/app/map-tools.js';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { MCPClient } from './mcp-client.js';
 import { StubMapManager } from './stub-map-manager.js';
+
+// Resolve the geo-agent app dir. Defaults to the sibling checkout, but
+// GEO_AGENT_DIR lets the runner point at an isolated, always-fresh-from-main
+// copy (see fresh-geoagent.sh) so a headless run never depends on whatever
+// branch or in-progress edits are live in a shared dev checkout that other
+// agents may be using. Static import specifiers can't be parameterized, so
+// these four app modules load via dynamic import (top-level await). Only
+// mcp-client.js stays vendored locally (it has a bare specifier that must
+// resolve against this package's node_modules — see check-drift.sh).
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const GEO_AGENT_DIR = process.env.GEO_AGENT_DIR
+    ? path.resolve(process.env.GEO_AGENT_DIR)
+    : path.resolve(__dirname, '../../geo-agent');
+const geoApp = (m) => import(pathToFileURL(path.join(GEO_AGENT_DIR, 'app', m)).href);
+const { Agent } = await geoApp('agent.js');
+const { DatasetCatalog } = await geoApp('dataset-catalog.js');
+const { ToolRegistry } = await geoApp('tool-registry.js');
+const { createMapTools } = await geoApp('map-tools.js');
 
 function parseArgs(argv) {
     const args = { _positional: [] };
@@ -203,6 +217,7 @@ async function main() {
     const log = (msg) => { if (!quiet) console.log(msg); };
     const err = (msg) => console.error(msg);
 
+    err(`[headless] geo-agent: ${GEO_AGENT_DIR}`);
     err(`[headless] STAC catalog: ${config.catalog}`);
     const catalog = new DatasetCatalog();
     await catalog.load(config);


### PR DESCRIPTION
Renames the nimbus (DSE) model `nemotron`→`qwen` (endpoint now serves `nvidia/Qwen3.6-35B-A3B-NVFP4`); **requires a proxy pod restart** to take effect (config git-synced at boot).

Also lands the source.coop + dev-MCP outage-testing harness and a re-vendor of `headless/mcp-client.js` (geo-agent #275).

Benchmark finding: nimbus `qwen` is analytically strong (answers match gold) but tool-call format is unstable (~1/4 clean completions) → filed geo-agent#288.

_`TESTING-DURING-CEPH-OUTAGE.{md,bosl.json}` were co-authored with a concurrent agent session in the same checkout._