### PR TITLE
Honor enable_thinking on nimbus qwen + log its reasoning trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,18 @@ See [Releases](README.md#releases) for how a release is cut.
   Enables the two-pass reasoning ON/OFF assessment against the gold baseline (#58).
 
 ### Fixed
+- **nimbus `qwen` ignored `enable_thinking`; its reasoning trace wasn't logged (#66).**
+  Two fixes for the direct nimbus vLLM endpoint (`nvidia/Qwen3.6-35B-A3B-NVFP4`):
+  (1) added `nimbus.thinking_models = {"qwen": "enable_thinking"}` to `config.json` —
+  the block had no `thinking_models`, so `proxy_chat` dropped the client's
+  `enable_thinking` flag (`no thinking_key configured — ignoring`) and the endpoint
+  reasoned regardless. Verified against the endpoint: `chat_template_kwargs=
+  {"enable_thinking": false}` suppresses the trace, `true` restores it. (2) `log_response`
+  now reads `message.reasoning_content or message.reasoning` — nimbus emits the trace
+  under `reasoning` (not `reasoning_content` like NRP), so `has_reasoning_content` /
+  `reasoning_content` were empty for nimbus even when it clearly reasoned. Pairs with
+  the request-side `enable_thinking` column (#64) to make requested-vs-observed reasoning
+  analyzable for nimbus. Requires a pod restart (config git-synced at boot).
 - **gemma/gemma-small-e4b `enable_thinking` was silently ignored (#57).** These
   NRP models support disabling reasoning via `chat_template_kwargs={"enable_thinking":
   false}`, but they were absent from `config.json`'s `nrp.thinking_models`, so

--- a/config.json
+++ b/config.json
@@ -54,7 +54,10 @@
             "api_key_env": "NIMBUS_API_KEY",
             "models": [
                 "qwen"
-            ]
+            ],
+            "thinking_models": {
+                "qwen": "enable_thinking"
+            }
         },
         "gemma4-nimbus": {
             "endpoint": "https://gemma4-nimbus.carlboettiger.info/v1/chat/completions",

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -407,10 +407,15 @@ def log_response(provider: str, model: str, response_data: dict, latency_ms: int
         if "choices" in response_data and len(response_data["choices"]) > 0:
             message = response_data["choices"][0].get("message", {})
             content = _scrub_text(message.get("content") or "")
-            reasoning = _scrub_text(message.get("reasoning_content") or "")
+            # Reasoning trace field name is provider-dependent: NRP ellm (qwen3 etc.)
+            # emits `reasoning_content`; the nimbus vLLM endpoint emits `reasoning`.
+            # Prefer `reasoning_content`, fall back to `reasoning`, so the trace is
+            # captured (and `has_reasoning_content` is accurate) for both (#66).
+            raw_reasoning = message.get("reasoning_content") or message.get("reasoning")
+            reasoning = _scrub_text(raw_reasoning or "")
             log_entry["has_content"] = bool(message.get("content"))
             log_entry["has_tool_calls"] = bool(message.get("tool_calls"))
-            log_entry["has_reasoning_content"] = bool(message.get("reasoning_content"))
+            log_entry["has_reasoning_content"] = bool(raw_reasoning)
             # Full (scrubbed) response — this is the training target, no longer
             # truncated. *_preview kept for cheap kubectl/SQL scans (back-compat).
             log_entry["content"] = _cap(content, _CONTENT_MAX)

--- a/test_logging.py
+++ b/test_logging.py
@@ -69,6 +69,34 @@ def test_response_content_not_truncated_and_scrubbed():
     assert len(entry["content_preview"]) <= 200    # preview still capped
 
 
+def test_reasoning_field_fallback_for_nimbus():
+    # #66: NRP emits `reasoning_content`; the nimbus vLLM endpoint emits `reasoning`.
+    # Both must set has_reasoning_content and land in the reasoning_content column.
+    p = _reload(LOG_CONTENT_MAX="0")
+    # nimbus-style: trace under `reasoning`, no `reasoning_content`
+    p._log_buffer.clear()
+    p.log_response("nimbus", "qwen",
+                   {"choices": [{"message": {"content": "answer", "reasoning": "R" * 300}}]},
+                   10, request_id="n1")
+    e = p._log_buffer[-1]
+    assert e["has_reasoning_content"] is True
+    assert e["reasoning_content"].startswith("R")
+    # NRP-style still works, and reasoning_content wins if both are present
+    p._log_buffer.clear()
+    p.log_response("nrp", "qwen3",
+                   {"choices": [{"message": {"content": "answer",
+                                             "reasoning_content": "PREFERRED", "reasoning": "IGNORED"}}]},
+                   10, request_id="r1")
+    e = p._log_buffer[-1]
+    assert e["has_reasoning_content"] is True
+    assert e["reasoning_content"] == "PREFERRED"
+    # No reasoning at all → flag false
+    p._log_buffer.clear()
+    p.log_response("nimbus", "qwen",
+                   {"choices": [{"message": {"content": "answer"}}]}, 10, request_id="p1")
+    assert p._log_buffer[-1]["has_reasoning_content"] is False
+
+
 def test_reasoning_capped_independently_of_content():
     # Middle ground: full final answer + full tool calls, but bounded reasoning.
     p = _reload(LOG_CONTENT_MAX="0", LOG_REASONING_MAX="100")


### PR DESCRIPTION
Closes #66.

## What

Two fixes for the direct nimbus vLLM endpoint (`nvidia/Qwen3.6-35B-A3B-NVFP4`), both verified against the live endpoint:

1. **`config.json`** — add `nimbus.thinking_models = {"qwen": "enable_thinking"}`. The nimbus block had no `thinking_models`, so `proxy_chat` found no `thinking_key` and dropped the client's `enable_thinking` flag (logging `no thinking_key configured — ignoring`); the endpoint reasoned regardless of the request.
2. **`log_response`** — read `message.reasoning_content or message.reasoning`. nimbus returns the trace under `reasoning`, not `reasoning_content` (as NRP does), so `has_reasoning_content`/`reasoning_content` were empty for nimbus even when it clearly reasoned. Prefer `reasoning_content`, fall back to `reasoning` — covers both providers.

## Verification (direct calls to the endpoint)

`model qwen`, prompt *"What is 17 * 23? Think step by step…"*, `max_tokens:250`:

| request | `reasoning` field | `content` | result |
|---|---|---|---|
| baseline (no kwarg) | present | `null` | reasoning **ON by default** |
| `chat_template_kwargs={"enable_thinking":false}` | `None` | populated | **suppressed ✓** |
| `chat_template_kwargs={"enable_thinking":true}` | present | `null` | ON ✓ |

With fix (1) the proxy sends exactly `chat_template_kwargs={"enable_thinking": false}` — the request confirmed to suppress reasoning. The table also shows the trace arrives under `reasoning`, which is what fix (2) addresses.

- `python -m pytest test_logging.py` → **22 passed** (1 new: `reasoning` fallback, `reasoning_content` precedence, and no-reasoning → flag false).
- `config.json` valid JSON; `llm_proxy.py` compiles.

## Deploy note

Config is git-synced at pod boot, so this needs a proxy pod **restart** to take effect (same as the nimbus rename in #62). `log_response` change ships in the same restart (app code git-cloned at boot). No cron/schema changes. No ceph dependency.

## Out of scope

`gemma4-nimbus` also lacks `thinking_models`; left alone until there's a need for reasoning control there (the model may not even be a thinking model). Noted in #66.