### PR TITLE
feat(config): add qwen3-cirrus self-hosted provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ See [Releases](README.md#releases) for how a release is cut.
   stays vendored (bare-specifier resolution) and the script warns on drift.
 
 ### Added
+- **New self-hosted provider `qwen3-cirrus`.** Adds the `qwen3-cirrus.carlboettiger.info`
+  endpoint (qwen3 on the local k3s / cirrus host) to `config.json` under the model id
+  `qwen3-cirrus` — distinct from nrp's `qwen3` and nimbus's `qwen` so the proxy's
+  exact-match-then-prefix routing forwards it unambiguously. Reuses `NIMBUS_API_KEY`
+  (same as the other `carlboettiger.info` vLLM endpoints) and is marked thinking-capable
+  (`enable_thinking`). Requires a pod restart to take effect (config is git-synced at
+  pod start).
 - **Log the requested thinking mode `enable_thinking` (#64).** `log_request` now
   records `request.enable_thinking` — the mode the client **asked for** — alongside
   the existing response-side `has_reasoning_content`/`reasoning_content` (what the

--- a/config.json
+++ b/config.json
@@ -65,6 +65,16 @@
             "models": [
                 "gemma4"
             ]
+        },
+        "qwen3-cirrus": {
+            "endpoint": "https://qwen3-cirrus.carlboettiger.info/v1/chat/completions",
+            "api_key_env": "NIMBUS_API_KEY",
+            "models": [
+                "qwen3-cirrus"
+            ],
+            "thinking_models": {
+                "qwen3-cirrus": "enable_thinking"
+            }
         }
     }
 }


### PR DESCRIPTION
Adds the `qwen3-cirrus.carlboettiger.info` endpoint (qwen3 on the local k3s / cirrus host) to `config.json` as a new provider.

## Details
- **Model id `qwen3-cirrus`** — distinct from nrp's `qwen3` and nimbus's `qwen`, so the proxy's exact-match-then-prefix routing (`llm_proxy.py:304`) forwards it unambiguously.
- **Reuses `NIMBUS_API_KEY`** — same as the other `carlboettiger.info` vLLM endpoints (`nimbus`, `gemma4-nimbus`); already wired into `deployment.yaml`, so no secret/deployment change needed.
- **Thinking-capable** (`enable_thinking`), like nrp's `qwen3` and nimbus's `qwen`.

## Deploy note
Config is git-synced at pod start, so this needs a **pod restart** on the NRP cluster (`biodiversity` namespace) to take effect. kubectl on the dev machine does not reach that cluster.

## Assumptions to confirm
- The served model registers under id `qwen3-cirrus`. If the vLLM server uses a different id, the `models` list needs adjusting.
- If the endpoint needs a different API key than the shared `NIMBUS_API_KEY`, a new env var + secret ref is required.