### PR TITLE
fix(proxy): stop force-sending temperature to models that reject it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ This is an LLM proxy service that routes chat completion requests to NRP, OpenRo
 
 > **Track changes.** Behavior/config/ops changes should add a [CHANGELOG.md](CHANGELOG.md) entry under `## [Unreleased]`; see [README → Releases](README.md#releases) for the (SemVer) release process.
 
+> **Use a git worktree — never build on top of another branch's active work.** The primary checkout is frequently mid-edit on some feature branch (uncommitted changes, a branch based on a stale `main`). Do **not** make your edits there: you'll tangle your change with unrelated work, and if that branch is behind `main` you can silently *revert* already-merged commits when you ship. For any change, start clean: `git worktree add <path> -b <branch> origin/main` (fetch first), edit there, PR to `main`. This keeps your diff minimal and based on current `main`.
+
 > **CORS gotcha:** browser CORS is enforced by the **haproxy ingress** (`ingress.yaml` annotations), *not* the app's `CORSMiddleware` (which is effectively dead config). `cors-allow-headers` is an explicit list — a new custom request header (e.g. `X-Client`) must be added there or the browser preflight blocks the whole request. See the comment in `ingress.yaml`.
 
 ## Evaluating Logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,17 @@ See [Releases](README.md#releases) for how a release is cut.
   Enables the two-pass reasoning ON/OFF assessment against the gold baseline (#58).
 
 ### Fixed
+- **`temperature` no longer force-sent to models that reject it.** The proxy
+  unconditionally injected `temperature` (default `0.0`) into every upstream
+  payload, so the newest Anthropic models — Claude Sonnet 5, Opus 4.8/4.7, Fable 5
+  — returned `400 "temperature is deprecated for this model"` (they removed the
+  sampling params entirely). Added a per-provider `no_sampling_params` list of
+  model IDs (config-driven, matched exact-then-prefix like routing, and populated
+  for the `anthropic` provider); `temperature`/`top_p` are dropped for those models
+  and left untouched for everything else, so the forced `temperature: 0.0`
+  determinism default (#33) still holds for open models and older Anthropic models
+  (`claude-sonnet-4-6`, `claude-haiku-4-5`) that still accept it. Requires a pod
+  restart to pick up the config change.
 - **nimbus `qwen` ignored `enable_thinking`; its reasoning trace wasn't logged (#66).**
   Two fixes for the direct nimbus vLLM endpoint (`nvidia/Qwen3.6-35B-A3B-NVFP4`):
   (1) added `nimbus.thinking_models = {"qwen": "enable_thinking"}` to `config.json` —

--- a/config.json
+++ b/config.json
@@ -47,6 +47,13 @@
                 "claude-sonnet-4-6",
                 "claude-haiku-4-5",
                 "claude-opus-4-8"
+            ],
+            "no_sampling_params": [
+                "claude-sonnet-5",
+                "claude-opus-4-8",
+                "claude-opus-4-7",
+                "claude-fable-5",
+                "claude-mythos-5"
             ]
         },
         "nimbus": {

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -512,9 +512,20 @@ async def proxy_chat(request: ChatRequest, http_request: Request, authorization:
     payload = {
         "model": request.model,
         "messages": request.messages,
-        "temperature": request.temperature
     }
-    
+
+    # Sampling params: the newest Anthropic models (Sonnet 5, Opus 4.8/4.7, Fable 5,
+    # ...) reject `temperature`/`top_p`/`top_k` with a 400 — they were removed, not
+    # deprecated. `no_sampling_params` lists (per provider) the model IDs that must
+    # not receive them; matched exact-then-prefix like model routing. Everything else
+    # keeps the forced `temperature: 0.0` default (#33) for eval determinism.
+    no_sampling = provider_config.get("no_sampling_params", [])
+    rejects_sampling = request.model in no_sampling or any(
+        request.model.startswith(p) for p in no_sampling
+    )
+    if not rejects_sampling:
+        payload["temperature"] = request.temperature
+
     # Add tools if provided
     if request.tools:
         payload["tools"] = request.tools
@@ -525,6 +536,8 @@ async def proxy_chat(request: ChatRequest, http_request: Request, authorization:
     for field in ("top_p", "seed", "stop", "max_tokens", "response_format"):
         value = getattr(request, field)
         if value is not None:
+            if field == "top_p" and rejects_sampling:
+                continue  # same 400 as temperature on these models
             payload[field] = value
 
     # OpenRouter-only knobs: the `provider` routing block (zdr / order / only /


### PR DESCRIPTION
## Problem

Requests to `claude-sonnet-5` (and `claude-opus-4-8`, already in `config.json`) fail with:

```
LLM API error (400): {"error":{"code":"invalid_request_error","message":"`temperature` is deprecated for this model."}}
```

Not a geo-agent issue. The proxy at `llm_proxy.py` builds every upstream payload with `"temperature": request.temperature` (default `0.0`), so even a client that sends no temperature gets one forwarded. Anthropic's newest models (Sonnet 5, Opus 4.8/4.7, Fable 5) **removed** the sampling params and 400 when they're present.

## Fix

Config-driven, per-provider `no_sampling_params` list of model IDs (mirrors the existing model-keyed `thinking_models` pattern), matched exact-then-prefix like routing:

- `temperature` and `top_p` are dropped for models in that list.
- Everything else keeps the forced `temperature: 0.0` determinism default (#33) — including the **older** Anthropic models (`claude-sonnet-4-6`, `claude-haiku-4-5`) that still accept it, which is why the list is explicit IDs, not the `claude-` prefix.

## Deploy

Config is git-synced at pod start, so this needs a `kubectl rollout restart deployment/open-llm-proxy -n biodiversity` after merge to take effect.

Also documents the git-worktree workflow in AGENTS.md.