### PR TITLE
fix(proxy): carry no_sampling_params through the PROVIDERS builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,10 @@ See [Releases](README.md#releases) for how a release is cut.
   and left untouched for everything else, so the forced `temperature: 0.0`
   determinism default (#33) still holds for open models and older Anthropic models
   (`claude-sonnet-4-6`, `claude-haiku-4-5`) that still accept it. Requires a pod
-  restart to pick up the config change.
+  restart to pick up the config change. (Follow-up: the `PROVIDERS` builder copies
+  a fixed key whitelist from `config.json`, so `no_sampling_params` also had to be
+  added there — without it the request-time lookup always saw an empty list and the
+  guard never fired.)
 - **nimbus `qwen` ignored `enable_thinking`; its reasoning trace wasn't logged (#66).**
   Two fixes for the direct nimbus vLLM endpoint (`nvidia/Qwen3.6-35B-A3B-NVFP4`):
   (1) added `nimbus.thinking_models = {"qwen": "enable_thinking"}` to `config.json` —

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -282,7 +282,11 @@ for provider_name, provider_config in config["providers"].items():
         "api_key": api_key,
         "models": provider_config["models"],
         "extra_headers": provider_config.get("extra_headers", {}),
-        "thinking_models": provider_config.get("thinking_models", {})
+        "thinking_models": provider_config.get("thinking_models", {}),
+        # Models that 400 on sampling params (temperature/top_p) — e.g. the newest
+        # Anthropic models. Must be carried through here: this rebuilt dict (not the
+        # raw config) is what get_provider_for_model returns at request time.
+        "no_sampling_params": provider_config.get("no_sampling_params", [])
     }
 
 # Log configuration status


### PR DESCRIPTION
Follow-up to #73. The temperature guard was live but never fired: `PROVIDERS` is rebuilt from `config.json` with a fixed key whitelist (`endpoint`/`api_key`/`models`/`extra_headers`/`thinking_models`) that silently dropped `no_sampling_params`. So `provider_config.get('no_sampling_params', [])` at request time always returned `[]`, `rejects_sampling` was always `False`, and `claude-sonnet-5` still 400'd upstream.

Verified against `api.anthropic.com`: the OpenAI-compat endpoint returns 200 with no `temperature` and 400 with `temperature:0` — confirming the payload, not the upstream, was the problem. Verified the real `llm_proxy` module now yields `rejects_sampling=True` for `claude-sonnet-5`/`claude-opus-4-8` and `False` for `claude-sonnet-4-6`/`claude-haiku-4-5`/open models.

Needs a pod restart after merge.