### PR TITLE
docs(caching): app-selectable Claude routing for prompt caching (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ See [Releases](README.md#releases) for how a release is cut.
 ## [Unreleased]
 
 ### Changed
+- **Documented Claude prompt-caching routing (#75) — app selects the route by model id.**
+  No code change: `anthropic/claude-*` already routes to OpenRouter (which maps the
+  OpenAI-style `cache_control` breakpoint onto Anthropic's native param, so prompt
+  caching lands), while bare `claude-*` routes to Anthropic's OpenAI-compat endpoint
+  (which silently ignores `cache_control`). Verified end-to-end on
+  `anthropic/claude-haiku-4.5`: a repeated ~6.8k-token cached prefix billed
+  `cache_write_tokens` on the first call and `cached_tokens` on the second (~12× lower
+  prefix cost). README's provider-routing section now spells out the two model ids
+  side by side, the `anthropic/…` = "served by OpenRouter" naming gotcha, and the
+  `"usage": {"include": true}` knob for surfacing cache accounting. Unblocks the
+  geo-agent client half (per-model `prompt_cache: true`, already merged and off by
+  default).
 - **Nimbus (DSE) model renamed `nemotron` → `qwen`.** The `vllm-nimbus.carlboettiger.info`
   endpoint now serves `nvidia/Qwen3.6-35B-A3B-NVFP4` under the id `qwen` (was
   `nemotron`). Updated `config.json`'s `nimbus.models` to `["qwen"]` so the proxy

--- a/README.md
+++ b/README.md
@@ -39,10 +39,25 @@ Configured in `config.json`. Most deployments only need NRP:
 |---|---|---|
 | **NRP** (`ellm.nrp-nautilus.io`) | `kimi`, `qwen3`, `glm-5`, `minimax-m2`, `gpt-oss`, `gemma` | Default; supports `enable_thinking` for applicable models |
 | **OpenRouter** | `anthropic/…`, `mistralai/…`, `openai/…`, `qwen/…`, `nvidia/…`, `amazon/…`, `z-ai/…`, `minimax/…`, `moonshotai/…` | Prefix match; requires separate API key |
-| **Anthropic** | `claude-…` (default `claude-sonnet-4-6`; `claude-opus-4-8`, `claude-haiku-4-5` also route) | Direct via Anthropic's OpenAI-compatible `/v1/chat/completions`; prefix match. Bills the Developer Platform API (not the Claude.ai Team plan) — set `ANTHROPIC_API_KEY`. The default model is chosen app-side (`llm_model`); the proxy just routes whatever `claude-*` it receives |
+| **Anthropic** | `claude-…` (default `claude-sonnet-4-6`; `claude-opus-4-8`, `claude-haiku-4-5` also route) | Direct via Anthropic's OpenAI-compatible `/v1/chat/completions`; prefix match. Bills the Developer Platform API (not the Claude.ai Team plan) — set `ANTHROPIC_API_KEY`. The default model is chosen app-side (`llm_model`); the proxy just routes whatever `claude-*` it receives. **No prompt caching** — see below |
 | **Nimbus** | `nemotron` | Private vLLM instance; requires separate API key |
 
 Unknown models fall back to NRP. To customize the model list, edit `config.json` — no code change needed.
+
+#### Claude: direct vs. OpenRouter (prompt caching)
+
+The **app picks the route by model id** — there are two ways to reach Claude, and they behave differently for [prompt caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching):
+
+| Send `model:` | Routes to | Prompt caching |
+|---|---|---|
+| `claude-sonnet-4-6` (bare `claude-*`) | Anthropic direct | ❌ **ignored** |
+| `anthropic/claude-sonnet-4.5` (OpenRouter slug) | OpenRouter → Anthropic | ✅ **works** |
+
+Anthropic's OpenAI-compatibility endpoint (`/v1/chat/completions`) silently ignores message-embedded `cache_control` — prompt caching is a native Messages-API (`/v1/messages`) feature (geo-agent [#273](https://github.com/boettiger-lab/geo-agent/issues/273), proxy [#75](https://github.com/boettiger-lab/open-llm-proxy/issues/75)). OpenRouter maps the OpenAI-style `cache_control` breakpoint onto Anthropic's native param, so the same request caches there.
+
+> **Naming gotcha:** `anthropic/…` is OpenRouter's *vendor namespace* ("the Anthropic-brand model **served by OpenRouter**"), **not** "route to Anthropic direct." Bare `claude-*` is the direct route. OpenRouter also uses its own version formatting (`claude-sonnet-4.5`, not `claude-sonnet-4-6`) — the app owns the exact slug.
+
+To get the savings, the app (client-side) must (1) send the system prompt as content parts with a `cache_control: {"type":"ephemeral"}` breakpoint, and (2) use the `anthropic/…` model id. Add `"usage": {"include": true}` to the request body to see the cache accounting (`cached_tokens` / `cache_write_tokens`) in the response and logs. Verified on `anthropic/claude-haiku-4.5`: a repeated ~6.8k-token prefix billed `cache_write_tokens` on the first call and `cached_tokens` on the second (~12× lower prefix cost).
 
 ### Thinking mode
 


### PR DESCRIPTION
Documents that the app selects the Claude route by **model id**, and confirms caching lands via OpenRouter — no proxy code change.

- Bare `claude-*` → Anthropic OpenAI-compat endpoint → `cache_control` silently ignored.
- `anthropic/claude-*` → OpenRouter → maps `cache_control` to Anthropic native → **caching works**.

Verified end-to-end on `anthropic/claude-haiku-4.5`: repeated ~6.8k-token prefix billed `cache_write_tokens` (call 1) then `cached_tokens` (call 2), ~12× lower prefix cost.

README provider-routing section updated (two model ids side by side, the `anthropic/…` = served-by-OpenRouter naming gotcha, `usage:{include:true}` knob) + CHANGELOG. Closes #75.