### PR TITLE
Baseline golden: add ca-30x30 traps from the 2026-07-10 analysis (#40 grow-on-fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ See [Releases](README.md#releases) for how a release is cut.
 
 ## [Unreleased]
 
+### Added
+- **Baseline golden set: 4 new ca-30x30 regression questions (#40 grow-on-fix) —
+  3 answer-mode + 1 clarify-mode.** Operator-verified gold + authoritative SQL +
+  `trap` tags for the failures found in the 2026-07-10 proxy-log analysis of the
+  ca-30x30 app (DSE-nimbus `qwen`):
+  (answer) `% of California conserved` — pins the denominator to the source ecoregion
+  polygon area (101.5M ac → 26.1%), trap `ca-denominator-ecoregion-source-area`;
+  (answer) `CWHR13 habitat breakdown` — correct `whr13num` legend + fractional-hex area,
+  traps `cwhr-code-name-from-schema-not-memory`, `cwhr13-use-fractional-hex-not-mode`;
+  (answer) `% hardwood woodland conserved` — Hardwood Woodland = code 52 (13.6%), trap
+  `cwhr-hardwood-woodland-is-code-52`; (clarify) `% of GAP-1 land in top-20% endemic
+  richness` — genuinely ambiguous (endemic-metric + threshold-population forks), so the
+  gold is to ASK, not answer; a preloaded `resolution` field carries the disambiguated
+  answer (~20.8% for ACE AllTaxaEnd) to give if the model asks. `bench_mean_acc` is now
+  nullable for grow-on-fix additions (not in the original 4-model benchmark), and
+  clarify records gained an optional `resolution` field. First accuracy marks for
+  `qwen` + `z-ai/glm-5.2` are recorded in `gold/ca-30x30.md` (both models silently
+  answered the clarify question → FAIL). Related: geo-agent#303, ca-30x30#87,
+  data-workflows#387, mcp-data-server#294.
+
 ### Changed
 - **Documented Claude prompt-caching routing (#75) — app selects the route by model id.**
   No code change: `anthropic/claude-*` already routes to OpenRouter (which maps the

--- a/headless/baseline/build_golden.py
+++ b/headless/baseline/build_golden.py
@@ -33,6 +33,20 @@ META = {
  ("ca-30x30","q2"): dict(id="ca-ecoregion-most-conserved", trap="group-by-native-ecoregion-field",
    gold="Mojave Desert ~7.37M acres #1",
    accept="top ecoregion = Mojave Desert"),
+ ("ca-30x30","q3"): dict(id="ca-pct-conserved", trap="ca-denominator-ecoregion-source-area;units-percent-not-acres",
+   gold="~26.1% (26.47M ac GAP1+2 / 101.5M ac CA extent). Denominator = SUM(Shape_Area) of the source ecoregion polygons (101,498,000 ac), NOT a hex SUM (103.3M, double-counts dup rows) or count×nominal-cell-area (95.3M).",
+   accept="~26% (25.5–26.6). MUST divide 26.47M GAP1+2 by the ~101.5M ecoregion extent; reject 25.6% (hex-sum denom), 27.8% (nominal-area denom), acres-only, or '% of the 30% target'.",
+   note="Guidance trap added 2026-07-10 from proxy-log analysis: qwen recomputed the denominator ad hoc (25.6% vs 27.8% across runs). See notes/ca-30x30-gold-truth-vs-models.md; fixed by ca-30x30#87 (hardwired denominator)."),
+ ("ca-30x30","q4"): dict(id="ca-cwhr13-pct-conserved", trap="cwhr-code-name-from-schema-not-memory;cwhr13-use-fractional-hex-not-mode",
+   gold="Per whr13num (name from STAC legend, area from cwhr13-hex-fractions): Urban(80) 1.0%, Agriculture(10) 2.4%, Hardwood Woodland(52) 13.6%, Herbaceous(60) 15.8%, Water(90) 20.8%, Hardwood Forest(51) 21.3%, Conifer Forest(31) 23.5%, Shrub(70) 26.6%, Conifer Woodland(32) 28.8%, Wetland(100) 45.6%, Desert Shrub(41) 48.2%, Barren/Other(20) 51.7%, Desert Woodland(42) 56.7%.",
+   accept="Class NAMES correct per whr13num legend (10=Agriculture, 31=Conifer Forest, 52=Hardwood Woodland, 80=Urban, 90=Water …) — NOT fabricated (e.g. 10=Conifer, 80=Barren is the failure). Percents ±3pt. Least protected = Urban/Agriculture; most = Desert Woodland/Barren.",
+   note="Guidance trap added 2026-07-10: qwen queried cwhr13 without get_schema and fabricated 12/13 class names. See geo-agent#303, ca-30x30#87 (CWHR caveat), notes/ca-30x30-gold-truth-vs-models.md."),
+ ("ca-30x30","q5"): dict(id="ca-hardwood-woodland-pct", trap="cwhr-hardwood-woodland-is-code-52;cwhr13-use-fractional-hex-not-mode",
+   gold="~13.6% (Hardwood Woodland = whr13num 52; 5.87M ac total, 0.80M ac GAP1+2). Hardwood FOREST is code 51 (21.3%) — a distinct class.",
+   accept="~13–14% AND uses whr13num=52. Reject answers built on code 10 (Agriculture→2.4%), 70 (Shrub→26%), 60-class oak subtypes, or 'code 51' — all wrong-code selections seen in the logs.",
+   note="Guidance trap added 2026-07-10: minimax cycled through codes 71-76/70/10 (→2.4%/3.5%/26%/36%); qwen3/qwen used code 52 correctly (→13.5-13.8%). The clearest 'two numeric codes' failure. See notes/ca-30x30-gold-truth-vs-models.md."),
+ # NB: the ca-30x30 endemic×GAP-1 question is ambiguous (metric-layer + threshold-population
+ # forks) — it is a mode=clarify test (CLARIFY list below), NOT an answer-mode gold.
  ("global-30x30","q1"): dict(id="glob-pct-land-protected", trap="dedup-protected-hexes;land-mask-denominator",
    gold="~16.5% of global land inside WDPA",
    accept="~15–18%"),
@@ -110,7 +124,8 @@ for app in ["biodiversity","bosl-high-seas","ca-30x30","global-30x30","tpl-ca","
             "gold": m["gold"], "accept": m["accept"],
             "trap": m["trap"].split(";"),
             "sql_ref": f"gold/{app}.md (q{i})",
-            "bench_mean_acc": BENCH_FLAT[m["id"]],
+            # null for grow-on-fix additions not in the original 4-model benchmark
+            "bench_mean_acc": BENCH_FLAT.get(m["id"]),
         }
         if m.get("note"): rec["note"] = m["note"]
         records.append(rec)
@@ -133,14 +148,23 @@ CLARIFY = [
    ambiguity="normalization method and weighting unspecified (min-max vs z-score vs rank; equal vs custom weights; NCP is an intensity mixed with extensive sums)",
    accept="asks how to normalize/weight the composite (and flags the intensity-vs-extensive mismatch) before ranking; does NOT silently choose a method",
    pairs_with="wet-top10-hydrobasins-composite"),
+ dict(id="clarify-ca-endemic-gap1", app="ca-30x30",
+   question="What percent of GAP 1 land is in the top 20% (>=80th percentile) of endemic-species richness?",
+   ambiguity="'endemic-species richness' is unspecified: (1) WHICH layer — ACE `AllTaxaEnd` (all endemic/near-endemic taxa) vs the separate rarity-weighted endemic *plant* richness layer (plants only); (2) percentile over WHICH population (all ACE hexagons → P80=4 vs nonzero-only → higher). Axis (1) dominates the answer.",
+   accept="GOLD = recognizes 'endemic richness' is unspecified (at minimum the metric-layer choice) and ASKS which layer/threshold before computing. Silently answering with ANY single number — even the correct ~20.8% AllTaxaEnd value — is a FAIL; the model must ask, not guess.",
+   resolution="If the user picks ACE `AllTaxaEnd`, top-20% = AllTaxaEnd ≥ P80 (=4 over distinct hexagons), GAP-1 land by sanctioned Gap1_acres/Total_Acre area-weight (reGAP=1 gives the same): **~20.8%** — ≈ the 20% expected by chance, so GAP-1 land is NOT endemic-enriched. Alternative resolutions: rarity-weighted endemic *plant* richness layer → ~25%; AllTaxaEnd with a nonzero-only percentile population / polygon-acre GAP-1 → ~30%. Operator-verified SQL in gold/ca-30x30.md (q6).",
+   pairs_with=None),
 ]
 for c in CLARIFY:
-    records.append({
+    rec = {
         "id": c["id"], "app": c["app"], "q_idx": "clarify", "question": c["question"],
         "mode": "clarify", "ambiguity": c["ambiguity"], "accept": c["accept"],
         "pairs_with": c["pairs_with"],
         "note": "Gold = identify the ambiguity and ask; NOT a data answer. Currently fails for most models (they answer anyway) — gated on a clarification-steering guidance change (geo-agent issue).",
-    })
+    }
+    # optional preloaded disambiguation answer(s) to provide IF the model asks
+    if c.get("resolution"): rec["resolution"] = c["resolution"]
+    records.append(rec)
 
 manifest = {
     "version": "2026-06-27",
@@ -174,6 +198,11 @@ print("wrote questions.txt")
 ans = [r for r in records if r["mode"] == "answer"]
 clar = [r for r in records if r["mode"] == "clarify"]
 print(f"  modes: {len(ans)} answer, {len(clar)} clarify")
-hard = sorted(ans, key=lambda r: r["bench_mean_acc"])[:5]
+scored = [r for r in ans if r["bench_mean_acc"] is not None]
+hard = sorted(scored, key=lambda r: r["bench_mean_acc"])[:5]
 print("hardest answer-mode (trap-rule seeds):")
 for r in hard: print(f"  {r['bench_mean_acc']:.2f}  {r['id']:32} traps={r['trap']}")
+new = [r for r in ans if r["bench_mean_acc"] is None]
+if new:
+    print(f"grow-on-fix additions (no first-run bench): {len(new)}")
+    for r in new: print(f"  --    {r['id']:32} traps={r['trap']}")

--- a/headless/baseline/gold/ca-30x30.md
+++ b/headless/baseline/gold/ca-30x30.md
@@ -20,3 +20,85 @@ FROM read_parquet('s3://public-ca30x30/conserved-areas-terrestrial-2025.parquet'
 GROUP BY CA_Ecoregi ORDER BY gap1_2_acres DESC;
 ```
 - **Confidence:** HIGH. "Conserved" = GAP 1+2 (`Acres` col). Mojave #1 by wide margin (robust even if "conserved"=full extent: Mojave still leads at 10.94M). Ecoregion from native `CA_Ecoregi` field.
+
+## Q3. What percent of California's area is conserved under 30x30 (GAP 1 or 2)?
+- **Answer:** **~26.1%** = 26,471,459 ac GAP 1+2 ÷ **101,498,000 ac** California extent. (All-GAP protected = 52.38M = 51.6%.)
+- **Denominator:** the source **ecoregion polygons** — `SUM(Shape_Area)` over the 20 features in `ecoregion.parquet` (EPSG:3310, equal-area) = 410,749 km² = 101.5M ac. NOT a hex-cell sum (`SUM(h3_cell_area)` over the ecoregion hex = 103.3M, double-counts ~8,600 duplicate rows → 25.6%) and NOT count×nominal-cell-area (95.3M → 27.8%).
+- **SQL:**
+```sql
+SELECT SUM(Acres) / (
+         SELECT SUM(Shape_Area)*0.000247105
+         FROM read_parquet('s3://public-ca30x30/ecoregion.parquet')
+       ) * 100 AS pct_gap12
+FROM read_parquet('s3://public-ca30x30/conserved-areas-terrestrial-2025.parquet');
+```
+- **Confidence:** HIGH. Numerator stable at 26.47M across all runs; only the denominator drifts. Verified against source geoparquet. See data-workflows#387 (dup rows), mcp-data-server#294 (nominal area), ca-30x30#87.
+- **First-mark (2026-07-10, single-shot):** qwen **26.1% ✓**, glm-5.2 **26.1% ✓** — both used the 101.5M ecoregion denominator. PASS 2/2. (The morning's 25.6/27.8 drift did not recur standalone — it was multi-turn-conditioned.)
+
+## Q4. Break down California's major habitat types (CWHR13) by percent conserved under 30x30 (GAP 1 or 2).
+- **Answer** (name from the `whr13num` STAC legend; area from the **fractional** hex asset; % = GAP1+2 ÷ total):
+
+  | code | habitat | total (M ac) | GAP1+2 (M ac) | % |
+  |--:|---|--:|--:|--:|
+  | 80 | Urban | 4.78 | 0.05 | 1.0 |
+  | 10 | Agriculture | 10.25 | 0.25 | 2.4 |
+  | 52 | Hardwood Woodland | 5.87 | 0.80 | 13.6 |
+  | 60 | Herbaceous | 10.97 | 1.74 | 15.8 |
+  | 90 | Water | 1.85 | 0.39 | 20.8 |
+  | 51 | Hardwood Forest | 5.21 | 1.11 | 21.3 |
+  | 31 | Conifer Forest | 17.31 | 4.08 | 23.5 |
+  | 70 | Shrub | 12.97 | 3.44 | 26.6 |
+  | 32 | Conifer Woodland | 3.22 | 0.93 | 28.8 |
+  | 100 | Wetland | 0.85 | 0.39 | 45.6 |
+  | 41 | Desert Shrub | 19.26 | 9.27 | 48.2 |
+  | 20 | Barren/Other | 2.88 | 1.49 | 51.7 |
+  | 42 | Desert Woodland | 0.96 | 0.55 | 56.7 |
+
+- **SQL:**
+```sql
+WITH cell_g12 AS (  -- per res-10 cell, GAP1+2 coverage weight = Acres/Total_Acre (STAC-sanctioned overlay weight)
+  SELECT h10, h0, MAX(CASE WHEN Total_Acre>0 THEN Acres/Total_Acre ELSE 0 END) AS g12w
+  FROM (SELECT DISTINCT h10, h0, _cng_fid, Acres, Total_Acre
+        FROM read_parquet('s3://public-ca30x30/conserved-areas-terrestrial-2025/hex/h0=*/data_0.parquet'))
+  GROUP BY h10, h0),
+frac AS (SELECT h10, h0, whr13num, frac
+  FROM read_parquet('s3://public-ca30x30/cwhr13/hex-fractions/h0=*/data_0.parquet') WHERE whr13num<>0)
+SELECT f.whr13num, SUM(f.frac)*3.71816/1e6 AS total_Macres,
+       SUM(f.frac*COALESCE(g.g12w,0))*3.71816/1e6 AS gap12_Macres,
+       100*SUM(f.frac*COALESCE(g.g12w,0))/SUM(f.frac) AS pct
+FROM frac f LEFT JOIN cell_g12 g ON f.h10=g.h10 AND f.h0=g.h0
+GROUP BY f.whr13num ORDER BY pct;
+```
+- **Confidence:** HIGH on names + ordering; MEDIUM on exact % (overlay weighting is an approximation). `whr13num` legend: 10=Agriculture, 20=Barren/Other, 31=Conifer Forest, 32=Conifer Woodland, 41=Desert Shrub, 42=Desert Woodland, 51=Hardwood Forest, 52=Hardwood Woodland, 60=Herbaceous, 70=Shrub, 80=Urban, 90=Water, 100=Wetland — get from `get_schema`, never memory. Area from `cwhr13-hex-fractions` (NOT the mode asset, #301).
+- **First-mark (2026-07-10, single-shot):** glm-5.2 **✓** — all 13 names correct + gold-matching %, used the sanctioned `Final_g*_p` overlay weight. qwen **partial** — names ✓ (called get_schema; **no legend hallucination standalone**), but % materially off (e.g. Conifer Forest 35.8% vs 23.5%; forced the class sum to 26.47M via a different overlay weighting). Naming trap PASSED by both; qwen imprecise on area (and slow — 23 calls / 802s vs glm 3 / 266s). The morning's fabricated-legend failure was multi-turn-conditioned and did not recur here.
+
+## Q5. What percent of hardwood woodland is conserved under 30x30 (GAP 1 or 2)?
+- **Answer:** **~13.6%** — Hardwood Woodland = `whr13num` **52** (5.87M ac total, 0.80M ac GAP1+2). Hardwood *Forest* is code **51** (21.3%) — a separate class; don't conflate.
+- **SQL:** as Q4, filtered to `whr13num = 52`.
+- **Confidence:** HIGH on the code (52) and ~13.6%. The whole-question failure mode is picking the wrong code (10/70/51 or 60-class oak subtypes) — the "two numeric codes" trap.
+- **First-mark (2026-07-10, single-shot):** qwen **13.6% (code 52) ✓**, glm-5.2 **13.6% (code 52) ✓**. PASS 2/2 — both selected the correct class code. (Contrast the historical logs where minimax cycled through wrong codes → 2.4/3.5/26/36%.)
+
+## Q6 (mode=clarify). What percent of GAP 1 land is in the top 20% (≥80th percentile) of endemic-species richness?
+**This is a CLARIFY question, not an answer-mode gold.** "endemic-species richness" is unspecified and the choice materially changes the answer, so the gold response is to **ask which metric/threshold** before computing. Silently answering with any single number — even the correct ~20.8% — is a **FAIL**.
+
+- **Ambiguity axes:**
+  1. **Which layer** — ACE `AllTaxaEnd` (all endemic/near-endemic taxa) vs the separate **rarity-weighted endemic *plant* richness** layer (plants only). *Dominant axis.*
+  2. **Percentile population** — over all ACE hexagons (`AllTaxaEnd` P80 = 4) vs nonzero-only (higher threshold).
+  3. (Minor) GAP-1 land by sanctioned `Gap1_acres/Total_Acre` area-weight vs `reGAP=1` — both converge to the same answer at res-8.
+
+- **Preloaded resolution (provide IF the model asks):** with ACE `AllTaxaEnd`, top-20% = `AllTaxaEnd ≥ P80` (=4 over distinct hexagons), GAP-1 by sanctioned area weight → **~20.8%** (≈ the 20% expected by chance → GAP-1 land is **not** endemic-enriched). Alternatives: rarity-weighted endemic-plant layer → ~25%; nonzero-only percentile + polygon-acre GAP-1 → ~30%.
+- **SQL (canonical AllTaxaEnd resolution, sanctioned GAP-1 area weight):**
+```sql
+WITH thr AS (SELECT quantile_cont(AllTaxaEnd,0.8) p80
+             FROM (SELECT DISTINCT Hex_ID, AllTaxaEnd
+                   FROM read_parquet('s3://public-cdfw/ace/terrestrial-biodiversity-summary/hex/h0=*/data_0.parquet'))),
+ace AS (SELECT DISTINCT h8, h0, AllTaxaEnd
+        FROM read_parquet('s3://public-cdfw/ace/terrestrial-biodiversity-summary/hex/h0=*/data_0.parquet')),
+gap1w AS (SELECT h8, h0, MAX(CASE WHEN Total_Acre>0 THEN Gap1_acres/Total_Acre ELSE 0 END) g1w
+          FROM (SELECT DISTINCT h8,h0,_cng_fid,Gap1_acres,Total_Acre
+                FROM read_parquet('s3://public-ca30x30/conserved-areas-terrestrial-2025/hex/h0=*/data_0.parquet'))
+          GROUP BY h8,h0)
+SELECT 100.0*SUM(CASE WHEN a.AllTaxaEnd>=(SELECT p80 FROM thr) THEN g.g1w ELSE 0 END)/SUM(g.g1w) AS pct
+FROM gap1w g JOIN ace a ON g.h8=a.h8 AND g.h0=a.h0;   -- ~20.8%
+```
+- **First-mark (2026-07-10):** both models FAILED clarify — glm-5.2 silently answered 25.2% (rarity-weighted-plant layer), qwen silently answered 30.5% (AllTaxaEnd/P80=6/polygon-acre). Neither asked. Exactly the "ask, don't guess" gap this mode gates.

--- a/headless/baseline/golden.json
+++ b/headless/baseline/golden.json
@@ -7,9 +7,9 @@
     "grading": "judge each model answer vs `gold`/`accept`; gold is operator-verified via own duckdb-geo queries (NOT model consensus).",
     "pass": "targeted trap fixed AND no regression vs this baseline (per-question, instance-level)."
   },
-  "n_questions": 25,
-  "n_answer": 22,
-  "n_clarify": 3,
+  "n_questions": 29,
+  "n_answer": 25,
+  "n_clarify": 4,
   "modes": {
     "answer": "gold = the computed answer; grade against `accept`.",
     "clarify": "gold = recognize the ambiguity and ask; grade on whether the model asks rather than silently picks. Tied to a clarification-steering guidance change."
@@ -104,6 +104,54 @@
       ],
       "sql_ref": "gold/ca-30x30.md (q2)",
       "bench_mean_acc": 1.0
+    },
+    {
+      "id": "ca-pct-conserved",
+      "app": "ca-30x30",
+      "q_idx": "q3",
+      "question": "What percent of California's area is conserved under 30x30 (GAP 1 or 2)?",
+      "mode": "answer",
+      "gold": "~26.1% (26.47M ac GAP1+2 / 101.5M ac CA extent). Denominator = SUM(Shape_Area) of the source ecoregion polygons (101,498,000 ac), NOT a hex SUM (103.3M, double-counts dup rows) or count\u00d7nominal-cell-area (95.3M).",
+      "accept": "~26% (25.5\u201326.6). MUST divide 26.47M GAP1+2 by the ~101.5M ecoregion extent; reject 25.6% (hex-sum denom), 27.8% (nominal-area denom), acres-only, or '% of the 30% target'.",
+      "trap": [
+        "ca-denominator-ecoregion-source-area",
+        "units-percent-not-acres"
+      ],
+      "sql_ref": "gold/ca-30x30.md (q3)",
+      "bench_mean_acc": null,
+      "note": "Guidance trap added 2026-07-10 from proxy-log analysis: qwen recomputed the denominator ad hoc (25.6% vs 27.8% across runs). See notes/ca-30x30-gold-truth-vs-models.md; fixed by ca-30x30#87 (hardwired denominator)."
+    },
+    {
+      "id": "ca-cwhr13-pct-conserved",
+      "app": "ca-30x30",
+      "q_idx": "q4",
+      "question": "Break down California's major habitat types (CWHR13) by percent conserved under 30x30 (GAP 1 or 2).",
+      "mode": "answer",
+      "gold": "Per whr13num (name from STAC legend, area from cwhr13-hex-fractions): Urban(80) 1.0%, Agriculture(10) 2.4%, Hardwood Woodland(52) 13.6%, Herbaceous(60) 15.8%, Water(90) 20.8%, Hardwood Forest(51) 21.3%, Conifer Forest(31) 23.5%, Shrub(70) 26.6%, Conifer Woodland(32) 28.8%, Wetland(100) 45.6%, Desert Shrub(41) 48.2%, Barren/Other(20) 51.7%, Desert Woodland(42) 56.7%.",
+      "accept": "Class NAMES correct per whr13num legend (10=Agriculture, 31=Conifer Forest, 52=Hardwood Woodland, 80=Urban, 90=Water \u2026) \u2014 NOT fabricated (e.g. 10=Conifer, 80=Barren is the failure). Percents \u00b13pt. Least protected = Urban/Agriculture; most = Desert Woodland/Barren.",
+      "trap": [
+        "cwhr-code-name-from-schema-not-memory",
+        "cwhr13-use-fractional-hex-not-mode"
+      ],
+      "sql_ref": "gold/ca-30x30.md (q4)",
+      "bench_mean_acc": null,
+      "note": "Guidance trap added 2026-07-10: qwen queried cwhr13 without get_schema and fabricated 12/13 class names. See geo-agent#303, ca-30x30#87 (CWHR caveat), notes/ca-30x30-gold-truth-vs-models.md."
+    },
+    {
+      "id": "ca-hardwood-woodland-pct",
+      "app": "ca-30x30",
+      "q_idx": "q5",
+      "question": "What percent of hardwood woodland is conserved under 30x30 (GAP 1 or 2)?",
+      "mode": "answer",
+      "gold": "~13.6% (Hardwood Woodland = whr13num 52; 5.87M ac total, 0.80M ac GAP1+2). Hardwood FOREST is code 51 (21.3%) \u2014 a distinct class.",
+      "accept": "~13\u201314% AND uses whr13num=52. Reject answers built on code 10 (Agriculture\u21922.4%), 70 (Shrub\u219226%), 60-class oak subtypes, or 'code 51' \u2014 all wrong-code selections seen in the logs.",
+      "trap": [
+        "cwhr-hardwood-woodland-is-code-52",
+        "cwhr13-use-fractional-hex-not-mode"
+      ],
+      "sql_ref": "gold/ca-30x30.md (q5)",
+      "bench_mean_acc": null,
+      "note": "Guidance trap added 2026-07-10: minimax cycled through codes 71-76/70/10 (\u21922.4%/3.5%/26%/36%); qwen3/qwen used code 52 correctly (\u219213.5-13.8%). The clearest 'two numeric codes' failure. See notes/ca-30x30-gold-truth-vs-models.md."
     },
     {
       "id": "glob-pct-land-protected",
@@ -381,6 +429,18 @@
       "accept": "asks how to normalize/weight the composite (and flags the intensity-vs-extensive mismatch) before ranking; does NOT silently choose a method",
       "pairs_with": "wet-top10-hydrobasins-composite",
       "note": "Gold = identify the ambiguity and ask; NOT a data answer. Currently fails for most models (they answer anyway) \u2014 gated on a clarification-steering guidance change (geo-agent issue)."
+    },
+    {
+      "id": "clarify-ca-endemic-gap1",
+      "app": "ca-30x30",
+      "q_idx": "clarify",
+      "question": "What percent of GAP 1 land is in the top 20% (>=80th percentile) of endemic-species richness?",
+      "mode": "clarify",
+      "ambiguity": "'endemic-species richness' is unspecified: (1) WHICH layer \u2014 ACE `AllTaxaEnd` (all endemic/near-endemic taxa) vs the separate rarity-weighted endemic *plant* richness layer (plants only); (2) percentile over WHICH population (all ACE hexagons \u2192 P80=4 vs nonzero-only \u2192 higher). Axis (1) dominates the answer.",
+      "accept": "GOLD = recognizes 'endemic richness' is unspecified (at minimum the metric-layer choice) and ASKS which layer/threshold before computing. Silently answering with ANY single number \u2014 even the correct ~20.8% AllTaxaEnd value \u2014 is a FAIL; the model must ask, not guess.",
+      "pairs_with": null,
+      "note": "Gold = identify the ambiguity and ask; NOT a data answer. Currently fails for most models (they answer anyway) \u2014 gated on a clarification-steering guidance change (geo-agent issue).",
+      "resolution": "If the user picks ACE `AllTaxaEnd`, top-20% = AllTaxaEnd \u2265 P80 (=4 over distinct hexagons), GAP-1 land by sanctioned Gap1_acres/Total_Acre area-weight (reGAP=1 gives the same): **~20.8%** \u2014 \u2248 the 20% expected by chance, so GAP-1 land is NOT endemic-enriched. Alternative resolutions: rarity-weighted endemic *plant* richness layer \u2192 ~25%; AllTaxaEnd with a nonzero-only percentile population / polygon-acre GAP-1 \u2192 ~30%. Operator-verified SQL in gold/ca-30x30.md (q6)."
     }
   ]
 }

--- a/headless/baseline/questions.txt
+++ b/headless/baseline/questions.txt
@@ -9,6 +9,9 @@ How many seamounts are there in the Sargasso Sea "Ecologically or Biologically S
 # ca-30x30
 How many acres of California land are conserved at GAP status 1 or 2?
 Which ecoregion has the most conserved acreage?
+What percent of California's area is conserved under 30x30 (GAP 1 or 2)?
+Break down California's major habitat types (CWHR13) by percent conserved under 30x30 (GAP 1 or 2).
+What percent of hardwood woodland is conserved under 30x30 (GAP 1 or 2)?
 
 # global-30x30
 What percentage of global land is currently inside a designated protected area?

--- a/headless/baseline/questions/ca-30x30.txt
+++ b/headless/baseline/questions/ca-30x30.txt
@@ -1,2 +1,5 @@
 How many acres of California land are conserved at GAP status 1 or 2?
 Which ecoregion has the most conserved acreage?
+What percent of California's area is conserved under 30x30 (GAP 1 or 2)?
+Break down California's major habitat types (CWHR13) by percent conserved under 30x30 (GAP 1 or 2).
+What percent of hardwood woodland is conserved under 30x30 (GAP 1 or 2)?

--- a/headless/baseline/questions/clarify.txt
+++ b/headless/baseline/questions/clarify.txt
@@ -10,3 +10,5 @@ How much and what type of industrial fishing would be displaced by designating a
 Which congressional district has raised the most conservation funding through ballot measures since 2010?
 # app=wetlands
 Rank the top 10 level-3 hydrobasins by wetland extent, carbon, and NCP, normalized.
+# app=ca-30x30
+What percent of GAP 1 land is in the top 20% (>=80th percentile) of endemic-species richness?

--- a/notes/ca-30x30-gold-truth-vs-models.md
+++ b/notes/ca-30x30-gold-truth-vs-models.md
@@ -1,0 +1,150 @@
+# CA 30x30 — gold truth vs. what the open models answered
+
+Generated 2026-07-10. Gold truth computed directly against the `duckdb-geo` MCP
+(public `s3://public-ca30x30` + `s3://public-cdfw` parquet), following the
+sanctioned aggregation rules in each dataset's STAC metadata. Model answers are
+from the open-llm-proxy logs for `origin=https://ca-30x30.nrp-nautilus.io`
+(all on the DSE-nimbus `qwen`, plus historical `qwen3`, `qwen3-small`,
+`gemma`, `minimax-m2`).
+
+**Does the earlier questions table cover everything?** It captured all 19
+*session-opening* questions. The proxy only logs each session's first question,
+so verbatim mid-session follow-ups aren't recoverable — but every theme
+(statewide protection, CWHR habitat, hardwood woodland, ACE biodiversity, FMMP,
+definitions) appears as some session's opener, so the coverage below is complete
+by theme. Questions collapse into ~5 computable buckets + 3 informational.
+
+Gold-truth method notes: statewide numerator from the polygon geoparquet
+(one row/feature, no dedup); CA denominator = 101.5M ac (source ecoregion
+polygons, verified earlier). Habitat overlay uses the `cwhr13-hex-fractions`
+asset (`SUM(frac·cell_area)`) weighted by each conserved unit's GAP1+2 share
+`Acres/Total_Acre` (the STAC-sanctioned feature-overlay weight), not the biased
+`mode` asset. ACE joins at res-8 with dedup by `Hex_ID`.
+
+---
+
+## Bucket A — "how much of California is protected?" (7 phrasings)
+
+**GOLD:** GAP1+2 = **26.47M ac** (GAP1 17.73 + GAP2 8.74) = **26.1% of California**.
+GAP3+4 ("other protected") = 25.90M. Total protected (all GAP) = 52.38M = 51.6%.
+Denominator = 101.5M ac.
+
+| model / date | answered | verdict |
+|---|---|---|
+| qwen 2026-07-10 | 25.6% (denom 103.3M — hex `SUM`, double-counts dup rows) | numerator ✓, **% low** |
+| qwen 2026-07-08 | 27.8% (denom 95.3M — distinct cells × *nominal* area) | numerator ✓, **% high** |
+| qwen 2026-07-10 (2nd session) | 26.47M ac, **no %**, no query at all (answered from context) | acres ✓, incomplete |
+| qwen 2026-07-07 | 26.47M ac + "85% of the 30% target" | reframed, no "% of CA" |
+| minimax-m2 (various) | 25.1 / 26.0 / 30 % | scattered |
+
+The **numerator (26.47M) is rock-solid every time**; only the denominator/framing
+drifts. Fixed by hardwiring 101.5M → 26.1% in ca-30x30#87.
+
+---
+
+## Bucket B — "how much of every CWHR13 habitat is protected?" (habitat table)
+
+**GOLD** (% of each class that is GAP1+2 conserved):
+
+| code | habitat | total (M ac) | GAP1+2 (M ac) | % protected |
+|--:|---|--:|--:|--:|
+| 80 | Urban | 4.78 | 0.05 | 1.0 |
+| 10 | Agriculture | 10.25 | 0.25 | 2.4 |
+| 52 | **Hardwood Woodland** | 5.87 | 0.80 | **13.6** |
+| 60 | Herbaceous | 10.97 | 1.74 | 15.8 |
+| 90 | Water | 1.85 | 0.39 | 20.8 |
+| 51 | Hardwood Forest | 5.21 | 1.11 | 21.3 |
+| 31 | Conifer Forest | 17.31 | 4.08 | 23.5 |
+| 70 | Shrub | 12.97 | 3.44 | 26.6 |
+| 32 | Conifer Woodland | 3.22 | 0.93 | 28.8 |
+| 100 | Wetland | 0.85 | 0.39 | 45.6 |
+| 41 | Desert Shrub | 19.26 | 9.27 | 48.2 |
+| 20 | Barren/Other | 2.88 | 1.49 | 51.7 |
+| 42 | Desert Woodland | 0.96 | 0.55 | 56.7 |
+
+**Model behavior:**
+- **qwen 2026-07-10:** fabricated the code→name legend — **12 of 13 names wrong**
+  (called 10 "Conifer Forest" [=Agriculture], 41 "Chaparral" [=Desert Shrub],
+  80 "Barren" [=Urban], 51 "Pinyon-Juniper" [=Hardwood Forest], …). Never called
+  `get_schema(cwhr13)`; no name column exists in the hex data so it hallucinated.
+  Root cause: geo-agent#303.
+- **qwen 2026-07-07:** correct *names* (Agriculture, Barren/Other…) but the *areas*
+  were far off (Agriculture "961,589 ac / 4.6%" vs gold 10.25M / 2.4%; Barren
+  "79.8%" vs gold 51.7%) — a restrictive/mode-based join undercounting class totals.
+
+So the habitat table fails on **names** (hallucinated legend) and, separately, on
+**areas** (method-dependent) — both need to be right and neither reliably was.
+
+---
+
+## Bucket C — "what % of hardwood woodland is protected?" (5+ phrasings)
+
+**GOLD:** Hardwood Woodland = `whr13num` **code 52**, total 5.87M ac,
+GAP1+2 = 0.80M ac → **13.6%**. (Hardwood *Forest* = code 51 = 21.3%, a distinct class.)
+
+This question is the clearest window into the "two numeric codes" confusion — the
+answer depended entirely on which code the model picked:
+
+| model / date | code it used | answer | verdict |
+|---|---|---|---|
+| qwen3 2026-06-24 | **52** (correct) | 5.81M total, **13.5%** | ✅ correct |
+| qwen 2026-07-07 | **52** (correct) | 5.81M, 802,430 ac, **13.8%** | ✅ correct |
+| minimax-m2 2026-06-22 | 71–76 (60-class oak types) | 3.14M, **3.5%** | ❌ wrong code |
+| minimax-m2 2026-06-22 | 70 ("Hardwood") | 13.0M, **26.0%** | ❌ wrong code |
+| minimax-m2 2026-06-23 | 10 ("Hardwood") | **2.4%** | ❌ (2.4% is Agriculture) |
+| minimax-m2 2026-06-23 | 60-class "hardwood-dominated" | **36.2%** | ❌ wrong code |
+| minimax-m2 2026-06-24 | 52 (right code) but total 19.3M | **14.0%** | ⚠️ right code, wrong total |
+
+`qwen3` and `qwen` (when they read the schema) nailed it at ~13.5–13.8% ≈ gold
+13.6%. `minimax-m2` cycled through codes 71–76, 70, 10, 9, 60-class subsets before
+landing on 52 — every wrong code produced a confidently-stated wrong percentage
+(2.4%, 3.5%, 26%, 36%). Same failure family as Bucket B: no reliable code→name step.
+
+---
+
+## Bucket D — ACE biodiversity (3 questions)
+
+**D1. "what % of GAP-1 land is in ≥80th-percentile endemic biodiversity?"**
+GOLD: with P80 of `AllTaxaEnd` = 4 endemic taxa, **20.7%** of GAP-1 land (103,900
+res-8 cells) falls in the top-20% endemic cells — i.e. GAP-1 land is *not*
+enriched for endemic biodiversity (≈ the 20% expected by chance).
+- **minimax-m2 2026-06-22:** answered **20.52%** (104,889 GAP-1 cells, threshold P80).
+  ✅ Essentially correct — matches gold to 0.2 pt. The model got this one right.
+
+**D2. "Show me bird species richness across the state"** — map request. Correct
+field is `NtvBird` (native bird models per hexagon; range 0–242, statewide mean
+116.7, highest in Marin). Gold is a rendered gradient, not a number.
+
+**D3. "Show me the ACE statewide biodiversity rank"** — map request. Correct field
+is `BioRankSW` (1–5 statewide quintile; 12,778 of 63,890 hexagons are rank 5).
+Rendered layer, not a number.
+
+---
+
+## Bucket E — informational (3 questions, no numeric gold)
+
+- "Can you give me the FMMP links?" / "link me to the official source for FMMP data" —
+  answer is a citation to CA FMMP (`fmmp-2022` dataset / CA Dept. of Conservation),
+  not a computation.
+- "what does CWHR stand for" — California Wildlife Habitat Relationships.
+
+---
+
+## Scorecard & where the errors come from
+
+| question bucket | model got it right? | failure mode | fix |
+|---|---|---|---|
+| A. statewide % | numerator always ✓, % drifted 25.6–27.8 | denominator recomputed ad hoc | ca-30x30#87 (hardwire 101.5M) |
+| B. habitat table | ✗ (names hallucinated; areas method-dependent) | no code→name step; wrong asset for area | geo-agent#303; #301 |
+| C. hardwood woodland | ✓ *iff* it used code 52 (qwen/qwen3), ✗ for minimax | wrong CWHR code picked from memory | geo-agent#303; ca-30x30#87 caveat |
+| D1. endemic × GAP1 | ✓ (20.5% ≈ gold 20.7%) | — | — |
+| D2/D3. maps | n/a (display) | — | — |
+
+**Bottom line:** the models are reliable on well-scoped numeric joins when they read
+the schema (Bucket A numerator, C-with-code-52, D1). They fail exactly where a
+**coded value must be resolved** — the CWHR habitat legend — because there's no name
+column in the hex data and nothing forces `get_schema`, so they fill the gap from
+memory. That single gap explains both the mislabeled habitat table (B) and the
+hardwood-woodland scatter (C). Fixes already filed: geo-agent#303 (reactive
+schema-on-error + inline small legends), ca-30x30#87 (hardwire denominator + CWHR
+code caveat), data-workflows#387 (dup rows), mcp-data-server#294 (exact H3 area).


### PR DESCRIPTION
Turns the 2026-07-10 ca-30x30 proxy-log findings into permanent regression gates in the #40 standing baseline. **3 answer-mode + 1 clarify-mode** question, each with operator-verified gold (via `duckdb-geo`), authoritative SQL, and `trap` tags.

| id | mode | gold | trap(s) |
|---|---|---|---|
| `ca-pct-conserved` | answer | 26.1% (26.47M ÷ 101.5M ecoregion) | `ca-denominator-ecoregion-source-area` |
| `ca-cwhr13-pct-conserved` | answer | 13-class table, correct legend | `cwhr-code-name-from-schema-not-memory`, `cwhr13-use-fractional-hex-not-mode` |
| `ca-hardwood-woodland-pct` | answer | 13.6% (code **52**) | `cwhr-hardwood-woodland-is-code-52` |
| `clarify-ca-endemic-gap1` | **clarify** | *ask* (ambiguous metric/threshold); preloaded resolution ~20.8% | ask-don't-guess |

### First accuracy marks (recorded in `gold/ca-30x30.md`)
Single-shot via `headless/run.js`, current ca-30x30 `main` system prompt:

| Q | qwen (nimbus 3.6) | z-ai/glm-5.2 |
|---|---|---|
| pct-conserved | 26.1% ✓ | 26.1% ✓ |
| cwhr13 table | names ✓, % off (partial) | ✓ |
| hardwood=52 | 13.6% ✓ | 13.6% ✓ |
| endemic (clarify) | answered 30.5% → FAIL | answered 25.2% → FAIL |

Notably, **neither model reproduced the morning legend hallucination in single-shot** — both called `get_schema` and got the CWHR names right — confirming that failure was multi-turn-conditioned (motivates geo-agent#303). qwen is correct-but-imprecise on the habitat % and far slower (23 calls/802s vs glm 3/266s).

### Mechanics
- Edited the source files (`questions/*.txt`, `META`/`CLARIFY` in `build_golden.py`, `gold/ca-30x30.md`) and regenerated `golden.json`+`questions.txt` via `build_golden.py`.
- `bench_mean_acc` is now nullable for grow-on-fix additions; clarify records gained an optional `resolution` field (preloaded disambiguation answer).

Refs geo-agent#303, ca-30x30#87, data-workflows#387, mcp-data-server#294.