### PR TITLE
Multi-key client auth (PROXY_KEYS_EXTRA) — revocable eval keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ See [Releases](README.md#releases) for how a release is cut.
 ## [Unreleased]
 
 ### Added
+- **Multi-key client auth — accept more than one `PROXY_KEY` so eval/dev keys are
+  independently revocable.** New `PROXY_KEYS_EXTRA` env (comma-separated, wired from
+  `open-llm-proxy-secrets`/`proxy-keys-extra`, `optional: true`) is folded into the
+  accepted-key set alongside the primary `PROXY_KEY`; the auth check is now a set
+  membership test. Backward compatible — with `PROXY_KEYS_EXTRA` unset the accepted
+  set is exactly `{PROXY_KEY}`. Revoke a key by removing it from the secret value and
+  restarting. Deliberately minimal: no per-key rate limits or attribution (we are not
+  reinventing LiteLLM) — provider-side spend caps remain the enforcement point. Lets
+  group members run the headless eval locally with a disposable key instead of the
+  shared production key. Covered by `test_compute_valid_keys_multi_and_backward_compat`.
 - **Baseline golden set: 4 new ca-30x30 regression questions (#40 grow-on-fix) —
   3 answer-mode + 1 clarify-mode.** Operator-verified gold + authoritative SQL +
   `trap` tags for the failures found in the 2026-07-10 proxy-log analysis of the

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -132,6 +132,16 @@ spec:
             secretKeyRef:
               name: open-llm-proxy-secrets
               key: proxy-key
+        # Optional additional revocable client keys (comma-separated), e.g.
+        # per-user eval keys. Accepted exactly like PROXY_KEY; revoke by removing
+        # from the secret value and restarting. optional=true so the pod starts
+        # fine when the secret key is absent (backward compatible).
+        - name: PROXY_KEYS_EXTRA
+          valueFrom:
+            secretKeyRef:
+              name: open-llm-proxy-secrets
+              key: proxy-keys-extra
+              optional: true
         - name: OPENROUTER_KEY
           valueFrom:
             secretKeyRef:

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -268,8 +268,25 @@ def load_config() -> dict:
 
 # Load config and build providers
 config = load_config()
-PROXY_KEY = os.getenv("PROXY_KEY")  # Key required from clients
+PROXY_KEY = os.getenv("PROXY_KEY")  # Primary client key (prod apps)
 CACHE_SALT = os.getenv("CACHE_SALT")  # Optional: isolate cached responses per deployment
+
+
+def compute_valid_keys(primary, extra):
+    """Set of accepted client keys: the primary PROXY_KEY plus any comma-separated
+    revocable extras (PROXY_KEYS_EXTRA) — e.g. per-user eval keys. Blank/whitespace
+    entries are dropped. Deliberately NOT a key-management layer: keys are accepted
+    equally, with no per-key rate limits or attribution. Revoke a key by removing it
+    from PROXY_KEYS_EXTRA and restarting; spend caps are enforced upstream at the
+    providers, not here."""
+    return frozenset(
+        k.strip() for k in ([primary] + (extra or "").split(",")) if k and k.strip()
+    )
+
+
+# All client keys the proxy will accept. Backward-compatible: with no
+# PROXY_KEYS_EXTRA this is exactly {PROXY_KEY}, identical to the old behavior.
+VALID_PROXY_KEYS = compute_valid_keys(PROXY_KEY, os.getenv("PROXY_KEYS_EXTRA", ""))
 
 # Build PROVIDERS dictionary from config
 PROVIDERS = {}
@@ -299,6 +316,8 @@ for provider, config in PROVIDERS.items():
     print(f"{status} {provider.upper()}: {config['endpoint']} (key: {'set' if has_key else 'MISSING'})")
 if not PROXY_KEY:
     print("⚠️  WARNING: PROXY_KEY not set - proxy will reject all requests!")
+elif len(VALID_PROXY_KEYS) > 1:
+    print(f"✓ Accepting {len(VALID_PROXY_KEYS)} client keys (PROXY_KEY + {len(VALID_PROXY_KEYS)-1} from PROXY_KEYS_EXTRA)")
 if CACHE_SALT:
     print("✓ CACHE_SALT configured - responses isolated from other NRP tenants")
 else:
@@ -481,7 +500,7 @@ async def proxy_chat(request: ChatRequest, http_request: Request, authorization:
     if authorization:
         client_key = authorization.replace('Bearer ', '').strip()
     
-    if not client_key or client_key != PROXY_KEY:
+    if not client_key or client_key not in VALID_PROXY_KEYS:
         raise HTTPException(status_code=401, detail="Unauthorized: Invalid or missing proxy key")
     
     # Determine provider based on model

--- a/test_logging.py
+++ b/test_logging.py
@@ -20,6 +20,22 @@ def _reload(**env):
     return importlib.reload(llm_proxy)
 
 
+def test_compute_valid_keys_multi_and_backward_compat():
+    """Multi-key auth (#): PROXY_KEY plus comma-separated PROXY_KEYS_EXTRA are all
+    accepted; blanks dropped; single-key setup is unchanged."""
+    f = llm_proxy.compute_valid_keys
+    # backward compatible: no extras -> exactly the primary
+    assert f("prod", "") == frozenset({"prod"})
+    assert f("prod", None) == frozenset({"prod"})
+    # extras accepted alongside the primary
+    assert f("prod", "eval1,eval2") == frozenset({"prod", "eval1", "eval2"})
+    # whitespace and empty entries are dropped (no accidental "" accept-all)
+    assert f("prod", " eval1 , , eval2 ,") == frozenset({"prod", "eval1", "eval2"})
+    assert "" not in f("prod", ",, ,")
+    # a random key is NOT in the set (the property the auth check relies on)
+    assert "attacker" not in f("prod", "eval1")
+
+
 def test_scrub_redacts_tool_call_arguments():
     p = importlib.reload(llm_proxy)
     args = json.dumps({


### PR DESCRIPTION
Lets group members run the headless eval locally with a **disposable, independently-revocable** key instead of the shared production `PROXY_KEY`.

**Change (minimal):** auth was `client_key != PROXY_KEY` (single key). Now the proxy accepts a *set*: `PROXY_KEY` + optional comma-separated `PROXY_KEYS_EXTRA` (from `open-llm-proxy-secrets`/`proxy-keys-extra`, `optional: true`). Auth is now set-membership.

- **Backward compatible:** with `PROXY_KEYS_EXTRA` unset, the accepted set is exactly `{PROXY_KEY}` — no behavior change.
- **Revoke** a key by removing it from the secret value + rollout restart.
- **Not a key-management layer:** no per-key rate limits or attribution (we are not reinventing LiteLLM). Provider-side spend caps stay the enforcement point.
- Deploy loop: initContainer git-syncs `main` into `/app`, so code lands on rollout restart; the `deployment.yaml` env add needs a `kubectl apply`/patch.

Covered by `test_compute_valid_keys_multi_and_backward_compat` (multi-key, whitespace/blank dropping, no accidental empty-string accept-all).