### PR TITLE
chore(ingress): align timeout-client with timeout-server (600s) hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ See [Releases](README.md#releases) for how a release is cut.
   data-workflows#387, mcp-data-server#294.
 
 ### Changed
+- **Align ingress `timeout-client` with `timeout-server` (both 600s) — hygiene.**
+  Added `haproxy-ingress.github.io/timeout-client: "600s"` so the client- and
+  server-side idle timeouts match (the proxy calls upstream non-streaming, so a long
+  completion leaves both sides idle). Does **not** resolve the ~300s ceiling on long
+  single generations investigated in #82 — testing showed NRP's shared haproxy enforces
+  a client timeout that this per-Ingress annotation doesn't override. #82 closed as
+  resolved-by-finding: the practical answer for slow reasoning models (e.g. glm-5.2) is
+  to run reasoning-OFF (consistently benchmarked as good OFF / not useful ON, #58), and
+  the app exposes reasoning toggles — so the streaming/infra fix isn't worth pursuing.
 - **Documented Claude prompt-caching routing (#75) — app selects the route by model id.**
   No code change: `anthropic/claude-*` already routes to OpenRouter (which maps the
   OpenAI-style `cache_control` breakpoint onto Anthropic's native param, so prompt

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -21,7 +21,16 @@ metadata:
     haproxy-ingress.github.io/cors-allow-headers: "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Accept,Accept-Encoding,Accept-Language,Connection,Host,Origin,Referer,Sec-Fetch-Dest,Sec-Fetch-Mode,Sec-Fetch-Site,Priority,Authorization,X-Client,X-Session-Id"
     haproxy-ingress.github.io/cors-allow-credentials: "false"
     haproxy-ingress.github.io/cors-max-age: "600"
+    # Keep timeout-client aligned with timeout-server (hygiene). Because the proxy
+    # calls upstream non-streaming, a long completion leaves BOTH sides idle — the
+    # backend silent (timeout-server) and the client waiting (timeout-client) — so
+    # the two should match. NOTE: this does NOT resolve #82. A ~300s ceiling still
+    # cuts long single generations (client sees `fetch failed` at ~300s); testing
+    # showed NRP's shared haproxy enforces that client timeout and this per-Ingress
+    # annotation does not override it. The real fix is streaming end-to-end (proxy
+    # + geo-agent) or an NRP-side timeout bump — tracked in #82.
     haproxy-ingress.github.io/timeout-server: "600s"
+    haproxy-ingress.github.io/timeout-client: "600s"
     haproxy-ingress.github.io/timeout-tunnel: "3600s"
 spec:
   ingressClassName: haproxy


### PR DESCRIPTION
Small hygiene change from the #82 investigation. Adds `haproxy-ingress.github.io/timeout-client: "600s"` so the client- and server-side idle timeouts match (the proxy calls upstream non-streaming, so a long completion leaves both sides idle).

**This does not resolve #82.** Testing (glm-5 reasoning-ON, fishing question) showed the ~300s ceiling still fires — NRP's shared haproxy enforces a client timeout that this per-Ingress annotation doesn't override. Already applied to the live ingress; this commit brings git in sync so it doesn't drift.

**#82 closed as resolved-by-finding** (not by this change): the practical answer for slow reasoning models like glm-5.2 is to run reasoning-**OFF** — consistently benchmarked as good OFF / not useful ON (#58) — and the app exposes reasoning toggles. The streaming/infra fix that would raise the ceiling isn't worth pursuing for this purpose.