### PR TITLE
chore(gold): re-verify baseline against current NRP vintage — no drift (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ See [Releases](README.md#releases) for how a release is cut.
   data-workflows#387, mcp-data-server#294.
 
 ### Changed
+- **Re-verified the gold baseline against current NRP data vintage — no drift (#81).**
+  WDPA advanced Dec-2025 → June-2026 (`WDPA_poly_Jun2026`, 306,985 features) and ca30x30's
+  canonical file was re-confirmed authoritative. Re-ran the gold SQL for the four
+  WDPA-dependent global-30x30 answers and both ca-30x30 GAP-status answers against
+  `s3-west`: every value reproduced **exactly** (H3-hex aggregation at h8 is robust to
+  WDPA's incremental additions). No expected-value edits to `gold/*.md` / `golden.json`;
+  added provenance notes to the two gold headers recording the vintage they were
+  re-verified against. Closes the loop from data-workflows#360.
 - **Align ingress `timeout-client` with `timeout-server` (both 600s) — hygiene.**
   Added `haproxy-ingress.github.io/timeout-client: "600s"` so the client- and
   server-side idle timeouts match (the proxy calls upstream non-streaming, so a long

--- a/headless/baseline/gold/ca-30x30.md
+++ b/headless/baseline/gold/ca-30x30.md
@@ -1,5 +1,10 @@
 # Gold — ca-30x30
 
+<!-- Provenance: Q1 (GAP1+2 acres) and Q2 (top ecoregion) re-verified 2026-07-13 against
+     canonical NRP conserved-areas-terrestrial-2025.parquet. Reproduced exactly
+     (17,728,246 / 8,743,213 / 26,471,459 ac); the earlier 7.93M GAP2 figure was an old
+     repackaged mirror file, not canonical. No changes. See open-llm-proxy#81. -->
+
 ## Q1. How many acres of California land are conserved at GAP status 1 or 2?
 - **Answer:** **26,471,459 acres GAP 1+2** (GAP 1 = 17,728,246; GAP 2 = 8,743,213). (context: GAP 3+4 = 25.90M; all units = 52.38M — NOT part of answer)
 - **Dataset:** `ca30x30-conserved-areas-terrestrial-2025` — `read_parquet('s3://public-ca30x30/conserved-areas-terrestrial-2025.parquet')` (flat, one row/feature; 45,811 rows).

--- a/headless/baseline/gold/global-30x30.md
+++ b/headless/baseline/gold/global-30x30.md
@@ -1,5 +1,9 @@
 # Gold — global-30x30
 
+<!-- Provenance: WDPA-dependent answers (Q1–Q4) re-verified 2026-07-13 against current NRP
+     (WDPA_poly_Jun2026, 306,985 features — advanced past the Dec-2025 vintage they were first
+     computed on). All values reproduced exactly; no changes. See open-llm-proxy#81. -->
+
 ## Q1. What % of global land is inside a designated protected area?
 - **Answer:** **16.48%** (29,263,682 protected land h8 cells / 177,521,782 total land h8 cells). Matches Protected Planet ~16–17% terrestrial.
 - **Datasets:** `wdpa` `s3://public-wdpa/wdpa/hex/h0=*/data_0.parquet`; land mask `cgls-lc100-2019` `s3://public-land-cover/cgls-lc100-2019/hex/h0=*/data_0.parquet` (land = lc_class NOT IN (0,80,200)).


### PR DESCRIPTION
Closes #81.

Re-ran the gold SQL against **current NRP Ceph data** (`s3-west`, via `duckdb-geo` MCP) on 2026-07-13, after data-workflows#360 made the failover mirror byte-faithful and surfaced that NRP itself had advanced past some gold vintages.

## Result: no drift
| id | gold | current NRP | verdict |
|---|---|---|---|
| `glob-pct-land-protected` | 16.48% | 16.4846% | ✅ |
| `glob-people-in-pas` | 357,331,494 | 357,331,494 | ✅ exact |
| `glob-least-represented-ecoregions` | ~32 @ 0%; overall 16.69% | same tie, 16.6851% | ✅ |
| `glob-top5-pa-mammal-richness` | Rwenzori 210.0 … Basse-Mana 199.8 | identical | ✅ exact |
| `ca-gap12-acres` | 17,728,246 / 8,743,213 / 26,471,459 | identical | ✅ exact |
| `ca-ecoregion-most-conserved` | Mojave 7.37M > Sierra 4.64M > … | identical | ✅ exact |
| `tpl-boulder-funders` (spot-check) | Boulder Sales Tax $321.2M … | identical | ✅ |

WDPA confirmed advanced to `WDPA_poly_Jun2026` (306,985 features), but every value held — H3-hex aggregation at h8 is robust to the incremental additions. The earlier ca30x30 GAP2 7.93M figure was the old repackaged **mirror** file; canonical reproduces 8,743,213 exactly.

## Changes
Docs/provenance only — **no expected-value edits**:
- Provenance notes in the `global-30x30` / `ca-30x30` gold headers (vintage re-verified against).
- CHANGELOG entry under `[Unreleased] → Changed`.

The standing baseline (#40) is valid against current NRP; the remaining low-risk tpl questions (pinned-version datasets) were left unrun beyond the Boulder spot-check.