### PR TITLE
fix(proxy): make caller-facing nginx 502s visible in the logs (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,8 +128,9 @@ See [Releases](README.md#releases) for how a release is cut.
   `error="Client disconnected/cancelled after …ms (upstream still pending)"`, and
   re-raises; and the success path prints a greppable `⚠️  Slow completion` marker when
   `latency_ms > 300000` (case (a) — a logged 200 the user actually saw as a 502).
-  Diagnosis/visibility only; the root-cause fix (end-to-end SSE streaming so bytes keep
-  flowing) is cross-repo and tracked against geo-agent. See #82.
+  Visibility only — this does not change the request path or claim a root cause; it
+  makes the currently-invisible cut requests observable so the mechanism (why the
+  caller sees a 502, not a 504) can be pinned down from real data. See #82.
 - **Strip leaked `<arg_key>`/`<arg_value>` (GLM) and `<parameter=…>` (qwen) tool-call
   arg dialect from responses (#85).** Some open-weight backends (`z-ai/glm-5.2`, the
   qwen family) intermittently fail to decode their own tool-call argument encoding,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,23 @@ See [Releases](README.md#releases) for how a release is cut.
   in the June 2026 corpus, 339 direct calls versus ~3,255 actual, the #2 MCP tool. The
   note now distinguishes local-only from local-delegate and says to attribute every
   `get_schema` call to `get_stac_details` when estimating server load.
+- **Log client-disconnect / cancelled requests so the caller-facing nginx 502s stop
+  being invisible here.** Every geo-agent app fronts this proxy with an nginx sidecar
+  whose `proxy_read_timeout` is 300s (`geo-agent-template` configmap). Because the proxy
+  calls upstream **non-streaming**, zero bytes flow until the whole completion is
+  buffered, so any turn slower than 300s makes nginx return a `nginx/1.29.6` **502** to
+  the browser — while the proxy itself either (a) eventually succeeds and logs a slow
+  **200**, (b) times out at 600s and logs a **504**, or (c) is cancelled by uvicorn when
+  nginx drops the connection. Case (c) raised `asyncio.CancelledError`, which is a
+  `BaseException` and so slipped past the handler's `except Exception` — the request
+  left only a pre-flight request row and no response/error row, which is why the 502s
+  were unobservable from the proxy logs. The chat handler now catches
+  `asyncio.CancelledError`, logs a response row with
+  `error="Client disconnected/cancelled after …ms (upstream still pending)"`, and
+  re-raises; and the success path prints a greppable `⚠️  Slow completion` marker when
+  `latency_ms > 300000` (case (a) — a logged 200 the user actually saw as a 502).
+  Diagnosis/visibility only; the root-cause fix (end-to-end SSE streaming so bytes keep
+  flowing) is cross-repo and tracked against geo-agent. See #82.
 - **Strip leaked `<arg_key>`/`<arg_value>` (GLM) and `<parameter=…>` (qwen) tool-call
   arg dialect from responses (#85).** Some open-weight backends (`z-ai/glm-5.2`, the
   qwen family) intermittently fail to decode their own tool-call argument encoding,

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -714,9 +714,33 @@ async def proxy_chat(request: ChatRequest, http_request: Request, authorization:
 
             # Log successful response
             latency_ms = int((time.time() - start_time) * 1000)
+            # Callers front this proxy with an nginx sidecar whose proxy_read_timeout
+            # is 300s (geo-agent-template configmap). Because we call upstream
+            # non-streaming, zero bytes flow until the whole completion is buffered —
+            # so any turn slower than that already returned an nginx 502 to the
+            # browser even though *we* eventually succeed. Flag it so a logged 200
+            # that the user experienced as a 502 is greppable in pod logs (#82).
+            if latency_ms > 300_000:
+                print(f"⚠️  Slow completion: {latency_ms}ms exceeds the 300s client-side "
+                      f"nginx read timeout (model={request.model}, request_id={request_id}) — "
+                      f"the browser likely already received an nginx 502 for this turn",
+                      flush=True)
             log_response(provider_name, request.model, result, latency_ms, origin=origin, request_id=request_id, session_id=session_id, client=client, dialect_repaired=dialect_repaired)
 
             return result
+
+        except asyncio.CancelledError:
+            # The caller (the app's nginx sidecar, proxy_read_timeout 300s) gave up
+            # and closed the connection while we were still awaiting upstream, so
+            # uvicorn cancelled this handler. CancelledError is a BaseException, so
+            # the `except Exception` below never caught it — the request vanished
+            # from S3 (only the pre-flight request row remained), which is exactly
+            # why the client-facing nginx 502s were invisible here (#82). Log it,
+            # then re-raise so the cancellation still propagates correctly.
+            latency_ms = int((time.time() - start_time) * 1000)
+            error_detail = f"Client disconnected/cancelled after {latency_ms}ms (upstream still pending)"
+            log_response(provider_name, request.model, {}, latency_ms, error=error_detail, origin=origin, request_id=request_id, session_id=session_id, client=client)
+            raise
 
         except httpx.TimeoutException as e:
             latency_ms = int((time.time() - start_time) * 1000)

--- a/test_logging.py
+++ b/test_logging.py
@@ -485,6 +485,46 @@ def test_error_path_captures_allowlisted_upstream_headers():
     json.dumps(errs[0])   # must stay serializable
 
 
+def test_client_disconnect_is_logged_and_reraised():
+    """When the caller (nginx sidecar, 300s read timeout) drops the connection and
+    uvicorn cancels the handler mid-upstream, we log a response row with a
+    disconnect error AND re-raise CancelledError — so the previously-invisible
+    client-facing nginx 502s become observable in the logs (#82)."""
+    import asyncio
+    from unittest.mock import patch
+
+    p = _reload(PROXY_KEY="testkey")
+    p._log_buffer.clear()
+
+    class _FakeAsyncClient:
+        def __init__(self, *a, **k):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def post(self, *a, **k):
+            raise asyncio.CancelledError()  # client went away while we awaited upstream
+
+    class _FakeRequest:
+        headers = {"origin": "https://app"}
+
+    req = p.ChatRequest(model="qwen3", messages=[{"role": "user", "content": "hi"}])
+    with patch.object(p, "get_provider_for_model",
+                      return_value=("nrp", {"endpoint": "http://upstream", "api_key": "k"})), \
+         patch.object(p.httpx, "AsyncClient", _FakeAsyncClient):
+        try:
+            asyncio.run(p.proxy_chat(req, _FakeRequest(), authorization="Bearer testkey"))
+            assert False, "expected CancelledError to propagate"
+        except asyncio.CancelledError:
+            pass  # must re-raise, not swallow
+
+    errs = [e for e in p._log_buffer if e.get("type") == "response" and e.get("error")]
+    assert len(errs) == 1
+    assert "disconnected" in errs[0]["error"].lower()
+    json.dumps(errs[0])   # must stay serializable
+
+
 def test_passthrough_sampling_knobs_forwarded():
     """seed/top_p/stop/max_tokens/response_format reach upstream on any provider (#47)."""
     payload = _run_proxy_capture(dict(


### PR DESCRIPTION
## Problem

Users of the geo-agent apps see repeated
`LLM API error (502): <html>…<center>nginx/1.29.6</center>…` in the browser, yet
open-llm-proxy's logs show no 502s. The 502s are invisible from this side.

## What this PR does (visibility only)

Makes the invisible cases observable — it does **not** change the request path or
assert a root cause.

- Catch `asyncio.CancelledError` around the upstream call (raised when the caller
  drops the connection and uvicorn cancels the handler — a `BaseException` that
  slipped past `except Exception`, so the request left only a pre-flight row), log a
  response row with `error="Client disconnected/cancelled after …ms"`, and **re-raise**.
- Print a greppable `⚠️  Slow completion` marker when `latency_ms > 300000`.
- New test `test_client_disconnect_is_logged_and_reraised`; full suite 32 passed.

## What is verified vs. open

**Verified:** the `nginx/1.29.6` 502 is emitted by the app pod's nginx sidecar (which
reverse-proxies `/api/llm/` here with `proxy_read_timeout 300s`), not by this proxy or
any haproxy; this proxy calls upstream non-streaming; this proxy logs no 502 for these.

**Open (deliberately not prescribing a fix):** nginx returns **504** on
`proxy_read_timeout`, but the caller sees a **502** — i.e. the connection is being
reset/closed, not merely idle-timing-out. The actual mechanism is not yet established.
This PR exists precisely to get the data needed to establish it. See #82; symptom
tracked in geo-agent#322.