### PR TITLE
Route deepseek/ OpenRouter family (deepseek-v4-flash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ See [Releases](README.md#releases) for how a release is cut.
 
 ## [Unreleased]
 
+### Added
+- **Route the `deepseek/` OpenRouter family.** Added `deepseek/` to the OpenRouter
+  provider's prefix allowlist so `deepseek/deepseek-v4-flash` (and other
+  `deepseek/…` models) route instead of silently falling back to NRP. Enables the
+  fleet-wide "DeepSeek V4 Flash (OpenRouter)" picker option.
+
 ### Fixed
 - **Strip leaked `<arg_key>`/`<arg_value>` (GLM) and `<parameter=…>` (qwen) tool-call
   arg dialect from responses (#85).** Some open-weight backends (`z-ai/glm-5.2`, the

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Configured in `config.json`. Most deployments only need NRP:
 | Provider | Models | Notes |
 |---|---|---|
 | **NRP** (`ellm.nrp-nautilus.io`) | `kimi`, `qwen3`, `glm-5`, `minimax-m2`, `gpt-oss`, `gemma` | Default; supports `enable_thinking` for applicable models |
-| **OpenRouter** | `anthropic/…`, `mistralai/…`, `openai/…`, `qwen/…`, `nvidia/…`, `amazon/…`, `z-ai/…`, `minimax/…`, `moonshotai/…` | Prefix match; requires separate API key |
+| **OpenRouter** | `anthropic/…`, `mistralai/…`, `openai/…`, `qwen/…`, `nvidia/…`, `amazon/…`, `z-ai/…`, `minimax/…`, `moonshotai/…`, `deepseek/…` | Prefix match; requires separate API key |
 | **Anthropic** | `claude-…` (default `claude-sonnet-4-6`; `claude-opus-4-8`, `claude-haiku-4-5` also route) | Direct via Anthropic's OpenAI-compatible `/v1/chat/completions`; prefix match. Bills the Developer Platform API (not the Claude.ai Team plan) — set `ANTHROPIC_API_KEY`. The default model is chosen app-side (`llm_model`); the proxy just routes whatever `claude-*` it receives. **No prompt caching** — see below |
 | **Nimbus** | `nemotron` | Private vLLM instance; requires separate API key |
 

--- a/config.json
+++ b/config.json
@@ -32,7 +32,8 @@
                 "nvidia/",
                 "z-ai/",
                 "minimax/",
-                "moonshotai/"
+                "moonshotai/",
+                "deepseek/"
             ],
             "extra_headers": {
                 "HTTP-Referer": "https://open-llm-proxy.nrp-nautilus.io",

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -330,7 +330,7 @@ def load_config() -> dict:
             "openrouter": {
                 "endpoint": "https://openrouter.ai/api/v1/chat/completions",
                 "api_key_env": "OPENROUTER_KEY",
-                "models": ["anthropic/", "mistralai/", "amazon/", "openai/", "qwen/", "nvidia/", "z-ai/", "minimax/", "moonshotai/"],
+                "models": ["anthropic/", "mistralai/", "amazon/", "openai/", "qwen/", "nvidia/", "z-ai/", "minimax/", "moonshotai/", "deepseek/"],
                 "extra_headers": {
                     "HTTP-Referer": "https://wetlands.nrp-nautilus.io",
                     "X-Title": "Wetlands Chatbot"


### PR DESCRIPTION
Adds `deepseek/` to the OpenRouter provider prefix allowlist in `config.json` (and the code fallback default), so `deepseek/deepseek-v4-flash` routes to OpenRouter instead of silently falling back to NRP (`get_provider_for_model` only matches known prefixes).

Enables a fleet-wide **DeepSeek V4 Flash (OpenRouter)** picker option being added to the geo-agent apps. Docs (README provider table) and CHANGELOG updated.

Deploy: proxy re-clones `main` via its git-sync init container, so a `rollout restart` after merge picks this up.