### PR TITLE
chore: gitignore .ipynb_checkpoints/ and .vscode/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ ENV/
 # Node
 node_modules/
 headless/runs/
+
+# Editor / notebook artifacts
+.ipynb_checkpoints/
+.vscode/


### PR DESCRIPTION
Fleet-wide hygiene: adds `.ipynb_checkpoints/` (Jupyter) and `.vscode/` (editor settings) to `.gitignore` so these local artifacts stop showing as untracked.