### PR TITLE
feat(headless): print ##BENCH-VERSIONS## line from matrix Job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ See [Releases](README.md#releases) for how a release is cut.
 ## [Unreleased]
 
 ### Added
+- **Print a `##BENCH-VERSIONS##` line from the headless matrix Job.** After the Job
+  clones open-llm-proxy + geo-agent + the app repo, it now emits a single grep-able
+  line with the exact geo-agent / app / proxy git SHAs (from the shallow clones), the
+  app repo, both branches, and the app config's `mcp_url`. Lets downstream benchmark
+  tooling (`boettiger-lab/geo-agent-benchmark`, olp#91) capture a reproducible
+  `versions` block per run instead of guessing which stack a score was measured under.
+  Purely additive logging — does not affect the matrix run.
 - **Route the `deepseek/` OpenRouter family.** Added `deepseek/` to the OpenRouter
   provider's prefix allowlist so `deepseek/deepseek-v4-flash` (and other
   `deepseek/…` models) route instead of silently falling back to NRP. Enables the

--- a/headless/k8s/matrix-job.yaml
+++ b/headless/k8s/matrix-job.yaml
@@ -81,6 +81,18 @@ spec:
               git clone --depth 1 --branch "$APP_BRANCH" \
                   "https://github.com/$APP_REPO.git" "$APP_NAME"
 
+              # Record the exact stack this run used, as a single grep-able line, so
+              # downstream tooling (e.g. geo-agent-benchmark/scripts/collect_run.py) can
+              # populate a reproducible versions block. SHAs come from the shallow clones;
+              # mcp_url from the app config. Non-allowlisted $vars survive envsubst and
+              # run in-pod. Purely additive — does not affect the matrix run.
+              GEO_SHA="$(git -C /work/geo-agent rev-parse HEAD 2>/dev/null || echo unknown)"
+              APP_SHA="$(git -C "/work/$APP_NAME" rev-parse HEAD 2>/dev/null || echo unknown)"
+              PROXY_SHA="$(git -C /work/open-llm-proxy rev-parse HEAD 2>/dev/null || echo unknown)"
+              MCP_URL="$(python3 -c "import json,sys;print(json.load(open('/work/$APP_NAME/layers-input.json')).get('mcp_url',''))" 2>/dev/null || echo '')"
+              printf '##BENCH-VERSIONS## {"geo_agent":"%s","app_repo":"%s","app_sha":"%s","proxy_sha":"%s","mcp_url":"%s","app_branch":"%s","geo_agent_branch":"%s"}\n' \
+                  "$GEO_SHA" "$APP_REPO" "$APP_SHA" "$PROXY_SHA" "$MCP_URL" "$APP_BRANCH" "$GEO_AGENT_BRANCH"
+
               cd /work/open-llm-proxy/headless
               npm ci --no-audit --no-fund
 


### PR DESCRIPTION
Additive logging in the headless matrix Job: after cloning open-llm-proxy + geo-agent + the app repo, print one grep-able line with the exact geo-agent / app / proxy git SHAs, app repo, branches, and app-config `mcp_url`.

This lets the new benchmark repo (`boettiger-lab/geo-agent-benchmark`, see #91) auto-populate a reproducible `versions` block per run via `collect_run.py` — instead of guessing which stack a score was measured under.

- Non-allowlisted `$vars` survive `envsubst` and run in-pod; verified the rendered YAML parses and the SHAs/$(...) are preserved while allowlisted placeholders substitute.
- Purely additive — the matrix run itself is unchanged.

Refs #91