### PR TITLE
feat(logging): capture user_message_this_turn — the per-turn prompt (#89)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ SELECT * FROM read_ndjson_auto('/tmp/open-llm-proxy-logs/YYYY-MM-DD/*.jsonl',
 "
 ```
 
-**Parquet schema** (same for daily and monthly tiers): the hot fields are flattened to typed columns — `ts, type, request_id, session_id, origin, client, provider, model, message_count, tools_count, enable_thinking, user_question, latency_ms, has_tool_calls, has_content, tool_calls, tool_results, tokens, error` — plus `entry VARCHAR`, the full original log record as JSON text (kept for fidelity). Prefer the flat columns; for fields not promoted, use `json_extract_string(entry,'$.field')` / `json_extract(entry,'$.field')` (the `entry::JSON->>` form intermittently throws a cast error in aggregates). Legacy files predating the flatten carry only `ts/type/request_id/origin/entry`.
+**Parquet schema** (same for daily and monthly tiers): the hot fields are flattened to typed columns — `ts, type, request_id, session_id, origin, client, provider, model, message_count, tools_count, enable_thinking, user_question, user_message_this_turn, latency_ms, has_tool_calls, has_content, tool_calls, tool_results, tokens, error` — plus `entry VARCHAR`, the full original log record as JSON text (kept for fidelity). Prefer the flat columns; for fields not promoted, use `json_extract_string(entry,'$.field')` / `json_extract(entry,'$.field')` (the `entry::JSON->>` form intermittently throws a cast error in aggregates). Legacy files predating the flatten carry only `ts/type/request_id/origin/entry`.
 
 **Session view** (`s3://logs-open-llm-proxy/sessions/**/*.parquet`): one row per *turn*, request already joined to its response, ordered by `turn_idx` within `session_key`. This is the query-ready artifact — "show me every turn of session X in order, with tool calls and results" is one flat `SELECT`, no manual interleaving. Disjoint from the `consolidated/**` glob. See [LOGGING.md](LOGGING.md#reconstructing-a-conversation).
 
@@ -49,7 +49,7 @@ For automation, one-shot CI queries, or queries that need sub-minute freshness w
 
 Each LLM call produces a `request` row and a `response` row linked by `request_id`. Key fields inside `entry` (Parquet) or as top-level columns (JSONL):
 
-- **Request**: `user_question`, `tool_results_this_turn`, `model`, `origin`, `message_count`
+- **Request**: `user_question` (session opener), `user_message_this_turn` (the actual prompt for *this* turn — use this to count/read distinct follow-up requests within a session), `tool_results_this_turn`, `model`, `origin`, `message_count`
 - **Response**: `tool_calls`, `content_preview`, `tokens`, `latency_ms`, `error` (only on failures)
 
 **Reconstructing a conversation**: for completed days, just query the **session view** (`sessions/**`) by `session_key` and order by `turn_idx` — the interleaving is already done. To reconstruct by hand (e.g. today's raw JSONL): group by `session_id` (exact; falls back to `user_question` for pre-wiring records), filter by `origin`, sort by `ts` (Parquet) / `timestamp` (JSONL). The `tool_results_this_turn` on each request shows what the previous turn's tool calls returned; `tool_calls` on each response shows what the LLM called next.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ See [Releases](README.md#releases) for how a release is cut.
 ## [Unreleased]
 
 ### Added
+- **Log `user_message_this_turn` — the actual per-turn prompt (#89).** `session_id`
+  persists across a whole browsing day, and `user_question` only ever held the
+  *first* user message of the session, repeated verbatim on every subsequent turn —
+  so distinct mid-session requests were uncountable and the follow-up prompt that
+  triggered a given turn was unrecoverable from the logs (you had to reverse-engineer
+  intent from tool calls). `log_request` now also captures the **last** user message
+  as `user_message_this_turn`, alongside the unchanged `user_question` opener. The
+  field is flattened to a typed column in the daily/monthly consolidated Parquet and
+  surfaced per-turn in the session view, so "read the real sequence of what the user
+  asked" is `SELECT turn_idx, user_message_this_turn … ORDER BY turn_idx`. Captured in
+  the default `summary` mode (no need for `LOG_CAPTURE_MODE=full`). Back-compat: the
+  reflatten schema-upgrade pass re-flattens existing consolidated files to add the
+  column (`null` for pre-#89 records, whose raw `entry` never held it), keeping
+  `consolidated/**` on one schema; the guard sentinel moved from `model` to
+  `user_message_this_turn` so the upgrade re-triggers.
 - **Print a `##BENCH-VERSIONS##` line from the headless matrix Job.** After the Job
   clones open-llm-proxy + geo-agent + the app repo, it now emits a single grep-able
   line with the exact geo-agent / app / proxy git SHAs (from the shallow clones), the

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -59,6 +59,7 @@ for fidelity, so old `entry::JSON->>'…'` / `json_extract_string` queries still
 | `tools_count` | `INTEGER` | Request only — tools offered |
 | `enable_thinking` | `BOOLEAN` | Request only — the thinking mode the client **asked for** (`request.enable_thinking`). `null` = flag not sent / model default; `true`/`false` = explicit override. Distinct from the response-side `has_reasoning_content` (what the model actually **did**) — together they disambiguate "reasoning off by request" from "model chose not to think" from "non-thinking model". |
 | `user_question` | `VARCHAR` | Request only — **first** user message (see trap below) |
+| `user_message_this_turn` | `VARCHAR` | Request only — the **last** user message, i.e. the actual prompt that triggered *this* turn. Use this (not `user_question`) to count or read distinct requests within a session. `null` on records written before #89. |
 | `latency_ms` | `BIGINT` | Response only |
 | `has_tool_calls` | `BOOLEAN` | Response only |
 | `has_content` | `BOOLEAN` | Response only |
@@ -95,6 +96,7 @@ request/response interleaving:
 | `request_id` | `VARCHAR` | |
 | `origin`, `client`, `provider`, `model` | `VARCHAR` | |
 | `user_question` | `VARCHAR` | Opening question (same first-message-only caveat) |
+| `user_message_this_turn` | `VARCHAR` | The actual prompt for this turn (last user message). This is the field to read per-turn — `SELECT turn_idx, user_message_this_turn` gives the real sequence of what the user asked. `null` before #89. |
 | `message_count` | `INTEGER` | |
 | `enable_thinking` | `BOOLEAN` | Requested thinking mode this turn (`null` = default / not sent). Pair with `reasoning_content` to compare requested-vs-observed reasoning per turn. |
 | `tool_results` | `JSON` | Tool outputs that came *into* this turn |
@@ -211,7 +213,7 @@ origins), so capture is **training-grade**, controlled by `LOG_CAPTURE_MODE`:
 
 | Mode | What's captured | Use |
 |---|---|---|
-| `summary` (default) | Full response `content`/`reasoning_content`, generously-capped `user_question` and tool results, full `tool_calls`. **No** raw prompt. | Observability + most analysis; the response target is faithful. |
+| `summary` (default) | Full response `content`/`reasoning_content`, generously-capped `user_question` **and per-turn `user_message_this_turn`** and tool results, full `tool_calls`. **No** raw prompt (the full `messages` array). | Observability + most analysis; the response target is faithful, and follow-up prompts are captured per turn. |
 | `full` | Everything in `summary`, **plus** the entire `messages` array per request (system prompt de-duplicated by hash). | Reconstructing exact `(messages → completion)` training pairs. |
 
 Caps are tunable per field via env vars (`0` = uncapped): `LOG_CONTENT_MAX`
@@ -273,7 +275,8 @@ Each LLM call produces two JSON entries on stdout: a `REQUEST` line when the cal
 | `message_count` | Total messages in the conversation at this turn |
 | `tools_count` | Number of tools available to the LLM |
 | `enable_thinking` | The thinking mode the client **requested** for this turn (`request.enable_thinking`): `null` when the flag wasn't sent (model default), `true`/`false` on an explicit override. The request-side counterpart to the response's `has_reasoning_content`/`reasoning_content` (what the model actually did). Lets you tell "reasoning off by request" apart from "model chose not to think" and from "non-thinking model" — needed to evaluate a user-facing reasoning toggle from live traffic. |
-| `user_question` | First `role: user` message in the conversation. ⚠️ **First-message-only — this is a trap.** It is the human's *original* opening question and is stable across all turns of a tool-use loop, but it does **not** update when the user asks a follow-up in the same session. A session where the user opens with "Tell me about datasets" and later asks "now map the hardwood woodland" logs **both** turns under `user_question = "Tell me about datasets"`; the follow-up text lives only inside the `messages` array (`full` mode) and is invisible to any `user_question` filter. To find follow-ups, full-text-search the whole record or capture `session_id`. Capped at `LOG_USER_QUESTION_MAX` chars (default 4000). |
+| `user_question` | First `role: user` message in the conversation. ⚠️ **First-message-only — this is a trap.** It is the human's *original* opening question and is stable across all turns of a tool-use loop, but it does **not** update when the user asks a follow-up in the same session. A session where the user opens with "Tell me about datasets" and later asks "now map the hardwood woodland" logs **both** turns under `user_question = "Tell me about datasets"`. **To read the actual per-turn prompt, use `user_message_this_turn` instead** (below) — the trap only applies if you filter on `user_question`. Capped at `LOG_USER_QUESTION_MAX` chars (default 4000). |
+| `user_message_this_turn` | Last `role: user` message in the conversation — the actual prompt that triggered **this** turn (#89). This is the field to group/count/read distinct requests within a session, since `session_id` persists across a whole browsing day. On a one-shot first turn it equals `user_question`; on a follow-up it carries the new prompt ("now map the hardwood woodland") that `user_question` misses. `null` on records written before #89. Capped at `LOG_USER_QUESTION_MAX` chars. |
 | `tool_results_this_turn` | Array of `{tool_call_id, content}` for any `role: tool` messages appended since the last assistant turn. Captures results from both local geo-agent tools (e.g. `list_datasets`, `get_dataset_details`) and remote MCP tools (e.g. `query`). Each `content` is capped at `LOG_TOOL_RESULT_MAX` chars (default 20000). `null` on the first turn. |
 | `messages` | **Only when `LOG_CAPTURE_MODE=full`.** The entire scrubbed `messages` array sent to the provider — training-grade fidelity. The large system prompt is de-duplicated: each `role: system` message is replaced by `{role, system_sha256, content_len, _dedup: true}` and the full body is emitted once (per worker) as a separate `type: "system_prompt"` entry. Join `messages[].system_sha256` → the `system_prompt` entry to rehydrate. |
 
@@ -336,7 +339,7 @@ Records written before this wiring have `session_id = null`; group those by the
 > ordered by `turn_idx`. No manual pairing, no JSON casting:
 >
 > ```sql
-> SELECT turn_idx, model, user_question,
+> SELECT turn_idx, model, user_message_this_turn,   -- the real prompt each turn (not the stale opener)
 >        json_array_length(tool_results) AS results_in,
 >        json_array_length(tool_calls)   AS calls_out,
 >        assistant_content, latency_ms
@@ -358,7 +361,7 @@ Each POST to `/v1/chat/completions` is one LLM turn. A single user session produ
 
 Use `request_id` to pair each request with its response when log lines are interleaved under concurrent load.
 
-> ⚠️ **`user_question` groups by *opening* question, not by session.** Step 2 is a heuristic with two failure modes: (a) two different users who happen to open with the same question collapse into one apparent session, and (b) a single user's **follow-up questions never get their own group** — they stay pinned to the opening `user_question` (see the field note above). When `session_id` is populated, group by it instead — it is exact and survives follow-ups. Until then, treat a single `user_question` group as "one opening question and everything that followed it," not "one atomic question."
+> ⚠️ **`user_question` groups by *opening* question, not by session.** Step 2 is a heuristic with two failure modes: (a) two different users who happen to open with the same question collapse into one apparent session, and (b) a single user's **follow-up questions never get their own group** — they stay pinned to the opening `user_question` (see the field note above). When `session_id` is populated, group by it instead — it is exact and survives follow-ups. Until then, treat a single `user_question` group as "one opening question and everything that followed it," not "one atomic question." **To recover the distinct user requests *within* a session, read/segment on `user_message_this_turn` (#89), which carries each turn's actual prompt** — `user_question` cannot distinguish them.
 
 > 📋 **Brittle-JSON caveat (consolidated Parquet).** `entry::JSON->>'field'` intermittently throws `Conversion Error: Failed to cast value to numerical` — DuckDB mis-infers an all-`null` or numeric-looking JSON path and tries to cast the whole `entry` blob. It is load-bearing-flaky: the same expression works in a bare `SELECT` but fails inside a `GROUP BY`/aggregate. Use `json_extract_string(entry, '$.field')` (for text) and `json_extract(entry, '$.field')` (for JSON) instead — they never throw.
 

--- a/consolidate-daily-cronjob.yaml
+++ b/consolidate-daily-cronjob.yaml
@@ -136,6 +136,7 @@ spec:
                                       TRY_CAST(json_extract_string(entry,'$.message_count') AS INTEGER) AS message_count,
                                       TRY_CAST(json_extract_string(entry,'$.enable_thinking') AS BOOLEAN) AS enable_thinking,
                                       json_extract_string(entry,'$.user_question') AS user_question,
+                                      json_extract_string(entry,'$.user_message_this_turn') AS user_message_this_turn,
                                       json_extract(entry,'$.tool_results_this_turn') AS tool_results,
                                       TRY_CAST(json_extract_string(entry,'$.latency_ms') AS BIGINT) AS latency_ms,
                                       TRY_CAST(json_extract_string(entry,'$.has_tool_calls') AS BOOLEAN) AS has_tool_calls,
@@ -154,7 +155,7 @@ spec:
                               ),
                               req AS (
                                   SELECT session_key, session_id, request_id, ts, origin, client, provider, model,
-                                         user_question, message_count, enable_thinking, tool_results,
+                                         user_question, user_message_this_turn, message_count, enable_thinking, tool_results,
                                          ROW_NUMBER() OVER (PARTITION BY session_key ORDER BY ts, request_id) AS turn_idx
                                   FROM keyed
                               ),
@@ -166,7 +167,7 @@ spec:
                               SELECT req.session_key, req.session_id, req.turn_idx,
                                      req.ts AS request_ts, resp.response_ts, req.request_id,
                                      req.origin, req.client, req.provider, req.model,
-                                     req.user_question, req.message_count, req.enable_thinking, req.tool_results,
+                                     req.user_question, req.user_message_this_turn, req.message_count, req.enable_thinking, req.tool_results,
                                      resp.assistant_content, resp.reasoning_content, resp.tool_calls,
                                      resp.has_tool_calls, resp.has_content, resp.latency_ms, resp.tokens, resp.error
                               FROM req LEFT JOIN resp USING (request_id)
@@ -185,7 +186,11 @@ spec:
                   # COPY overwrites the source key.
                   def reflatten(path):
                       cols = [r[0] for r in con.execute(f"DESCRIBE SELECT * FROM read_parquet('{path}')").fetchall()]
-                      if 'model' in cols:
+                      # Sentinel = the newest flat column. Guarding on the latest-added
+                      # column (not just 'model') re-flattens wide-but-stale files when a
+                      # new column lands, keeping consolidated/** on one schema so the glob
+                      # composes without union_by_name (see the flatten note below).
+                      if 'user_message_this_turn' in cols:
                           return False
                       con.execute(f"""
                           CREATE OR REPLACE TEMP TABLE _wide AS
@@ -199,6 +204,7 @@ spec:
                                  TRY_CAST(json_extract_string(entry,'$.tools_count')   AS INTEGER) AS tools_count,
                                  TRY_CAST(json_extract_string(entry,'$.enable_thinking') AS BOOLEAN) AS enable_thinking,
                                  json_extract_string(entry,'$.user_question') AS user_question,
+                                 json_extract_string(entry,'$.user_message_this_turn') AS user_message_this_turn,
                                  TRY_CAST(json_extract_string(entry,'$.latency_ms') AS BIGINT) AS latency_ms,
                                  TRY_CAST(json_extract_string(entry,'$.has_tool_calls') AS BOOLEAN) AS has_tool_calls,
                                  TRY_CAST(json_extract_string(entry,'$.has_content')   AS BOOLEAN) AS has_content,
@@ -232,6 +238,7 @@ spec:
                                      TRY_CAST(json->>'tools_count'   AS INTEGER)  AS tools_count,
                                      TRY_CAST(json->>'enable_thinking' AS BOOLEAN) AS enable_thinking,
                                      json->>'user_question'                       AS user_question,
+                                     json->>'user_message_this_turn'              AS user_message_this_turn,
                                      TRY_CAST(json->>'latency_ms' AS BIGINT)      AS latency_ms,
                                      TRY_CAST(json->>'has_tool_calls' AS BOOLEAN) AS has_tool_calls,
                                      TRY_CAST(json->>'has_content'    AS BOOLEAN) AS has_content,

--- a/consolidate-monthly-cronjob.yaml
+++ b/consolidate-monthly-cronjob.yaml
@@ -124,6 +124,7 @@ spec:
                                       TRY_CAST(json_extract_string(entry,'$.message_count') AS INTEGER) AS message_count,
                                       TRY_CAST(json_extract_string(entry,'$.enable_thinking') AS BOOLEAN) AS enable_thinking,
                                       json_extract_string(entry,'$.user_question') AS user_question,
+                                      json_extract_string(entry,'$.user_message_this_turn') AS user_message_this_turn,
                                       json_extract(entry,'$.tool_results_this_turn') AS tool_results,
                                       TRY_CAST(json_extract_string(entry,'$.latency_ms') AS BIGINT) AS latency_ms,
                                       TRY_CAST(json_extract_string(entry,'$.has_tool_calls') AS BOOLEAN) AS has_tool_calls,
@@ -142,7 +143,7 @@ spec:
                               ),
                               req AS (
                                   SELECT session_key, session_id, request_id, ts, origin, client, provider, model,
-                                         user_question, message_count, enable_thinking, tool_results,
+                                         user_question, user_message_this_turn, message_count, enable_thinking, tool_results,
                                          ROW_NUMBER() OVER (PARTITION BY session_key ORDER BY ts, request_id) AS turn_idx
                                   FROM keyed
                               ),
@@ -154,7 +155,7 @@ spec:
                               SELECT req.session_key, req.session_id, req.turn_idx,
                                      req.ts AS request_ts, resp.response_ts, req.request_id,
                                      req.origin, req.client, req.provider, req.model,
-                                     req.user_question, req.message_count, req.enable_thinking, req.tool_results,
+                                     req.user_question, req.user_message_this_turn, req.message_count, req.enable_thinking, req.tool_results,
                                      resp.assistant_content, resp.reasoning_content, resp.tool_calls,
                                      resp.has_tool_calls, resp.has_content, resp.latency_ms, resp.tokens, resp.error
                               FROM req LEFT JOIN resp USING (request_id)
@@ -168,7 +169,10 @@ spec:
                   # Mirrors the daily job; here it upgrades monthly files.
                   def reflatten(path):
                       cols = [r[0] for r in con.execute(f"DESCRIBE SELECT * FROM read_parquet('{path}')").fetchall()]
-                      if 'model' in cols:
+                      # Sentinel = the newest flat column (see daily job): guarding on the
+                      # latest-added column re-flattens wide-but-stale files when a new
+                      # column lands, keeping consolidated/** on one schema.
+                      if 'user_message_this_turn' in cols:
                           return False
                       con.execute(f"""
                           CREATE OR REPLACE TEMP TABLE _wide AS
@@ -182,6 +186,7 @@ spec:
                                  TRY_CAST(json_extract_string(entry,'$.tools_count')   AS INTEGER) AS tools_count,
                                  TRY_CAST(json_extract_string(entry,'$.enable_thinking') AS BOOLEAN) AS enable_thinking,
                                  json_extract_string(entry,'$.user_question') AS user_question,
+                                 json_extract_string(entry,'$.user_message_this_turn') AS user_message_this_turn,
                                  TRY_CAST(json_extract_string(entry,'$.latency_ms') AS BIGINT) AS latency_ms,
                                  TRY_CAST(json_extract_string(entry,'$.has_tool_calls') AS BOOLEAN) AS has_tool_calls,
                                  TRY_CAST(json_extract_string(entry,'$.has_content')   AS BOOLEAN) AS has_content,

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -459,6 +459,15 @@ def log_request(provider: str, model: str, messages: List[Dict], tools_count: in
         (m.get("content", "") for m in messages if m.get("role") == "user"),
         ""
     )
+    # Extract THIS turn's user message (the LAST human message). session_id persists
+    # across a whole browsing day, so `user_question` above is only the session
+    # opener, repeated on every subsequent turn; this field carries the actual
+    # prompt that triggered the current turn, making distinct mid-session requests
+    # countable and readable from the logs (#89).
+    user_message_this_turn = next(
+        (m.get("content", "") for m in reversed(messages) if m.get("role") == "user"),
+        ""
+    )
     # Extract tool results added in this turn (role=tool messages at the end of history)
     # These capture both local geo-agent tool results and MCP tool results
     tool_results = []
@@ -487,6 +496,7 @@ def log_request(provider: str, model: str, messages: List[Dict], tools_count: in
         # the flag / model default; True/False = explicit request override.
         "enable_thinking": enable_thinking,
         "user_question": _scrub_text(_cap(user_question, _USER_QUESTION_MAX)),
+        "user_message_this_turn": _scrub_text(_cap(user_message_this_turn, _USER_QUESTION_MAX)),
         "tool_results_this_turn": list(reversed(tool_results)) if tool_results else None,
     }
     # Training-grade fidelity: capture the entire (scrubbed, system-deduped)

--- a/test_logging.py
+++ b/test_logging.py
@@ -137,6 +137,37 @@ def test_summary_mode_omits_messages():
     assert "messages" not in p._log_buffer[-1]
 
 
+def test_user_message_this_turn_is_latest_not_opener():
+    # #89: session_id persists across a whole browsing day, so `user_question`
+    # (the FIRST user message) is only the session opener. `user_message_this_turn`
+    # must carry the LAST user message so distinct mid-session requests are
+    # countable and the actual triggering prompt is recoverable.
+    p = _reload(LOG_CAPTURE_MODE="summary")
+    p._log_buffer.clear()
+    msgs = [
+        {"role": "user", "content": "show 3d hex of US vulnerable carbon"},  # opener
+        {"role": "assistant", "content": "..."},
+        {"role": "tool", "tool_call_id": "t1", "content": "result"},
+        {"role": "assistant", "content": "..."},
+        {"role": "user", "content": "now re-render on a log scale"},         # this turn
+    ]
+    p.log_request("nrp", "qwen3", msgs, request_id="r1")
+    entry = p._log_buffer[-1]
+    assert entry["user_question"] == "show 3d hex of US vulnerable carbon"
+    assert entry["user_message_this_turn"] == "now re-render on a log scale"
+
+
+def test_user_message_this_turn_equals_opener_on_first_turn():
+    # On a single-message first turn the two fields coincide (no regression for
+    # the common one-shot case).
+    p = _reload(LOG_CAPTURE_MODE="summary")
+    p._log_buffer.clear()
+    p.log_request("nrp", "qwen3", [{"role": "user", "content": "hi"}], request_id="r1")
+    entry = p._log_buffer[-1]
+    assert entry["user_question"] == "hi"
+    assert entry["user_message_this_turn"] == "hi"
+
+
 def test_request_logs_requested_enable_thinking():
     # #64: the requested thinking mode must be logged so it can be told apart from
     # observed reasoning after the fact. None (not sent) / True / False all round-trip,


### PR DESCRIPTION
## Problem (#89)

`session_id` persists across a whole browsing day, and `user_question` only ever held the **first** user message of the session — repeated verbatim on every subsequent turn. So from the logs you **cannot** count distinct mid-session requests or read the follow-up prompt that triggered a given turn; you have to reverse-engineer intent from tool calls.

This surfaced while investigating a ca-30x30 DoD-hallucination report: the offending turn's real question ("what habitats make up the conserved lands") was invisible — every turn logged `user_question = "What percent of California is protected?"` (the session opener).

## Fix

`log_request` now also captures the **last** user message as `user_message_this_turn`, alongside the unchanged `user_question` opener.

- **Proxy** (`llm_proxy.py`): new field, scrubbed + capped identically to `user_question`. Captured in the default `summary` mode — no `LOG_CAPTURE_MODE=full` needed.
- **Consolidation** (daily + monthly cronjobs): flattened to a typed column in `consolidated/**`, and surfaced per-turn in the `sessions/**` view (base CTE → `req` → final SELECT).
- **Back-compat / schema uniformity**: the `reflatten` guard sentinel moves from `'model'` → `'user_message_this_turn'` so existing wide files get re-flattened once to add the column (`null` for pre-#89 records, whose raw `entry` never held the key). Keeps `consolidated/**` on a single schema so the glob composes without `union_by_name`. Idempotent thereafter.

## Verification

- `test_logging.py`: +2 tests (opener≠this-turn on a follow-up; equal on a one-shot first turn). Full suite: **33 passed**.
- Consolidation SQL exercised end-to-end against local DuckDB: daily flatten, session view, and the reflatten upgrade+idempotency all produce the expected `user_message_this_turn` (and `null` for legacy entries).
- YAML manifests parse; docs updated (`LOGGING.md` field tables + trap note + reconstruction example, `AGENTS.md` column list, `CHANGELOG.md`).

## Acceptance (from #89)

- ✅ A mid-session request carries the text of that turn's user message, not the session opener.
- ✅ Segmenting a day's traffic by `user_message_this_turn` recovers the true request count with the actual follow-up prompt text present.

Closes #89