### PR TITLE
feat(config): route OpenRouter floating aliases (`~…`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ See [Releases](README.md#releases) for how a release is cut.
 ## [Unreleased]
 
 ### Added
+- **Route OpenRouter floating aliases (`~…`).** OpenRouter publishes always-latest
+  aliases whose model id carries a literal leading tilde — e.g.
+  `~deepseek/deepseek-v4-flash-latest` (canonical slug identical), as distinct from
+  the pinned `deepseek/deepseek-v4-flash-0731`. Because `get_provider_for_model`
+  matches by `str.startswith`, such an id matched *no* vendor prefix and silently
+  fell back to NRP, which does not serve it. Added `~` to the OpenRouter prefix
+  allowlist (`config.json` plus the in-code default), so any floating alias routes
+  to OpenRouter. No other provider's model ids begin with `~`, so the broad prefix
+  is unambiguous.
+
 - **Log `user_message_this_turn` — the actual per-turn prompt (#89).** `session_id`
   persists across a whole browsing day, and `user_question` only ever held the
   *first* user message of the session, repeated verbatim on every subsequent turn —

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Configured in `config.json`. Most deployments only need NRP:
 | Provider | Models | Notes |
 |---|---|---|
 | **NRP** (`ellm.nrp-nautilus.io`) | `kimi`, `qwen3`, `glm-5`, `minimax-m2`, `gpt-oss`, `gemma` | Default; supports `enable_thinking` for applicable models |
-| **OpenRouter** | `anthropic/…`, `mistralai/…`, `openai/…`, `qwen/…`, `nvidia/…`, `amazon/…`, `z-ai/…`, `minimax/…`, `moonshotai/…`, `deepseek/…` | Prefix match; requires separate API key |
+| **OpenRouter** | `anthropic/…`, `mistralai/…`, `openai/…`, `qwen/…`, `nvidia/…`, `amazon/…`, `z-ai/…`, `minimax/…`, `moonshotai/…`, `deepseek/…`, `~…` | Prefix match; requires separate API key. The `~` prefix catches OpenRouter's *floating aliases* (e.g. `~deepseek/deepseek-v4-flash-latest`), whose ids are literally `~`-prefixed and so never match a vendor prefix |
 | **Anthropic** | `claude-…` (default `claude-sonnet-4-6`; `claude-opus-4-8`, `claude-haiku-4-5` also route) | Direct via Anthropic's OpenAI-compatible `/v1/chat/completions`; prefix match. Bills the Developer Platform API (not the Claude.ai Team plan) — set `ANTHROPIC_API_KEY`. The default model is chosen app-side (`llm_model`); the proxy just routes whatever `claude-*` it receives. **No prompt caching** — see below |
 | **Nimbus** | `nemotron` | Private vLLM instance; requires separate API key |
 

--- a/config.json
+++ b/config.json
@@ -33,7 +33,8 @@
                 "z-ai/",
                 "minimax/",
                 "moonshotai/",
-                "deepseek/"
+                "deepseek/",
+                "~"
             ],
             "extra_headers": {
                 "HTTP-Referer": "https://open-llm-proxy.nrp-nautilus.io",

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -330,7 +330,7 @@ def load_config() -> dict:
             "openrouter": {
                 "endpoint": "https://openrouter.ai/api/v1/chat/completions",
                 "api_key_env": "OPENROUTER_KEY",
-                "models": ["anthropic/", "mistralai/", "amazon/", "openai/", "qwen/", "nvidia/", "z-ai/", "minimax/", "moonshotai/", "deepseek/"],
+                "models": ["anthropic/", "mistralai/", "amazon/", "openai/", "qwen/", "nvidia/", "z-ai/", "minimax/", "moonshotai/", "deepseek/", "~"],
                 "extra_headers": {
                     "HTTP-Referer": "https://wetlands.nrp-nautilus.io",
                     "X-Title": "Wetlands Chatbot"


### PR DESCRIPTION
## Problem

OpenRouter publishes always-latest aliases whose model id carries a **literal leading tilde** — e.g. `~deepseek/deepseek-v4-flash-latest` (its `canonical_slug` is identical; `tokenizer: "Router"`; its `/endpoints` response is empty because resolution happens OpenRouter-side at request time).

`get_provider_for_model` matches providers by `str.startswith`, so `~deepseek/…` matched **no** vendor prefix and fell through to the NRP default — which does not serve it. That is a silent wrong-provider route, not an error: same failure mode #90 fixed for the dated `deepseek/…` ids.

## Fix

Add `~` to the OpenRouter prefix allowlist, in `config.json` and the in-code default dict that mirrors it. No other provider's model ids begin with `~`, so the broad prefix is unambiguous and catches every future floating alias, not just DeepSeek's.

## Verification

Routing table after the change (no regressions):

| model | provider |
|---|---|
| `~deepseek/deepseek-v4-flash-latest` | openrouter |
| `deepseek/deepseek-v4-flash-0731` | openrouter |
| `z-ai/glm-5.2` | openrouter |
| `qwen3` | nrp |
| `qwen` | nimbus |
| `claude-sonnet-5` | anthropic |
| `gemma4` | gemma4-nimbus |

`33/33` tests pass. Audited the rest of the `~` path: the model id never reaches a URL path, cache key, or S3 log path (endpoint is a fixed URL, model rides in the JSON body), and `headless/run_matrix.sh` handles it safely — `--model "$m"` is quoted so no tilde expansion, and `msafe` only rewrites `/`, giving transcript names like `q1__~deepseek_deepseek-v4-flash-latest__t1.json`.

Consumers: the geo-agent-template and bosl-high-seas model dropdowns move to the alias in their own repos.