### PR TITLE
feat(headless): MCP_URL override so a matrix run can target dev

### DIFF
--- a/headless/README.md
+++ b/headless/README.md
@@ -65,6 +65,7 @@ request/response pairs.
 | `MODELS` | Optional override. Default: read from the app's `k8s/configmap.yaml` inside the pod |
 | `TRIALS` / `MAX_TURNS` / `APP_BRANCH` / `NAMESPACE` | Optional; sensible defaults |
 | `GEO_AGENT_BRANCH` | Optional; `boettiger-lab/geo-agent` branch to clone (default `main`). The runner imports its framework from this checkout, so set it to A/B-test a code-level geo-agent change on the open models before it ships in a pinned release. Pair with a second run on `main` for the baseline. |
+| `MCP_URL` | Optional MCP endpoint override (default: the app config's `mcp_url`). Every app commits a production head, so a gate run for an `mcp-data-server` guidance change **must** set this to `https://dev-duckdb-mcp.nrp-nautilus.io/mcp` — the injected guides come from whichever MCP the run talks to. Recorded per cell in the transcript, so a run's target is auditable after the fact. |
 
 ## Local single-run usage (ad-hoc debugging only)
 

--- a/headless/k8s/matrix-job.yaml
+++ b/headless/k8s/matrix-job.yaml
@@ -53,6 +53,8 @@ spec:
               value: "${MODELS}"
             - name: ENABLE_THINKING
               value: "${ENABLE_THINKING}"
+            - name: MCP_URL
+              value: "${MCP_URL}"
             - name: QUESTIONS_B64
               value: "${QUESTIONS_B64}"
             - name: SYSTEM_PROMPT_APPEND_B64
@@ -106,6 +108,7 @@ spec:
               echo "--- questions ---"
               cat "$QFILE"
               echo "--- models override: ${MODELS:-<from configmap>} ---"
+              echo "--- mcp: ${MCP_URL:-<from app config>} ---"
               echo
 
               # Delegate to the existing matrix script. RUNS_DIR is pod-local;
@@ -117,6 +120,7 @@ spec:
               TRIALS="$TRIALS" \
               MAX_TURNS="$MAX_TURNS" \
               MODELS="$MODELS" \
+              MCP_URL="$MCP_URL" \
               RUNS_DIR="$RUNS_DIR_REL" \
                   ./run_matrix.sh "/work/$APP_NAME" || rc=$?
 

--- a/headless/run-matrix-k8s.sh
+++ b/headless/run-matrix-k8s.sh
@@ -29,6 +29,13 @@
 #                          this checkout, so set it to A/B-test a code-level
 #                          change (e.g. a tool-description variant) on the open
 #                          model collection before it ships in a pinned release.
+#   MCP_URL                MCP endpoint override (default: the app config's own
+#                          mcp_url, which every app commits pointing at a
+#                          production head). Set it to
+#                          https://dev-duckdb-mcp.nrp-nautilus.io/mcp to gate an
+#                          mcp-data-server guidance change — the injected guides
+#                          come from whichever MCP the run talks to, so a run
+#                          against prod measures the old guidance.
 #   NAMESPACE              k8s namespace (default biodiversity)
 #   SYSTEM_PROMPT_APPEND_FILE
 #                          path to a local file whose contents are appended to
@@ -73,6 +80,7 @@ ENABLE_THINKING="${ENABLE_THINKING:-true}"
 case "$ENABLE_THINKING" in true|false) ;; *) echo "ERROR: ENABLE_THINKING must be 'true' or 'false' (got: '$ENABLE_THINKING')" >&2; exit 2;; esac
 APP_BRANCH="${APP_BRANCH:-main}"
 GEO_AGENT_BRANCH="${GEO_AGENT_BRANCH:-main}"
+MCP_URL="${MCP_URL:-}"
 NAMESPACE="${NAMESPACE:-biodiversity}"
 
 TS="$(date -u +%Y%m%d-%H%M%S)"
@@ -91,18 +99,19 @@ if [ -n "${SYSTEM_PROMPT_APPEND_FILE:-}" ]; then
 fi
 
 export APP_REPO APP_BRANCH GEO_AGENT_BRANCH APP_NAME JOB_NAME ORIGIN TAG TRIALS MAX_TURNS MODELS \
-    QUESTIONS_B64 SYSTEM_PROMPT_APPEND_B64 ENABLE_THINKING
+    QUESTIONS_B64 SYSTEM_PROMPT_APPEND_B64 ENABLE_THINKING MCP_URL
 
 # Allowlist: only these placeholders are substituted. Without this, envsubst
 # also replaces every $VAR reference in the bash script body (e.g. $QFILE,
 # $PROXY_KEY, $rc) with empty strings, breaking the pod at runtime.
-envsubst '${APP_REPO} ${APP_BRANCH} ${GEO_AGENT_BRANCH} ${APP_NAME} ${JOB_NAME} ${ORIGIN} ${TAG} ${TRIALS} ${MAX_TURNS} ${MODELS} ${QUESTIONS_B64} ${SYSTEM_PROMPT_APPEND_B64} ${ENABLE_THINKING}' \
+envsubst '${APP_REPO} ${APP_BRANCH} ${GEO_AGENT_BRANCH} ${APP_NAME} ${JOB_NAME} ${ORIGIN} ${TAG} ${TRIALS} ${MAX_TURNS} ${MODELS} ${QUESTIONS_B64} ${SYSTEM_PROMPT_APPEND_B64} ${ENABLE_THINKING} ${MCP_URL}' \
     < k8s/matrix-job.yaml | kubectl -n "$NAMESPACE" create -f -
 
 cat <<EOF
 
 job:    $JOB_NAME
 origin: $ORIGIN
+mcp:    ${MCP_URL:-<from app config>}
 
 follow:
   kubectl -n $NAMESPACE logs -f job/$JOB_NAME

--- a/headless/run_matrix.sh
+++ b/headless/run_matrix.sh
@@ -14,6 +14,11 @@
 #   RUNS_DIR            output directory — default runs/<APP_NAME>
 #   MODELS              space-separated override for the model list
 #   QUESTIONS_FILE      path to a file with one question per line (blank lines and #-comments ignored)
+#   MCP_URL             MCP endpoint override — default the app config's mcp_url.
+#                       Set it to the dev server when gating an mcp-data-server
+#                       guidance change: the injected guides come from whichever
+#                       MCP the run talks to, and every committed app config
+#                       points at a production head.
 set -u
 cd "$(dirname "$0")"
 
@@ -105,10 +110,16 @@ ORIGIN="${ORIGIN:-https://${APP_NAME}.nrp-nautilus.io/agent_runner}"
 RUNS_DIR="${RUNS_DIR:-runs/${APP_NAME}}"
 mkdir -p "$RUNS_DIR"
 
+# Optional MCP endpoint override, forwarded to run.js only when set so an unset
+# value keeps the app config's own mcp_url.
+MCP_ARGS=()
+[ -n "${MCP_URL:-}" ] && MCP_ARGS=(--mcp-url "$MCP_URL")
+
 TOTAL=$(( ${#MODEL_ARR[@]} * ${#QUESTIONS[@]} * TRIALS ))
 echo "=== matrix: app=${APP_NAME} models=${#MODEL_ARR[@]} questions=${#QUESTIONS[@]} trials=${TRIALS} → ${TOTAL} runs ==="
 echo "models: ${MODEL_ARR[*]}"
 echo "origin=${ORIGIN}  run-timeout=${PER_RUN_TIMEOUT_SEC}s/${BASH_TIMEOUT_SEC}s  max-turns=${MAX_TURNS}"
+echo "mcp:    ${MCP_URL:-<from app config>}"
 echo "runs:   ${RUNS_DIR}/"
 
 START="$(date +%s)"
@@ -139,6 +150,7 @@ for trial in $(seq 1 "$TRIALS"); do
                 node run.js "$q" \
                     --config "$CONFIG" \
                     --system-prompt "$SYSTEM_PROMPT" \
+                    ${MCP_ARGS[@]+"${MCP_ARGS[@]}"} \
                     --model "$m" \
                     --origin "$ORIGIN" \
                     --max-turns "$MAX_TURNS" \


### PR DESCRIPTION
## Why

`geo-agent-benchmark/AGENTS.md` requires that guidance-change validation runs hit **dev** MCP (`dev-duckdb-mcp.nrp-nautilus.io`), which serves the candidate `:main` guidance. The runner could not do that: it clones the app repo and uses that config's `mcp_url` verbatim, and every committed app config points at a production head — `ca-30x30` at `duckdb-mcp.nrp-nautilus.io`, `geo-agent-template` at `duckdb-mcp.carlboettiger.info` (the cirrus head; `mcp-data-server/AGENTS.md` still claims that one points at dev, which is now stale).

Since the injected `h3-guide.md` / `query-optimization.md` come from whichever MCP the run talks to, a Job run measured the *old* guidance no matter what was on dev. The only way to gate a change was a local `run_matrix.sh` with the proxy key copied out of the cluster Secret onto disk — precisely what the Job path exists to avoid.

Found while gating mcp-data-server#312 / boettiger-lab/mcp-data-server#350.

## What

`run.js` already accepted `--mcp-url`; this threads it through the two wrappers:

    MCP_URL env → run-matrix-k8s.sh → Job env → run_matrix.sh → run.js --mcp-url

Forwarded only when set (`MCP_ARGS` array is empty otherwise), so an unset `MCP_URL` is behavior-preserving — the app config's own `mcp_url` still wins. Both runners echo the resolved endpoint, and `run.js` already records it per cell in the transcript, which is what `collect_run.py` reads into `run.json → versions.mcp_url`.

## Usage

```bash
MCP_URL=https://dev-duckdb-mcp.nrp-nautilus.io/mcp \
  APP_REPO=boettiger-lab/ca-30x30 TIER=regression MODELS="z-ai/glm-5.2" \
  ../geo-agent-benchmark/scripts/run_benchmark.sh
```

## Test

Exercised end-to-end by the mcp-data-server#312 gate run: the Job log's `mcp:` line and every transcript's `mcp_url` show the dev endpoint, and the two res-8/res-9 rollup gate cells respond to guidance that exists only on dev.