### PR TITLE
chore(config): sync NRP model list — add deepseek-v4-flash and gemma/qwen3 variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ See [Releases](README.md#releases) for how a release is cut.
 ## [Unreleased]
 
 ### Added
+- **Sync the NRP model list — `deepseek-v4-flash` and the newer `gemma`/`qwen3`
+  variants.** `config.json`'s `nrp.models` had drifted behind
+  `GET https://ellm.nrp-nautilus.io/v1/models`. Added `deepseek-v4-flash`
+  (`deepseek-ai/DeepSeek-V4-Flash-0731`, 304B, ~1.04M context — the same weights
+  as OpenRouter's pinned `deepseek/deepseek-v4-flash-0731`, now served natively on
+  NRP, so a request can skip OpenRouter and its budget cap), plus `qwen3-small`,
+  `qwen3-4bit`, `gemma-small`, `gemma4-small`, and `gemma4-12b`. The list now
+  mirrors the live endpoint's chat models; `qwen3-embedding` is deliberately
+  omitted (this proxy serves chat completions only).
+
+  Only `deepseek-v4-flash` was previously *unroutable-by-name*: no exact entry and
+  no matching prefix (note `deepseek/` does **not** prefix-match the bare NRP
+  alias), so it hit the unknown-model fallback and logged
+  `⚠️  Unknown model … defaulting to NRP` on every request. It reached NRP by luck
+  of that default; it is now an explicit route. The `gemma*`/`qwen3*` variants were
+  already resolving via the `gemma`/`qwen3` prefixes — listing them explicitly is
+  documentation plus insurance against a future prefix change. Verified that every
+  id the live endpoint reports now routes to `nrp`, and that exact-match precedence
+  still sends `gemma4` → `gemma4-nimbus`, `qwen` → `nimbus`, and `qwen3-6` →
+  `qwen3-cirrus` rather than to NRP.
+
+  `thinking_models` gained `enable_thinking` for `qwen3-small`, `gemma-small`,
+  `gemma4-small`, and `gemma4-12b` (same chat templates as the `qwen3`/`gemma`
+  entries already mapped). `deepseek-v4-flash` is reasoning-capable per NRP's
+  feature matrix but is **not** mapped: its chat-template kwarg name is unverified
+  (the DeepSeek family uses `thinking`, not `enable_thinking`) and probing it needs
+  a live key. Until someone confirms it, a client sending `enable_thinking` for
+  that model gets the documented no-op (`no thinking_key configured — ignoring`)
+  and the model's own default, which is the safe failure.
+
 - **Route OpenRouter floating aliases (`~…`).** OpenRouter publishes always-latest
   aliases whose model id carries a literal leading tilde — e.g.
   `~deepseek/deepseek-v4-flash-latest` (canonical slug identical), as distinct from

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Configured in `config.json`. Most deployments only need NRP:
 
 | Provider | Models | Notes |
 |---|---|---|
-| **NRP** (`ellm.nrp-nautilus.io`) | `kimi`, `qwen3`, `glm-5`, `minimax-m2`, `gpt-oss`, `gemma` | Default; supports `enable_thinking` for applicable models |
+| **NRP** (`ellm.nrp-nautilus.io`) | `kimi`, `qwen3`, `qwen3-small`, `qwen3-4bit`, `glm-5`, `minimax-m2`, `deepseek-v4-flash`, `gpt-oss`, `gemma`, `gemma-small`, `gemma4-small`, `gemma4-12b`, `gemma-small-e4b` | Default; supports `enable_thinking` for applicable models. The list mirrors `GET https://ellm.nrp-nautilus.io/v1/models` (chat models only — `qwen3-embedding` is omitted); NRP adds and retires aliases as the open-weights frontier moves, so re-check it when a model 404s |
 | **OpenRouter** | `anthropic/…`, `mistralai/…`, `openai/…`, `qwen/…`, `nvidia/…`, `amazon/…`, `z-ai/…`, `minimax/…`, `moonshotai/…`, `deepseek/…`, `~…` | Prefix match; requires separate API key. The `~` prefix catches OpenRouter's *floating aliases* (e.g. `~deepseek/deepseek-v4-flash-latest`), whose ids are literally `~`-prefixed and so never match a vendor prefix |
 | **Anthropic** | `claude-…` (default `claude-sonnet-4-6`; `claude-opus-4-8`, `claude-haiku-4-5` also route) | Direct via Anthropic's OpenAI-compatible `/v1/chat/completions`; prefix match. Bills the Developer Platform API (not the Claude.ai Team plan) — set `ANTHROPIC_API_KEY`. The default model is chosen app-side (`llm_model`); the proxy just routes whatever `claude-*` it receives. **No prompt caching** — see below |
-| **Nimbus** | `nemotron` | Private vLLM instance; requires separate API key |
+| **Nimbus** | `qwen`, plus `gemma4` and `qwen3-6` on their own endpoints | Private vLLM instances; require separate API key |
 
 Unknown models fall back to NRP. To customize the model list, edit `config.json` — no code change needed.
 

--- a/config.json
+++ b/config.json
@@ -6,17 +6,27 @@
             "models": [
                 "kimi",
                 "qwen3",
+                "qwen3-small",
+                "qwen3-4bit",
                 "glm-5",
                 "minimax-m2",
+                "deepseek-v4-flash",
                 "gpt-oss",
                 "gemma",
+                "gemma-small",
+                "gemma4-small",
+                "gemma4-12b",
                 "gemma-small-e4b"
             ],
             "thinking_models": {
                 "kimi":   "thinking",
                 "qwen3":  "enable_thinking",
+                "qwen3-small": "enable_thinking",
                 "glm-5": "enable_thinking",
                 "gemma": "enable_thinking",
+                "gemma-small": "enable_thinking",
+                "gemma4-small": "enable_thinking",
+                "gemma4-12b": "enable_thinking",
                 "gemma-small-e4b": "enable_thinking"
             }
         },

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -325,7 +325,8 @@ def load_config() -> dict:
             "nrp": {
                 "endpoint": "https://ellm.nrp-nautilus.io/v1/chat/completions",
                 "api_key_env": "NRP_API_KEY",
-                "models": ["kimi", "qwen3", "glm-5"]
+                "models": ["kimi", "qwen3", "qwen3-small", "glm-5", "minimax-m2",
+                           "deepseek-v4-flash", "gpt-oss", "gemma", "gemma-small"]
             },
             "openrouter": {
                 "endpoint": "https://openrouter.ai/api/v1/chat/completions",


### PR DESCRIPTION
## What

`config.json`'s `nrp.models` had drifted behind the live model list. Synced it to `GET https://ellm.nrp-nautilus.io/v1/models` (chat models only).

**Added:** `deepseek-v4-flash`, `qwen3-small`, `qwen3-4bit`, `gemma-small`, `gemma4-small`, `gemma4-12b`.
**Omitted deliberately:** `qwen3-embedding` — this proxy serves chat completions only.
**Nothing removed:** every alias already listed is still live.

`deepseek-v4-flash` is `deepseek-ai/DeepSeek-V4-Flash-0731` (304B, ~1.04M context) — the same weights as OpenRouter's pinned `deepseek/deepseek-v4-flash-0731`, now served natively on NRP. Worth having: the NRP route skips OpenRouter and its monthly org budget cap.

## Why it mattered for deepseek-v4-flash specifically

It was the one model **unroutable by name**: no exact entry, and no matching prefix — note `deepseek/` does *not* prefix-match the bare NRP alias `deepseek-v4-flash`. It fell through to the unknown-model default, logging `⚠️  Unknown model 'deepseek-v4-flash', defaulting to NRP` on every request. It reached NRP by luck of that default; now it's an explicit route.

The `gemma*`/`qwen3*` variants were already resolving correctly via the `gemma`/`qwen3` prefixes — listing them explicitly is documentation plus insurance against a future prefix change.

## Verification

Routed all 14 live ids plus regression cases through `get_provider_for_model`'s logic:

- every live NRP id → `nrp` (all exact except `qwen3-embedding`, which still prefix-matches and is harmless)
- exact-match precedence intact: `gemma4` → `gemma4-nimbus`, `qwen` → `nimbus`, `qwen3-6` → `qwen3-cirrus` (i.e. the new `gemma`/`qwen3` entries do **not** steal the private endpoints)
- unchanged: `claude-sonnet-4-6` → `anthropic`, `deepseek/deepseek-v4-flash` → `openrouter`, `~openai/gpt-5` → `openrouter`

`config.json` parses; `llm_proxy.py` compiles. (`pytest` isn't installed in this environment, so `test_logging.py` wasn't run — this change touches no logging code.)

## One thing left unverified

`thinking_models` gains `enable_thinking` for `qwen3-small`, `gemma-small`, `gemma4-small`, `gemma4-12b` — same chat templates as the `qwen3`/`gemma` entries already mapped.

**`deepseek-v4-flash` is intentionally left out of `thinking_models`.** It's reasoning-capable per NRP's feature matrix, but the chat-template kwarg name is unverified — the DeepSeek family uses `thinking`, not `enable_thinking` — and confirming it needs a live key against the endpoint. `thinking_models` only takes effect when a client explicitly sends `enable_thinking`, so until someone probes it, such a request gets the documented no-op (`no thinking_key configured — ignoring`) and the model's own default. That's the safe failure, but it does mean `enable_thinking: false` can't currently suppress reasoning on this model. Follow-up for anyone with a key handy.