### PR TITLE
fix(config): declare all live NRP models, incl. deepseek-v4-flash (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ See [Releases](README.md#releases) for how a release is cut.
 ## [Unreleased]
 
 ### Added
+- **Declare every model NRP actually serves, including `deepseek-v4-flash` (#105).**
+  `nrp.models` listed 7 ids while `ellm.nrp-nautilus.io/v1/models` serves 14. The
+  undeclared ones still reached NRP, but only incidentally — `gemma4-small`,
+  `gemma4-12b`, `gemma-small`, `qwen3-small`, `qwen3-4bit` and `qwen3-embedding` rode
+  the broad `gemma`/`qwen3` prefixes, and `deepseek-v4-flash` matched nothing at all,
+  landing on the `⚠️ Unknown model` fallback (log noise on every request, and one
+  prefix edit away from silently rerouting: OpenRouter already carries `deepseek/`).
+  All 14 are now declared explicitly, so the list describes what the provider serves
+  and each routes by intent rather than by luck. Routing is unchanged for every model
+  — the new entries are exact matches for ids that already resolved to NRP.
+  `deepseek-v4-flash` also gains a `thinking_models` entry using the **`thinking`**
+  dialect (as `kimi` does, not `qwen3`'s `enable_thinking`, which it ignores), so its
+  reasoning can actually be toggled. Prefix matching remains provider-declaration-ordered;
+  the `gemma4-nimbus` / `qwen3-cirrus` shadowing noted in #105 is left as-is.
 - **Route OpenRouter floating aliases (`~…`).** OpenRouter publishes always-latest
   aliases whose model id carries a literal leading tilde — e.g.
   `~deepseek/deepseek-v4-flash-latest` (canonical slug identical), as distinct from

--- a/config.json
+++ b/config.json
@@ -10,10 +10,18 @@
                 "minimax-m2",
                 "gpt-oss",
                 "gemma",
-                "gemma-small-e4b"
+                "gemma-small-e4b",
+                "deepseek-v4-flash",
+                "gemma-small",
+                "gemma4-small",
+                "gemma4-12b",
+                "qwen3-small",
+                "qwen3-4bit",
+                "qwen3-embedding"
             ],
             "thinking_models": {
                 "kimi":   "thinking",
+                "deepseek-v4-flash": "thinking",
                 "qwen3":  "enable_thinking",
                 "glm-5": "enable_thinking",
                 "gemma": "enable_thinking",

--- a/test_logging.py
+++ b/test_logging.py
@@ -665,6 +665,37 @@ def test_handler_repairs_dialect_and_logs_count():
     assert "<arg_key>" not in json.dumps(responses[0])                   # log is clean too
 
 
+def test_nrp_models_route_by_declaration_not_fallback():
+    """Every model NRP actually serves must be *declared* in config.json (#105).
+
+    `get_provider_for_model` still lands unknown ids on NRP via its default branch,
+    so an undeclared-but-live model (e.g. `deepseek-v4-flash`) "works" while emitting
+    the unknown-model warning and remaining one prefix-edit away from silently
+    rerouting elsewhere. Assert the routing is intentional: declared, and warning-free.
+    """
+    import contextlib
+    import io
+
+    p = importlib.reload(llm_proxy)
+    # The model ids ellm.nrp-nautilus.io/v1/models serves. Refresh when NRP changes.
+    live = [
+        "gpt-oss", "gemma", "kimi", "minimax-m2", "deepseek-v4-flash", "gemma-small",
+        "gemma4-small", "gemma4-12b", "glm-5", "qwen3", "qwen3-embedding",
+        "qwen3-small", "qwen3-4bit", "gemma-small-e4b",
+    ]
+    for model in live:
+        assert model in p.PROVIDERS["nrp"]["models"], f"{model} is live on NRP but undeclared"
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            provider, _ = p.get_provider_for_model(model)
+        assert provider == "nrp", f"{model} routed to {provider}, not nrp"
+        assert "Unknown model" not in buf.getvalue(), f"{model} reached NRP via the fallback"
+
+    # deepseek-v4-flash ignores `enable_thinking` and honors `thinking` (probed
+    # against the endpoint in #105) — the same dialect kimi uses.
+    assert p.PROVIDERS["nrp"]["thinking_models"]["deepseek-v4-flash"] == "thinking"
+
+
 if __name__ == "__main__":
     import sys
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]


### PR DESCRIPTION
Closes #105 (primary fix + the config-drift item; the prefix-ordering item is deliberately left alone — see below).

## What

`config.json` → `providers.nrp.models` declared 7 ids; `ellm.nrp-nautilus.io/v1/models` currently serves 14 (verified live). All 14 are now declared.

`deepseek-v4-flash` matched **no** exact entry and **no** prefix (`openrouter` carries `deepseek/`, *with a slash*), so it reached NRP only through `get_provider_for_model()`'s `⚠️ Unknown model '<m>', defaulting to NRP` branch: warning noise on every request, and one prefix edit away from silently rerouting to OpenRouter. Six others — `gemma-small`, `gemma4-small`, `gemma4-12b`, `qwen3-small`, `qwen3-4bit`, `qwen3-embedding` — reached NRP incidentally via the broad `gemma`/`qwen3` prefixes.

Also adds the missing thinking dialect:

```json
"thinking_models": { "kimi": "thinking", "deepseek-v4-flash": "thinking", ... }
```

Per the probe in #105, `deepseek-v4-flash` **ignores** `{"enable_thinking": false}` and **honors** `{"thinking": false}` — the `kimi` dialect. Without the entry, `thinking_models.get(model)` missed and the toggle was a silent no-op.

## Routing impact: none

The exact-match pass runs before the prefix pass, and every newly declared id already resolved to `nrp` (six by prefix, one by fallback). The change makes the resolution intentional, not different.

## Deliberately not changed

- **Prefix matching stays provider-declaration-ordered.** #105 notes that `nrp`'s bare `gemma`/`qwen3` shadow the `gemma4-nimbus` and `qwen3-cirrus` providers. Switching to longest-prefix-first would move `gemma4-*` to nimbus and `qwen3-6*` to cirrus — a live routing change whose intent isn't settled, so it's out of scope here.
- **No thinking entries for the other newly declared models.** `qwen3-small`, `qwen3-4bit` and `gemma4-*` still have no `thinking_models` key, so `enable_thinking` remains a no-op for them (unchanged from today). The dialects aren't probed, and guessing risks a 400; worth a follow-up.

## Test

`test_nrp_models_route_by_declaration_not_fallback` asserts each of the 14 live ids is declared, routes to `nrp`, and does so **without** emitting the fallback warning — so the next undeclared-but-live model fails the suite instead of being discovered downstream. 34 passed.