### PR TITLE
fix(config): thinking toggle for qwen3-small and qwen3-4bit (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ See [Releases](README.md#releases) for how a release is cut.
 ## [Unreleased]
 
 ### Added
+- **Thinking toggle for `qwen3-small` and `qwen3-4bit` (#105 follow-up).** Both honor
+  `chat_template_kwargs: {"enable_thinking": false}` at the endpoint, but had no
+  `thinking_models` entry — so a client's `enable_thinking` flag was silently dropped
+  (`thinking_models.get(model)` missed and the proxy only logged an info line). Probed
+  every NRP model that lacked an entry; results now pinned in a test:
+  `qwen3-small`/`qwen3-4bit` honor `enable_thinking` (entries added); `gemma-small`,
+  `gemma4-small` and `gemma4-12b` emit no `reasoning` at any setting, so there is
+  nothing to toggle; `gpt-oss` and `minimax-m2` reason unconditionally and ignore both
+  boolean dialects — `gpt-oss` takes an OpenAI-style `reasoning_effort` *level*, which
+  the boolean `thinking_models` map cannot express. Verified end-to-end through the
+  deployed proxy that `deepseek-v4-flash` now toggles as intended.
 - **Declare every model NRP actually serves, including `deepseek-v4-flash` (#105).**
   `nrp.models` listed 7 ids while `ellm.nrp-nautilus.io/v1/models` serves 14. The
   undeclared ones still reached NRP, but only incidentally — `gemma4-small`,

--- a/config.json
+++ b/config.json
@@ -23,6 +23,8 @@
                 "kimi":   "thinking",
                 "deepseek-v4-flash": "thinking",
                 "qwen3":  "enable_thinking",
+                "qwen3-small": "enable_thinking",
+                "qwen3-4bit": "enable_thinking",
                 "glm-5": "enable_thinking",
                 "gemma": "enable_thinking",
                 "gemma-small-e4b": "enable_thinking"

--- a/test_logging.py
+++ b/test_logging.py
@@ -696,6 +696,37 @@ def test_nrp_models_route_by_declaration_not_fallback():
     assert p.PROVIDERS["nrp"]["thinking_models"]["deepseek-v4-flash"] == "thinking"
 
 
+def test_nrp_thinking_dialects_match_probed_behavior():
+    """The `thinking_models` map records a *probed* fact, not a guess (#105).
+
+    Each live NRP model was sent `{"enable_thinking": false}` and `{"thinking": false}`
+    as `chat_template_kwargs` and checked for a suppressed `reasoning` field. A wrong
+    or missing dialect is silent — `thinking_models.get(model)` misses and the client's
+    `enable_thinking` flag is dropped with only an info log — so pin the map here.
+    """
+    p = importlib.reload(llm_proxy)
+    thinking = p.PROVIDERS["nrp"]["thinking_models"]
+
+    # Honors `thinking`, ignores `enable_thinking`.
+    for model in ["kimi", "deepseek-v4-flash"]:
+        assert thinking[model] == "thinking"
+    # Honors `enable_thinking`.
+    for model in ["qwen3", "qwen3-small", "qwen3-4bit", "glm-5", "gemma"]:
+        assert thinking[model] == "enable_thinking"
+    # Emits no reasoning at any setting, so nothing to toggle. `gemma-small-e4b`
+    # keeps its inert entry (harmless, predates the probe); the rest stay absent
+    # so the client flag is dropped loudly rather than sent as a no-op kwarg.
+    for model in ["gemma-small", "gemma4-small", "gemma4-12b"]:
+        assert model not in thinking
+    # Reasoning is unconditional — neither dialect suppresses it. gpt-oss instead
+    # takes an OpenAI-style `reasoning_effort` *level*, which this boolean map
+    # cannot express; minimax-m2 exposes no off switch at all.
+    for model in ["gpt-oss", "minimax-m2"]:
+        assert model not in thinking
+    # Embedding model — not a chat endpoint.
+    assert "qwen3-embedding" not in thinking
+
+
 if __name__ == "__main__":
     import sys
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]


### PR DESCRIPTION
Follow-up to #106. That PR declared all 14 live NRP models but left the newly declared ones without `thinking_models` entries, since their dialects were unprobed. This probes them.

## Method

For every NRP model with no `thinking_models` entry, sent the same prompt three ways against `ellm.nrp-nautilus.io` — no kwargs, `chat_template_kwargs: {"enable_thinking": false}`, and `{"thinking": false}` — and checked whether the `reasoning` field disappeared relative to baseline.

| model | baseline `reasoning` | `enable_thinking:false` | `thinking:false` | verdict |
|---|---|---|---|---|
| `qwen3-small` | 322 chars | **suppressed** | 322 chars | `enable_thinking` |
| `qwen3-4bit` | 622 chars | **suppressed** | 622 chars | `enable_thinking` |
| `gemma-small` | none | none | none | nothing to toggle |
| `gemma4-small` | none | none | none | nothing to toggle |
| `gemma4-12b` | none | none | none | nothing to toggle |
| `gpt-oss` | 74 chars | ignored | ignored | no boolean off switch |
| `minimax-m2` | 254 chars | ignored | ignored | no off switch |

## Change

`qwen3-small` and `qwen3-4bit` get `enable_thinking` entries. Without them the failure was silent: `thinking_models.get(model)` missed, the client's `enable_thinking` flag was dropped, and the proxy logged only an info line — confirmed live through the deployed proxy, where `enable_thinking=false` on `qwen3-small` left reasoning fully intact.

The other five stay out of the map deliberately, which the new test asserts so the absences read as decisions rather than oversights.

## Also verified

- **`deepseek-v4-flash` works end-to-end** through the deployed proxy after #106: `enable_thinking=false` → reasoning suppressed; `true`/unset → reasoning present. Direct probing re-confirms it ignores `enable_thinking` and honors `thinking`.
- **`gemma-small-e4b`'s existing entry is inert** — the model emits no `reasoning` at any setting, so its `enable_thinking` entry does nothing. Harmless, left alone, noted in the test.
- **`gemma`'s entry is correct** — reasoning present at baseline, suppressed by `enable_thinking:false`.

## Not addressed

`gpt-oss` reasons unconditionally and is documented to take an OpenAI-style `reasoning_effort` *level* (`low`/`medium`/`high`) rather than a boolean. Supporting that needs more than a `thinking_models` entry — the map is boolean-only — so it's left for a follow-up. `minimax-m2` appears to have no off switch at all (it's a reasoning-first model).

35 tests pass.