### PR TITLE
fix: fail loudly on provenance-less matrix runs (#103); correct `get_schema` MCP note (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,32 @@ See [Releases](README.md#releases) for how a release is cut.
   fleet-wide "DeepSeek V4 Flash (OpenRouter)" picker option.
 
 ### Fixed
+- **Fail a matrix Job that can't establish its own provenance, and emit the versions
+  line twice (#103).** A 7-Job full-tier sweep on 2026-08-01 emitted **zero**
+  `##BENCH-VERSIONS##` lines, so 130 graded cells were published to the benchmark store
+  with `{"geo_agent": null, "proxy": null, "app_config_sha": null}` — permanently
+  unreproducible, because the SHAs can only be read from the shallow clones the Job
+  made and those are long gone. Nothing anywhere raised. `matrix-job.yaml` now builds
+  the line into `$BENCH_VERSIONS`, checks that each of `geo_agent`/`app_sha`/`proxy_sha`
+  resolved to something other than empty-or-`unknown`, and on failure prints a
+  `##BENCH-VERSIONS-MISSING##` marker naming the unresolved fields and **exits 1** —
+  before `npm ci`, so an unreproducible benchmark costs nothing instead of a full
+  matrix. This is the last point in the Job that can still see the clones. The line is
+  also echoed a second time in the trailer beside `summary.tsv` (and before `exit $rc`,
+  so a failed matrix still carries it), leaving provenance recoverable from a truncated
+  or rotated log. An empty `mcp_url` warns but does not fail. The emitted JSON is
+  byte-identical to before, so `collect_run.py` needs no change. Root cause of the
+  08-01 silence itself is still open — this makes a recurrence loud rather than silent.
+- **LOGGING.md: `get_schema` *does* reach the MCP server (#63).** The session-
+  reconstruction note claimed `list_datasets` and `get_schema` are both local geo-agent
+  tools whose calls "never reach the MCP server." True of `list_datasets`, wrong of
+  `get_schema`: its `execute()` delegates to the MCP `get_stac_details` tool, forwarding
+  the cached STAC collection inline (`geo-agent/app/map-tools.js`). Because the proxy
+  logs the name the *LLM* called and the delegated request never passes through here,
+  anyone counting MCP tool load from these logs undercounts `get_stac_details` badly —
+  in the June 2026 corpus, 339 direct calls versus ~3,255 actual, the #2 MCP tool. The
+  note now distinguishes local-only from local-delegate and says to attribute every
+  `get_schema` call to `get_stac_details` when estimating server load.
 - **Strip leaked `<arg_key>`/`<arg_value>` (GLM) and `<parameter=…>` (qwen) tool-call
   arg dialect from responses (#85).** Some open-weight backends (`z-ai/glm-5.2`, the
   qwen family) intermittently fail to decode their own tool-call argument encoding,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,9 +85,24 @@ See [Releases](README.md#releases) for how a release is cut.
   matrix. This is the last point in the Job that can still see the clones. The line is
   also echoed a second time in the trailer beside `summary.tsv` (and before `exit $rc`,
   so a failed matrix still carries it), leaving provenance recoverable from a truncated
-  or rotated log. An empty `mcp_url` warns but does not fail. The emitted JSON is
-  byte-identical to before, so `collect_run.py` needs no change. Root cause of the
-  08-01 silence itself is still open — this makes a recurrence loud rather than silent.
+  or rotated log. An empty `mcp_url` warns but does not fail.
+
+  The line now also records **which MCP build the run actually hit**, closing the last
+  provenance gap: `mcp_url` is stable across MCP upgrades, so two runs with identical
+  versions blocks could have queried different servers. The Job GETs `<mcp_root>/version`
+  — public and auth-exempt on mcp-data-server (mcp-data-server#221) — and adds
+  `mcp_server` (e.g. `mcp-data-server v0.8.15`) and `mcp_git_sha` (the running image's
+  full git SHA). This resolves for any head (NRP, dev, cirrus, a mirror) with no cluster
+  access or RBAC, and reports what actually *serves*, unlike a pod `imageID`, which reads
+  stale on disrupted-node orphans (mcp-data-server#383). It replaces the hand-passed
+  `--mcp-server 'mcp-data-server v0.8.10'`, which was exactly the kind of thing that goes
+  stale. Deliberately non-fatal — it is a network call to a third party, so a transient
+  failure records the explicit string `unknown` and warns rather than burning a 130-cell
+  matrix. `mcp_server` fills a key `collect_run.py` already reads (falling back to it when
+  `--mcp-server` is absent), and every pre-existing key is byte-identical, so nothing
+  downstream needs changing; verified against that parser, including the twice-emitted
+  line, which it dedupes idempotently. Root cause of the 08-01 silence itself is still
+  open — this makes a recurrence loud rather than silent.
 - **LOGGING.md: `get_schema` *does* reach the MCP server (#63).** The session-
   reconstruction note claimed `list_datasets` and `get_schema` are both local geo-agent
   tools whose calls "never reach the MCP server." True of `list_datasets`, wrong of

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -378,7 +378,12 @@ REQUEST  msg=6  user_question="Tell me about datasets"  tool_results=[{content: 
 RESPONSE has_content=true  content_preview="The PAD-US dataset contains..."
 ```
 
-Note: `list_datasets` and `get_schema` are local geo-agent tools — their results appear in `tool_results_this_turn` on the proxy but never reach the MCP server.
+Note: `list_datasets` and `get_schema` are both client-side geo-agent tools, but only one of them stays client-side.
+
+- **`list_datasets` is local-only.** It is answered from the in-browser catalog and never reaches the MCP server.
+- **`get_schema` is a local *delegate*.** Its `execute()` forwards to the MCP server as a **`get_stac_details`** call, passing the cached STAC collection inline (`geo-agent/app/map-tools.js`, `callTool('get_stac_details', …)`).
+
+> ⚠️ **Counting MCP tool load from proxy logs undercounts `get_stac_details`.** The proxy logs the name the *LLM* called (`get_schema`); the delegated MCP request does not pass through this proxy, so it is invisible here. To estimate real MCP-server load, attribute every `get_schema` tool-call to `get_stac_details` as well. In the June 2026 corpus that is the difference between 339 direct `get_stac_details` calls and ~3,255 actual ones (~2,916 arriving via `get_schema`) — i.e. the #2 MCP tool, not a minor one.
 
 ## What the MCP server logs add
 

--- a/headless/k8s/matrix-job.yaml
+++ b/headless/k8s/matrix-job.yaml
@@ -96,8 +96,36 @@ spec:
               # assigning the app value there would silently disable the override.
               APP_MCP_URL="$(python3 -c "import json,sys;print(json.load(open('/work/$APP_NAME/layers-input.json')).get('mcp_url',''))" 2>/dev/null || echo '')"
               EFFECTIVE_MCP_URL="${MCP_URL:-$APP_MCP_URL}"
-              BENCH_VERSIONS="$(printf '##BENCH-VERSIONS## {"geo_agent":"%s","app_repo":"%s","app_sha":"%s","proxy_sha":"%s","mcp_url":"%s","app_branch":"%s","geo_agent_branch":"%s"}' \
-                  "$GEO_SHA" "$APP_REPO" "$APP_SHA" "$PROXY_SHA" "$EFFECTIVE_MCP_URL" "$APP_BRANCH" "$GEO_AGENT_BRANCH")"
+
+              # Resolve what the MCP head is actually *running* (#103). mcp_url is stable
+              # across MCP upgrades, so two runs with identical versions blocks can still
+              # have hit different builds — which is why the server version was previously
+              # passed by hand (`--mcp-server 'mcp-data-server v0.8.10'`) and went stale.
+              # mcp-data-server serves a public, auth-exempt /version carrying the running
+              # image's version + git SHA (mcp-data-server#221), so this resolves for any
+              # head — NRP, dev, cirrus, a mirror — with no cluster access or RBAC. It also
+              # reports what actually *serves*, unlike a pod imageID, which reads stale on
+              # disrupted-node orphans (mcp-data-server#383).
+              # Non-fatal, unlike the SHAs above: this is a network call to a third party,
+              # and a transient failure must not burn a 130-cell matrix. It records the
+              # explicit string "unknown" (visible downstream, not absent) and warns.
+              MCP_SERVER=unknown
+              MCP_GIT_SHA=unknown
+              if [ -n "$EFFECTIVE_MCP_URL" ]; then
+                  MCP_PROBE="$(python3 -c 'import json,sys,urllib.parse,urllib.request;u=urllib.parse.urlsplit(sys.argv[1]);r=urllib.parse.urlunsplit((u.scheme,u.netloc,"","",""));d=json.load(urllib.request.urlopen(r+"/version",timeout=20));print("%s|%s"%(d.get("version") or "unknown",d.get("git_sha") or "unknown"))' "$EFFECTIVE_MCP_URL" 2>/dev/null || echo '')"
+                  if [ -n "$MCP_PROBE" ]; then
+                      MCP_SERVER="mcp-data-server ${MCP_PROBE%%|*}"
+                      MCP_GIT_SHA="${MCP_PROBE##*|}"
+                  else
+                      echo "WARNING: no /version from ${EFFECTIVE_MCP_URL} — MCP build recorded as unknown" >&2
+                  fi
+              fi
+
+              # mcp_server fills a key collect_run.py already reads (it falls back to this
+              # when --mcp-server isn't passed), so adding these two keys needs no change
+              # downstream; every other consumer key is byte-identical to before.
+              BENCH_VERSIONS="$(printf '##BENCH-VERSIONS## {"geo_agent":"%s","app_repo":"%s","app_sha":"%s","proxy_sha":"%s","mcp_url":"%s","mcp_server":"%s","mcp_git_sha":"%s","app_branch":"%s","geo_agent_branch":"%s"}' \
+                  "$GEO_SHA" "$APP_REPO" "$APP_SHA" "$PROXY_SHA" "$EFFECTIVE_MCP_URL" "$MCP_SERVER" "$MCP_GIT_SHA" "$APP_BRANCH" "$GEO_AGENT_BRANCH")"
 
               # A run whose provenance is missing is not a valid measurement, so refuse
               # to spend the matrix on one (#103). On 2026-08-01 a 7-Job sweep emitted no

--- a/headless/k8s/matrix-job.yaml
+++ b/headless/k8s/matrix-job.yaml
@@ -96,8 +96,29 @@ spec:
               # assigning the app value there would silently disable the override.
               APP_MCP_URL="$(python3 -c "import json,sys;print(json.load(open('/work/$APP_NAME/layers-input.json')).get('mcp_url',''))" 2>/dev/null || echo '')"
               EFFECTIVE_MCP_URL="${MCP_URL:-$APP_MCP_URL}"
-              printf '##BENCH-VERSIONS## {"geo_agent":"%s","app_repo":"%s","app_sha":"%s","proxy_sha":"%s","mcp_url":"%s","app_branch":"%s","geo_agent_branch":"%s"}\n' \
-                  "$GEO_SHA" "$APP_REPO" "$APP_SHA" "$PROXY_SHA" "$EFFECTIVE_MCP_URL" "$APP_BRANCH" "$GEO_AGENT_BRANCH"
+              BENCH_VERSIONS="$(printf '##BENCH-VERSIONS## {"geo_agent":"%s","app_repo":"%s","app_sha":"%s","proxy_sha":"%s","mcp_url":"%s","app_branch":"%s","geo_agent_branch":"%s"}' \
+                  "$GEO_SHA" "$APP_REPO" "$APP_SHA" "$PROXY_SHA" "$EFFECTIVE_MCP_URL" "$APP_BRANCH" "$GEO_AGENT_BRANCH")"
+
+              # A run whose provenance is missing is not a valid measurement, so refuse
+              # to spend the matrix on one (#103). On 2026-08-01 a 7-Job sweep emitted no
+              # versions line at all and 130 graded cells were published with null SHAs —
+              # unrecoverable after the fact, because the clones are gone. This is the last
+              # point that can still see them. Fail here, before npm ci and the run.
+              MISSING=""
+              for pair in "geo_agent:$GEO_SHA" "app_sha:$APP_SHA" "proxy_sha:$PROXY_SHA"; do
+                  case "${pair#*:}" in
+                      ""|unknown) MISSING="$MISSING ${pair%%:*}" ;;
+                  esac
+              done
+              if [ -n "$MISSING" ] || [ -z "$BENCH_VERSIONS" ]; then
+                  echo "##BENCH-VERSIONS-MISSING## unresolved:${MISSING:- <printf produced nothing>}"
+                  echo "ERROR: cannot establish stack provenance; refusing to run an" >&2
+                  echo "       unreproducible benchmark. See open-llm-proxy#103." >&2
+                  exit 1
+              fi
+              [ -n "$EFFECTIVE_MCP_URL" ] || \
+                  echo "WARNING: mcp_url is empty (no MCP_URL override, none in layers-input.json)" >&2
+              echo "$BENCH_VERSIONS"
 
               cd /work/open-llm-proxy/headless
               npm ci --no-audit --no-fund
@@ -151,6 +172,12 @@ spec:
 
               echo "=== summary.tsv ==="
               cat "$RUNS_DIR_REL/summary.tsv" 2>/dev/null || echo "(no summary written)"
+
+              # Emit provenance a second time, in the trailer beside summary.tsv, so a
+              # truncated or rotated log still carries it (#103). Consumers grep for the
+              # marker and take either copy — the two are byte-identical.
+              echo
+              echo "$BENCH_VERSIONS"
 
               echo
               echo "=== filter proxy logs by origin: $ORIGIN ==="


### PR DESCRIPTION
Two independent quick wins from the open-issue sweep. No proxy code touched — `llm_proxy.py` and `config.json` are untouched, and the 35-test suite passes unchanged.

## 1. `#103` — a benchmark run that can't prove its stack now fails instead of publishing

On 2026-08-01 a 7-Job full-tier sweep emitted **zero** `##BENCH-VERSIONS##` lines. Downstream, `geo-agent-benchmark` recorded `{"geo_agent": null, "proxy": null, "app_config_sha": null}` for all 130 graded cells and published them as `2026-08-01-full`. That provenance is **unrecoverable** — the SHAs exist only in the shallow clones the Job made, and those are gone. Nothing anywhere raised.

This implements all three asks.

**(1) Verify, then fail.** The line is built into `$BENCH_VERSIONS`; each of `geo_agent` / `app_sha` / `proxy_sha` must resolve to something other than empty-or-`unknown`. On failure the Job prints `##BENCH-VERSIONS-MISSING## unresolved: <fields>` and **exits 1** — before `npm ci`, immediately after the clones, the last point that can still see them. An unreproducible benchmark now costs a few seconds instead of a full matrix.

**(2) Emit twice.** The line is echoed again in the trailer beside `summary.tsv`, and before `exit "$rc"`, so a truncated/rotated log — or a *failed* matrix — still carries provenance.

**(3) Record the MCP build.** `mcp_url` is stable across MCP upgrades, so two runs with identical versions blocks could have hit different servers; the version was passed by hand (`--mcp-server 'mcp-data-server v0.8.10'`) and went stale, exactly as the issue predicts.

The Job now derives the root from `mcp_url` and GETs `/version`, which mcp-data-server serves **public and auth-exempt** (mcp-data-server#221), adding:

- `mcp_server` — e.g. `mcp-data-server v0.8.15`
- `mcp_git_sha` — the running image's full git SHA

I went with `/version` rather than the image digest the issue suggested, because it is strictly better here: it needs no cluster access or RBAC (the Job has neither), it resolves for **any** head — NRP, dev, cirrus, a mirror — and it reports what actually *serves*. A pod `imageID` would not: mcp-data-server#383 documents disrupted-node orphans that keep Running with a stale `ready: true` and an old digest. Happy to add the digest too if you want it belt-and-braces, but it can't be read from where this runs.

Deliberately **non-fatal**, unlike the three repo SHAs — it's a network call to a third party, so a transient failure records the explicit string `unknown` (visible downstream, not silently absent) and warns, rather than burning a 130-cell matrix.

### Compatibility

`mcp_server` fills a key **`collect_run.py` already reads** — `"mcp_server": a.mcp_server or ver.get("mcp_server")` — so it now populates automatically, and an explicit `--mcp-server` still overrides. Every pre-existing key is byte-identical; the two additions are new keys only.

Verified against the real parser, not by inspection: `versions_from_logs` picks up `mcp_server`, and the twice-emitted line dedupes idempotently (`if v.get(k) and not shared.get(k)`, plus an idempotent `apps[repo] = sha`). One optional follow-up **for that repo, not this one**: `mcp_git_sha` rides in the log but isn't in `collect_run.py`'s promoted-key tuple, so it isn't lifted into the `versions` block — a one-word addition there if you want it surfaced.

The new shell vars are deliberately **not** on the `envsubst` allowlist in `run-matrix-k8s.sh`, so they survive templating and evaluate in-pod — same convention as the existing `$QFILE` / `$rc`.

**Still open after this:** the 08-01 root cause. This makes a recurrence loud; it does not explain the original silence.

## 2. `#63` — `get_schema` is a local *delegate*, not a local tool

`LOGGING.md` claimed `list_datasets` and `get_schema` both "never reach the MCP server." Correct for the first, wrong for the second.

Verified against the sibling checkout — `geo-agent/app/map-tools.js`: `get_schema`'s `execute()` calls `mcpClient.callTool('get_stac_details', mcpArgs)`, forwarding the cached STAC collection inline. (`list_datasets` reads only from `catalog`, so it really is local-only.)

This matters because the proxy logs the name the **LLM** called, and the delegated MCP request doesn't pass through here — so counting MCP tool load from these logs undercounts `get_stac_details` by roughly 10x. Per #63, the June 2026 corpus shows 339 direct calls against ~3,255 actual, making it the **#2** MCP tool rather than a minor one. The note now separates local-only from local-delegate and tells readers to attribute `get_schema` calls to `get_stac_details` for load estimates.

## Verification

- Guard logic exercised standalone: happy path, `unknown` SHA, two simultaneously-empty SHAs, empty `mcp_url` — correct marker, field names, and exit codes in each.
- MCP probe block extracted **verbatim from the YAML** and run against: NRP prod (→ `mcp-data-server v0.8.15`, git `12d0b705`), the cirrus mirror head (→ `main`, `a5d79aae`), an unresolvable host, a reachable host with no `/version` route, and an empty `mcp_url`. The last three warn, record `unknown`, and exit 0. The `/mcp` path is correctly stripped to root.
- Emitted line parses as valid JSON; fed through the real `collect_run.py` (see above).
- `matrix-job.yaml` parses as YAML; embedded script passes `bash -n`.
- `pytest`: 35 passed.

Not smoke-tested as a live Job — the failure branch needs an artificially broken clone to reach. The happy path is a refactor of the existing `printf` plus one additive probe.
