### PR TITLE
fix(routing): configurable `default_provider`; 400 instead of 500 for unroutable model ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,22 @@ See [Releases](README.md#releases) for how a release is cut.
   fleet-wide "DeepSeek V4 Flash (OpenRouter)" picker option.
 
 ### Fixed
+- **Configurable `default_provider`; unroutable models get a 400, not a 500.** The
+  fallback for a model id matching no provider entry was a hard-coded
+  `return "nrp", PROVIDERS["nrp"]`. On NRP that is load-bearing — most of `nrp.models`
+  is redundant with it, and undeclared-but-live ids have always arrived this way. On a
+  deployment that doesn't serve NRP it was a latent `KeyError` *inside the request
+  handler*: an opaque 500 with no body, which is what the cirrus deployment returns
+  today for every bare NRP model id. The fallback is now the optional top-level
+  `default_provider` key (absent → `"nrp"`, so NRP behavior is untouched), and a
+  deployment with no usable default raises a typed `UnknownModelError` that the handler
+  renders as a **400 listing what this deployment actually serves**, logged against a
+  synthetic `unrouted` provider so the miss is visible. A `default_provider` naming an
+  unconfigured provider degrades to that same 400 path with a startup note rather than
+  failing at request time — which is also how a cirrus-style config (no `nrp` provider,
+  no `default_provider`) now behaves, so it needs no config change to stop 500ing.
+  Verified no behavior change on NRP by diffing resolved providers for all 37 ids in
+  `config.json` plus unknown/empty/floating-alias cases against `origin/main`: identical.
 - **Fail a matrix Job that can't establish its own provenance, and emit the versions
   line twice (#103).** A 7-Job full-tier sweep on 2026-08-01 emitted **zero**
   `##BENCH-VERSIONS##` lines, so 130 graded cells were published to the benchmark store

--- a/README.md
+++ b/README.md
@@ -116,6 +116,32 @@ Copy `config.json` or use it as-is. To use only NRP (the common case), you can t
 }
 ```
 
+#### `default_provider` (optional)
+
+A model id matching no provider entry goes to the **default provider**, which is
+`nrp` unless you say otherwise:
+
+```json
+{
+  "default_provider": "openrouter",
+  "providers": { "…": {} }
+}
+```
+
+This is why an NRP model id works whether or not it appears in `nrp.models` —
+the fallback catches it. Two other values are useful:
+
+- **another provider name** — for a deployment that doesn't serve NRP at all
+  (e.g. `cirrus/`), so unlisted ids land somewhere that exists;
+- **`null`** — no fallback. An unroutable id is rejected with a **400** naming
+  what the deployment *does* serve, instead of being forwarded to a provider
+  that will reject it less clearly.
+
+A `default_provider` naming a provider this deployment doesn't configure is not
+fatal: it logs a note at startup and behaves as `null`. That is also what
+happens on a deployment with no `nrp` provider and no `default_provider` set —
+it gets clear 400s rather than an opaque 500.
+
 ### 3. Set your log bucket
 
 In `deployment.yaml`, set `LOG_BUCKET` to a bucket in your namespace:

--- a/llm_proxy.py
+++ b/llm_proxy.py
@@ -398,6 +398,58 @@ for provider_name, provider_config in config["providers"].items():
         "no_sampling_params": provider_config.get("no_sampling_params", [])
     }
 
+# Provider that serves a model id matching no explicit entry.
+#
+# This was a hard-coded "nrp" for the life of the proxy, which is load-bearing on
+# the NRP deployment: most of `nrp.models` is redundant with this fallback, and
+# undeclared-but-live ids have always reached NRP through it. Keeping "nrp" as the
+# default preserves that behavior exactly.
+#
+# It also *only* worked on a deployment that serves NRP. Anywhere else the lookup
+# raised KeyError inside the request handler — a 500 with no useful body — which is
+# what the cirrus deployment hits for every bare NRP model id. Deployments that
+# don't serve NRP now name their own fallback, or set it to null/"" to reject
+# unroutable ids outright with a 400 that says what *is* served.
+def resolve_default_provider(cfg: dict, providers: dict):
+    """Pick the fallback provider, or None to reject unroutable ids with a 400.
+
+    Absent key -> "nrp", preserving the historical hard-coded behavior on NRP.
+    A named-but-unconfigured provider degrades to None with a warning rather than
+    blowing up at request time — which is exactly how a deployment that doesn't
+    serve NRP (cirrus) behaves with no `default_provider` set at all.
+    """
+    name = cfg.get("default_provider", "nrp")
+    if not name:
+        return None
+    if name not in providers:
+        print(f"ℹ️  default_provider '{name}' is not configured here — "
+              f"unroutable model ids will be rejected with 400")
+        return None
+    return name
+
+
+DEFAULT_PROVIDER = resolve_default_provider(config, PROVIDERS)
+
+
+class UnknownModelError(Exception):
+    """No provider matches this model id, and the deployment has no usable default.
+
+    Carried as an exception rather than a sentinel return so the request handler can
+    turn it into a 400 (client asked for something we don't serve) instead of the
+    KeyError-driven 500 this used to be.
+    """
+
+    def __init__(self, model: str):
+        self.model = model
+        served = "; ".join(
+            f"{name} ({', '.join(cfg['models'][:6])}{'…' if len(cfg['models']) > 6 else ''})"
+            for name, cfg in PROVIDERS.items()
+        )
+        super().__init__(
+            f"Unknown model '{model}'. This deployment serves: {served}"
+        )
+
+
 # Log configuration status
 print("=" * 60)
 print("🚀 Multi-Provider LLM Proxy Starting")
@@ -429,9 +481,11 @@ def get_provider_for_model(model: str) -> tuple[str, dict]:
             if model.startswith(model_prefix):
                 return provider_name, config
     
-    # Default to NRP
-    print(f"⚠️  Unknown model '{model}', defaulting to NRP")
-    return "nrp", PROVIDERS["nrp"]
+    # Fall back to the deployment's default provider, if it has one.
+    if DEFAULT_PROVIDER:
+        print(f"⚠️  Unknown model '{model}', defaulting to {DEFAULT_PROVIDER.upper()}")
+        return DEFAULT_PROVIDER, PROVIDERS[DEFAULT_PROVIDER]
+    raise UnknownModelError(model)
 
 def _never_raises(fn):
     """Logging must never break request serving.
@@ -612,7 +666,14 @@ async def proxy_chat(request: ChatRequest, http_request: Request, authorization:
         raise HTTPException(status_code=401, detail="Unauthorized: Invalid or missing proxy key")
     
     # Determine provider based on model
-    provider_name, provider_config = get_provider_for_model(request.model)
+    try:
+        provider_name, provider_config = get_provider_for_model(request.model)
+    except UnknownModelError as e:
+        # Client asked for something this deployment doesn't serve. Log it against a
+        # synthetic provider so the miss is visible in the logs (the request never
+        # reaches log_request, which runs after routing succeeds).
+        log_response("unrouted", request.model, {}, 0, error=str(e))
+        raise HTTPException(status_code=400, detail=str(e))
     endpoint = provider_config["endpoint"]
     api_key = provider_config["api_key"]
     

--- a/test_logging.py
+++ b/test_logging.py
@@ -739,3 +739,110 @@ if __name__ == "__main__":
             failed += 1
             print(f"FAIL {fn.__name__}: {type(e).__name__}: {e}")
     sys.exit(1 if failed else 0)
+
+
+# ---------------------------------------------------------------------------
+# default_provider / unroutable-model handling
+# ---------------------------------------------------------------------------
+
+CIRRUS_LIKE = {
+    "openrouter": {"endpoint": "https://openrouter.ai/x", "api_key": "k",
+                   "models": ["anthropic/", "z-ai/", "~"], "extra_headers": {},
+                   "thinking_models": {}, "no_sampling_params": []},
+    "nimbus": {"endpoint": "https://nimbus/x", "api_key": "k", "models": ["qwen"],
+               "extra_headers": {}, "thinking_models": {}, "no_sampling_params": []},
+}
+
+
+def test_default_provider_absent_key_is_nrp_backward_compat():
+    """No `default_provider` in config must behave exactly as the old hard-coded
+    "nrp" branch did — this is what every NRP model id relies on, since most of
+    `nrp.models` is redundant with the fallback."""
+    p = importlib.reload(llm_proxy)
+    assert p.resolve_default_provider({}, {"nrp": {}, "openrouter": {}}) == "nrp"
+    # ...and the shipped config.json still resolves to nrp
+    assert p.DEFAULT_PROVIDER == "nrp"
+
+
+def test_default_provider_is_configurable_and_can_be_disabled():
+    p = importlib.reload(llm_proxy)
+    r = p.resolve_default_provider
+    assert r({"default_provider": "openrouter"}, {"nrp": {}, "openrouter": {}}) == "openrouter"
+    # explicit null/"" -> no fallback, reject unroutable ids
+    assert r({"default_provider": None}, {"nrp": {}}) is None
+    assert r({"default_provider": ""}, {"nrp": {}}) is None
+
+
+def test_default_provider_unconfigured_name_degrades_to_none_not_keyerror():
+    """The cirrus case: config names (or defaults to) a provider this deployment
+    doesn't serve. Previously this reached `PROVIDERS["nrp"]` and raised KeyError
+    inside the request handler -> opaque 500. It must degrade to "no fallback"."""
+    p = importlib.reload(llm_proxy)
+    # cirrus's ConfigMap sets no default_provider at all, so the "nrp" default
+    # applies to a deployment with no nrp provider -> None, not an exception.
+    assert p.resolve_default_provider({}, CIRRUS_LIKE) is None
+    assert p.resolve_default_provider({"default_provider": "typo"}, CIRRUS_LIKE) is None
+
+
+def test_unroutable_model_raises_unknown_model_error_naming_what_is_served():
+    p = importlib.reload(llm_proxy)
+    p.PROVIDERS = CIRRUS_LIKE
+    p.DEFAULT_PROVIDER = None
+
+    # ids that DO route on a cirrus-like deployment still route
+    assert p.get_provider_for_model("z-ai/glm-5")[0] == "openrouter"
+    assert p.get_provider_for_model("qwen")[0] == "nimbus"
+
+    # bare NRP ids have nowhere to go -> a typed error, not KeyError
+    for model in ("glm-5", "kimi", "minimax-m2", "gpt-oss", "claude-sonnet-4-6"):
+        try:
+            p.get_provider_for_model(model)
+        except p.UnknownModelError as e:
+            assert model in str(e)
+            assert "openrouter" in str(e) and "nimbus" in str(e)   # says what IS served
+        else:
+            raise AssertionError(f"{model} should not have routed anywhere")
+
+
+def test_fallback_still_used_when_a_default_exists():
+    """With a default configured, an unknown id lands there and says so (unchanged
+    behavior on NRP, where this is how undeclared-but-live models have always run)."""
+    import contextlib
+    import io
+
+    p = importlib.reload(llm_proxy)
+    p.PROVIDERS = dict(CIRRUS_LIKE)
+    p.DEFAULT_PROVIDER = "openrouter"
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        name, _ = p.get_provider_for_model("some-new-model")
+    assert name == "openrouter"
+    assert "Unknown model" in buf.getvalue()
+
+
+def test_unroutable_model_returns_400_and_is_logged():
+    """End-to-end: the handler turns UnknownModelError into a 400 (not the old
+    KeyError-driven 500) and leaves a log row so the miss is visible."""
+    import asyncio
+
+    import pytest
+    from fastapi import HTTPException
+    from unittest.mock import patch
+
+    p = _reload(PROXY_KEY="testkey")
+    p._log_buffer.clear()
+
+    class _FakeRequest:
+        headers = {"origin": "https://app"}
+
+    req = p.ChatRequest(model="glm-5", messages=[{"role": "user", "content": "hi"}])
+    with patch.object(p, "PROVIDERS", CIRRUS_LIKE), \
+         patch.object(p, "DEFAULT_PROVIDER", None):
+        with pytest.raises(HTTPException) as ei:
+            asyncio.run(p.proxy_chat(req, _FakeRequest(), authorization="Bearer testkey"))
+
+    assert ei.value.status_code == 400
+    assert "glm-5" in ei.value.detail
+    responses = [e for e in p._log_buffer if e.get("type") == "response"]
+    assert len(responses) == 1 and responses[0]["provider"] == "unrouted"
+    assert "glm-5" in responses[0]["error"]


### PR DESCRIPTION
Unblocks #102, and is the first step away from maintaining model lists by hand.

## The bug

Routing's last resort is a hard-coded fallback:

```python
print(f"⚠️  Unknown model '{model}', defaulting to NRP")
return "nrp", PROVIDERS["nrp"]
```

**On NRP this is load-bearing and invisible.** Most of `nrp.models` is redundant with it — an id reaches NRP whether or not it is declared. That was #106's own finding: undeclared models *"still reached NRP, but only incidentally."*

**Anywhere that doesn't serve NRP it's a latent `KeyError`**, raised inside the request handler — an opaque 500 with no body. That is what `cirrus/` (#102) returns today for **15 of the 21** bare model ids in the fleet's config (`glm-5`, `kimi`, `minimax-m2`, `gpt-oss`, `gemma*`, `claude-*`). #102 lists this as a known limitation — "returns 500 rather than a useful 400" — which undersells it: it isn't an error-code nit, it's most of the fleet failing on the failover deployment.

## The change

- Optional top-level **`default_provider`**. Absent → `"nrp"`, so **NRP behavior is untouched**.
- No usable default → typed `UnknownModelError` → handler returns **400 naming what this deployment actually serves**, instead of 500.
- The miss is logged against a synthetic `unrouted` provider, so an unroutable id appears in the logs rather than vanishing (routing happens before `log_request`).
- A `default_provider` naming an unconfigured provider **degrades to the 400 path with a startup note** rather than failing per-request.

That last property matters for #102: a cirrus-style config — no `nrp` provider, no `default_provider` — now gets clean 400s **with no ConfigMap change at all**. #102 stays config-only and can merge as-is once this lands.

## Why this shape, and what's next

Per the discussion on #102: the alias/mapping table I first proposed would have been another hand-maintained model list, and I'd have baked today's staleness into it (the pinned `claude-sonnet-4-6` / `claude-opus-4-8` ids in `config.json` are already behind). Of the 22 commits that have ever touched `config.json`, ~13 are pure list maintenance. So this PR adds **no** model names — it only fixes the fallback mechanism.

Follow-ups, not in this PR:

1. Delete `nrp.models`' 14 entries — redundant with the fallback. (Note: `test_nrp_models_route_by_declaration_not_fallback` currently asserts the opposite and would be inverted; it passes untouched here.)
2. Drop Anthropic's three pinned ids in favor of the `claude-` prefix already in that provider's list — which would have routed `claude-sonnet-5` on day one.
3. Prefix-key `thinking_models` so new variants don't need a PR.
4. Expose `GET /v1/models` so apps populate pickers from the proxy instead of hardcoding ids.
5. Deprecate `gpt-oss` and `gemma*` fleet-wide (needs issues on the app repos).

## Verification

- **No behavior change on NRP**, checked rather than asserted: resolved provider for all 37 ids in `config.json` plus unknown / empty-string / floating-alias (`~openai/gpt-5`) / vendor-prefix cases, diffed against `origin/main`'s module. **Identical.** (Including that `totally-made-up-model` and `""` still land on `nrp`.)
- 41 tests pass (35 existing + 6 new): absent-key back-compat, configurable value, explicit `null`/`""`, unconfigured name, the typed error naming served providers, and an end-to-end handler test asserting 400 + the log row.
- The pre-existing `test_nrp_models_route_by_declaration_not_fallback` and the thinking-dialect tests pass unchanged.

Not exercised against a live cirrus pod — that needs this on `main` first, since those pods clone it at boot.