### PR TITLE
docs: correct the log-read credential scope (#113)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ SELECT * FROM read_ndjson_auto('/tmp/open-llm-proxy-logs/YYYY-MM-DD/*.jsonl',
 
 **Session view** (`s3://logs-open-llm-proxy/sessions/**/*.parquet`): one row per *turn*, request already joined to its response, ordered by `turn_idx` within `session_key`. This is the query-ready artifact — "show me every turn of session X in order, with tool calls and results" is one flat `SELECT`, no manual interleaving. Disjoint from the `consolidated/**` glob. See [LOGGING.md](LOGGING.md#reconstructing-a-conversation).
 
-For automation, one-shot CI queries, or queries that need sub-minute freshness without re-syncing, query S3 directly with `LOG_S3_KEY` / `LOG_S3_SECRET` from the shell — see [LOGGING.md](LOGGING.md#direct-s3-one-shot-queries-automation-or-inside-nrp-pods).
+For automation, one-shot CI queries, or queries that need sub-minute freshness without re-syncing, query S3 directly with `LOG_S3_KEY` / `LOG_S3_SECRET` from the shell — see [LOGGING.md](LOGGING.md#direct-s3-one-shot-queries-automation-or-inside-nrp-pods). **Those are the general NRP credentials** (read/write/delete, every bucket — there is only one), so prefer `./sync-logs.sh` and keep the direct path for cases that genuinely need it. Scoped read-only access is tracked in #113.
 
 Each LLM call produces a `request` row and a `response` row linked by `request_id`. Key fields inside `entry` (Parquet) or as top-level columns (JSONL):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,15 @@ See [Releases](README.md#releases) for how a release is cut.
   fleet-wide "DeepSeek V4 Flash (OpenRouter)" picker option.
 
 ### Fixed
+- **LOGGING.md wrongly described the log-read keys as scoped (#113).** The direct-S3
+  section said `LOG_S3_KEY`/`LOG_S3_SECRET` were "scoped keys for this bucket — distinct
+  from your general NRP credentials." There is exactly **one** credential for NRP bucket
+  access, so they are that credential: read/write/delete across every NRP bucket. The
+  claim was wrong in the dangerous direction — it made an over-broad key look already
+  contained, so handing it to an agent for a read-only log query looked safe. Both
+  LOGGING.md and AGENTS.md now state the real scope and steer to `./sync-logs.sh`, whose
+  local copy needs no secret at query time. Read-only single-bucket access is tracked in
+  #113, with the rustfs mirror/mint half in `geo-agent-ops#117`.
 - **Configurable `default_provider`; unroutable models get a 400, not a 500.** The
   fallback for a model id matching no provider entry was a hard-coded
   `return "nrp", PROVIDERS["nrp"]`. On NRP that is load-bearing — most of `nrp.models`

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -159,7 +159,11 @@ For queries that span today + history, UNION raw JSONL and consolidated Parquet 
 
 ### Direct S3 (one-shot queries, automation, or inside NRP pods)
 
-When you don't want a local copy — e.g. a single CI query, a k8s job, or always-current reads inside a pod — query S3 directly with a DuckDB secret. Set `LOG_S3_KEY` and `LOG_S3_SECRET` in your shell (scoped keys for this bucket — distinct from your general NRP credentials) and let the shell expand them. Agents should use the Bash tool so shell expansion keeps the secret values out of the conversation transcript.
+When you don't want a local copy — e.g. a single CI query, a k8s job, or always-current reads inside a pod — query S3 directly with a DuckDB secret. Set `LOG_S3_KEY` and `LOG_S3_SECRET` in your shell and let the shell expand them. Agents should use the Bash tool so shell expansion keeps the secret values out of the conversation transcript.
+
+> ⚠️ **These are not scoped, read-only keys.** There is exactly **one** credential for NRP bucket access, so `LOG_S3_KEY`/`LOG_S3_SECRET` are that same credential: **read/write/delete across every NRP bucket**, not just this one. (An earlier version of this note claimed they were "scoped keys for this bucket — distinct from your general NRP credentials." That was wrong, and wrong in the dangerous direction: it made an over-broad key look already-contained.)
+>
+> Treat this path as privileged. Prefer [`./sync-logs.sh`](#local-sync-recommended-for-interactive-analysis) — the local copy needs no secret at query time — and reach for direct S3 only when you genuinely need sub-minute freshness or an in-pod read. A read-only, single-bucket credential is tracked in #113 (with the mirror/mint half in `geo-agent-ops`); until it exists, sharing this key for log reads grants delete on everything it reaches.
 
 ```bash
 duckdb -s "


### PR DESCRIPTION
Docs only, but security-relevant.

## The bug

`LOGGING.md`'s direct-S3 section said:

> Set `LOG_S3_KEY` and `LOG_S3_SECRET` in your shell **(scoped keys for this bucket — distinct from your general NRP credentials)**

There is exactly **one** credential for NRP bucket access. So those variables hold that credential: **read/write/delete across every NRP bucket**, not a scoped read-only key for `logs-open-llm-proxy`.

## Why it matters more than a typo

It was wrong in the direction that hides risk. The note made an over-broad credential look already contained — so handing it to an agent for a read-only log query read as safe, and anyone auditing this file would find the problem already solved. It is exactly the claim that would keep #113 from being filed.

## Changes

- `LOGGING.md` — replaces the parenthetical with an explicit warning stating the real scope, and steers to `./sync-logs.sh`, whose local copy needs no secret at query time. The superseded claim is called out rather than silently deleted, since it has been read and believed.
- `AGENTS.md` — the same correction where it points agents at the direct-S3 path.
- `CHANGELOG.md` — entry under Fixed.

Both now point at #113 (consumer side) and `geo-agent-ops#117` (the rustfs mirror + read-only mint) for the actual fix.

Fixed the anchor while I was there: the link I first wrote pointed at a heading that doesn't exist; it now targets `#local-sync-recommended-for-interactive-analysis`.

No code touched; 41 tests pass unchanged.