### PR TITLE
docs(skill): fix broken and over-privileged log collection in `geo-agent-training`

### DIFF
--- a/.claude/skills/geo-agent-training/SKILL.md
+++ b/.claude/skills/geo-agent-training/SKILL.md
@@ -4,7 +4,7 @@ description: "Analyze geo-agent app behavior from LLM proxy and MCP server logs,
 license: Apache-2.0
 metadata:
   author: boettiger-lab
-  version: "2.0"
+  version: "2.1"
 ---
 
 # Geo-Agent Training Workflow
@@ -78,21 +78,48 @@ You need **both** proxy and MCP logs to see the full picture.
 
 ### LLM Proxy logs (what the model decided)
 
+**Default: sync the bucket once, then query locally.** From an `open-llm-proxy` checkout:
+
 ```bash
-# All pods, filtered to app origin — must check all pods
-for pod in $(kubectl -n biodiversity get pods -l app=llm-proxy -o name); do
-  kubectl -n biodiversity logs $pod --since=168h 2>/dev/null | grep '"origin":"https://APP.nrp-nautilus.io"'
-done | sort
+./sync-logs.sh          # -> /tmp/open-llm-proxy-logs (whole bucket, a few MiB, ~1s)
 ```
 
-Request log fields: `timestamp`, `type`, `provider`, `model`, `origin`, `client` (`X-Client` app+version, e.g. `geo-agent/v3.13.1`; `null` until the client sends it — filter on it to correlate behavior with a release), `message_count`, `tools_count`, `user_message`
+Then query the tier you need. For a *completed* session the **session view** is the
+right one — request already joined to response, one row per turn, in order:
 
-Response log format: `✓ RESPONSE: {...}` with `latency_ms`, `has_tool_calls`, `tool_calls`, `tokens`
+```bash
+duckdb -s "
+SELECT turn_idx, user_message_this_turn, tool_calls, tool_results
+FROM read_parquet('/tmp/open-llm-proxy-logs/sessions/**/*.parquet')
+WHERE origin = 'https://APP.nrp-nautilus.io'
+ORDER BY session_key, turn_idx;
+"
+```
 
-**Known limitations:**
-- `user_message` captures the last message in the conversation, which in a tool-use loop is usually a tool result — not the human's question
-- Responses lack an `origin` field (fix tracked in boettiger-lab/open-llm-proxy#2)
-- No request_id to correlate request/response pairs (fix tracked in boettiger-lab/open-llm-proxy#1)
+For history across sessions use `consolidated/**/*.parquet`; for *today* use the raw
+JSONL at `YYYY-MM-DD/*.jsonl`. See [LOGGING.md](../../../LOGGING.md) for the full schema.
+
+**Live tail** (the last ~60s, before the next S3 flush) — note the label is
+`app=open-llm-proxy`, not `app=llm-proxy`:
+
+```bash
+kubectl -n biodiversity logs deployment/open-llm-proxy --since=10m \
+  | grep '"origin":"https://APP.nrp-nautilus.io"'
+```
+
+Key request fields: `ts`, `type`, `provider`, `model`, `origin`, `session_id`,
+`request_id`, `client` (`X-Client` app+version, e.g. `geo-agent/v3.13.1` — filter on it
+to correlate behavior with a release), `message_count`, `tools_count`,
+`user_question` (the session *opener*), `user_message_this_turn` (this turn's actual
+prompt), `tool_results_this_turn`.
+
+Response fields: `latency_ms`, `has_tool_calls`, `tool_calls`, `tokens`, `error`.
+
+**Read `user_message_this_turn`, not `user_question`.** `user_question` holds only the
+first message of the session and is repeated verbatim on every later turn, so follow-up
+questions are invisible in it. Pair requests with responses via `request_id`, and group
+a session via `session_id` (both exact — `origin` + `user_question` grouping is a
+fallback for old records only).
 
 ### MCP Server logs (what SQL was executed)
 
@@ -102,11 +129,18 @@ for pod in $(kubectl -n biodiversity get pods -l app=duckdb-mcp -o name); do
 done | sort
 ```
 
-### Historical logs (S3 backup)
+### Historical logs
 
-```bash
-rclone copy nrp:logs-wetlands/ ./logs
-```
+Covered by `./sync-logs.sh` above — it pulls the whole `logs-open-llm-proxy` bucket,
+including the `consolidated/**` and `sessions/**` rollups, so there is no separate
+backup step.
+
+> ⚠️ **Don't reach for `rclone … nrp:` or `LOG_S3_KEY`/`LOG_S3_SECRET` to read logs.**
+> There is exactly one credential for NRP bucket access and it carries
+> **read/write/delete on every NRP bucket** — far beyond what reading a few MiB of logs
+> needs. `sync-logs.sh` uses the already-configured remote and its local copy needs no
+> secret at query time. A read-only, single-bucket credential is tracked in
+> boettiger-lab/open-llm-proxy#113.
 
 ## Step 2: Reconstruct Conversations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,16 @@ See [Releases](README.md#releases) for how a release is cut.
   fleet-wide "DeepSeek V4 Flash (OpenRouter)" picker option.
 
 ### Fixed
+- **`geo-agent-training` skill: log collection was broken and over-privileged.** Its
+  Step 1 selector was `app=llm-proxy`, which matches **no pods** — the label is
+  `app=open-llm-proxy` — so an agent following the skill collected zero proxy logs and
+  could conclude an app had no traffic. It then described a log schema three field-
+  generations stale (`user_message`, since replaced by `user_question` +
+  `user_message_this_turn`, #89) and listed "no `request_id`" and "responses lack
+  `origin`" as known limitations, both fixed long ago (#1, #2, closed). For history it
+  reached for `rclone copy nrp:logs-wetlands/` — the wrong bucket, via the broad NRP
+  credential (#113). Rewritten around `./sync-logs.sh` and the `sessions/**` view, with
+  the correct label, the current field list, and the credential warning. Skill 2.0 → 2.1.
 - **LOGGING.md wrongly described the log-read keys as scoped (#113).** The direct-S3
   section said `LOG_S3_KEY`/`LOG_S3_SECRET` were "scoped keys for this bucket — distinct
   from your general NRP credentials." There is exactly **one** credential for NRP bucket


### PR DESCRIPTION
Started as the `rclone nrp:` credential reference from #113. The surrounding Step 1 turned out to be broken in three ways, all verified rather than assumed.

## 1. The log-collection command returned nothing

```bash
kubectl -n biodiversity get pods -l app=llm-proxy    # -> "No resources found"
kubectl -n biodiversity get pods -l app=open-llm-proxy  # -> 3 pods
```

The skill used the first. An agent following it collected **zero** proxy logs — and the natural reading of an empty result is "this app has no traffic," not "my selector is wrong." That's a silent wrong-answer generator in a skill whose whole job is analyzing those logs.

## 2. The documented schema was three generations stale

It described `user_message`, replaced by `user_question` + `user_message_this_turn` (#89), and listed as **known limitations**:

- *"Responses lack an `origin` field (fix tracked in #2)"* — #2 **closed**
- *"No request_id to correlate request/response pairs (fix tracked in #1)"* — #1 **closed**

An agent trusting that list would hand-interleave records that are already joined, and would never look for `session_id` or the `sessions/**` view at all.

## 3. Historical logs used the wrong bucket via the broad credential

`rclone copy nrp:logs-wetlands/ ./logs` — not the proxy's bucket, and through the single NRP credential that carries read/write/delete on every bucket (#113, merged as #114).

## What it says now

- `./sync-logs.sh` as the default path, with the **`sessions/**`** view for completed sessions (request already joined to response, ordered by `turn_idx` — the thing the stale limitations told agents to do by hand).
- `kubectl` reframed as the live-tail path it actually is, with the correct label called out explicitly since the old one fails silently.
- Current request/response field lists, plus the `user_question` trap: it holds only the session opener and repeats on every later turn, so follow-ups are invisible in it.
- The credential warning from #113/#114, pointing at the read-only mint work.
- Skill version 2.0 → 2.1.

## Verification

- Both `kubectl` selectors run against the live cluster (0 pods vs 3).
- #1 and #2 confirmed `CLOSED` via `gh`.
- The relative link `../../../LOGGING.md` resolves from the skill's directory.
- Grepped for residual `app=llm-proxy` / `logs-wetlands` / `user_message` / `#1` / `#2` references — none left.
- 42 tests pass (docs-only change).

**Not verified:** the DuckDB snippet is composed from the schema documented in LOGGING.md — `duckdb` and the `rclone` remote aren't available in this session, so it hasn't been run against real data. Worth one execution before relying on it.

Scope note: you asked for the credential reference. I fixed the whole Step 1 block because the broken selector and the closed-issue limitations sit in the same section and would have kept producing wrong analyses. Happy to trim it back to just the `rclone` line if you'd rather keep the diff narrow.