### PR TITLE
feat(logs): mirror consolidated + sessions tiers to rustfs (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,27 @@ See [Releases](README.md#releases) for how a release is cut.
   `deepseek/…` models) route instead of silently falling back to NRP. Enables the
   fleet-wide "DeepSeek V4 Flash (OpenRouter)" picker option.
 
+### Added
+- **Mirror `consolidated/**` and `sessions/**` to rustfs from the consolidation CronJobs
+  (#116).** Log analysis has required the single NRP credential, which carries
+  read/write/delete on *every* NRP bucket, for a read-only task against one bucket of a
+  few MiB (#113). `geo-agent-ops` has minted a scoped pair — `logs-open-llm-proxy-reader`
+  (Get/List only) and `…-writer` (plus object Put/Delete, no bucket create/delete) — but
+  the rustfs bucket was empty, so the reader was useless. Both CronJobs now copy the
+  query-ready tiers there after the tiers are written and verified. Credentials come from
+  the `rustfs-logs-write` Secret under **`RUSTFS_*`** names, deliberately not `AWS_*`:
+  those are already bound to the `aws` secret for the NRP source, and reusing them would
+  clobber the source credential and break the job before it mirrored anything. All four
+  bindings are `optional: true`, so a cluster without the Secret still consolidates and
+  reports the mirror skipped. Copy-only, never delete — an accidental source deletion
+  must not propagate; re-copies when the source `LastModified` or size changes, which is
+  what catches the in-place rewrites the reflatten pass performs (size alone is not a
+  witness). Runs last so a mirror failure cannot cost the consolidation work, but it does
+  fail the Job, because a mirror that quietly stops is a stale mirror nobody notices.
+  NRP Ceph stays the system of record: rustfs shares the same rook Ceph, so this is a
+  convenience copy, not a second failure domain. Consumer-side retarget of `sync-logs.sh`
+  stays in #113 and deliberately does **not** land until the mirror is confirmed non-empty.
+
 ### Fixed
 - **`geo-agent-training` skill: log collection was broken and over-privileged.** Its
   Step 1 selector was `app=llm-proxy`, which matches **no pods** — the label is

--- a/LOGGING.md
+++ b/LOGGING.md
@@ -117,6 +117,19 @@ request/response interleaving:
 
 ## Access pattern
 
+> 🔜 **A read-only rustfs mirror is being stood up (#116).** The consolidation CronJobs now
+> copy `consolidated/**` and `sessions/**` to `logs-open-llm-proxy` on rustfs after each run,
+> so those tiers can be read with a credential scoped to that one bucket — Get/List only —
+> instead of the single NRP key that carries read/write/delete on *every* NRP bucket (#113).
+> The credential lives in the `rustfs-logs-read` Secret in `biodiversity`; reference it by
+> **name**, never by value, so rotation touches nothing here.
+>
+> **Not yet the recommended path.** The sections below still describe the NRP-key workflow,
+> and stay that way until the mirror has run and been confirmed non-empty — retargeting
+> sooner would make the recommended path return *nothing* rather than too much. NRP Ceph
+> remains the system of record either way; rustfs shares the same rook Ceph, so the mirror
+> is a convenience copy, not a second failure domain.
+
 ### Local sync (recommended for interactive analysis)
 
 The bucket is **private**, but `rclone` already has credentials configured under the `nrp` remote. Sync the bucket to a local scratch dir once per session, then query the local files — no S3 secret, no shell-expanded credentials, and orders of magnitude faster iteration:

--- a/consolidate-daily-cronjob.yaml
+++ b/consolidate-daily-cronjob.yaml
@@ -37,6 +37,24 @@ spec:
                   valueFrom: { secretKeyRef: { name: aws, key: AWS_ACCESS_KEY_ID } }
                 - name: AWS_SECRET_ACCESS_KEY
                   valueFrom: { secretKeyRef: { name: aws, key: AWS_SECRET_ACCESS_KEY } }
+                # rustfs mirror target (#116). Deliberately NOT named AWS_* — the
+                # consolidation work above binds those to the `aws` secret for the NRP
+                # source, and reusing the names would overwrite the source credential
+                # and break the job before it ever mirrored anything.
+                # `optional: true` throughout: a cluster without the secret still
+                # consolidates, and the mirror step reports itself skipped.
+                - name: RUSTFS_KEY
+                  valueFrom:
+                    secretKeyRef: { name: rustfs-logs-write, key: AWS_ACCESS_KEY_ID, optional: true }
+                - name: RUSTFS_SECRET
+                  valueFrom:
+                    secretKeyRef: { name: rustfs-logs-write, key: AWS_SECRET_ACCESS_KEY, optional: true }
+                - name: RUSTFS_ENDPOINT
+                  valueFrom:
+                    secretKeyRef: { name: rustfs-logs-write, key: AWS_S3_ENDPOINT, optional: true }
+                - name: RUSTFS_BUCKET
+                  valueFrom:
+                    secretKeyRef: { name: rustfs-logs-write, key: BUCKET, optional: true }
               command:
                 - /bin/bash
                 - -c
@@ -46,6 +64,7 @@ spec:
                   python - <<'PY'
                   import os, datetime, boto3, duckdb
                   from botocore.client import Config
+                  from botocore.exceptions import ClientError
 
                   BUCKET   = 'logs-open-llm-proxy'
                   ENDPOINT = 'http://rook-ceph-rgw-nautiluss3.rook'
@@ -280,6 +299,63 @@ spec:
                           upgraded += 1
                           print(f"  ⬆ re-flattened {day} to wide schema")
                   print(f"Legacy daily files upgraded to wide schema: {upgraded}")
+                  # -----------------------------------------------------------------
+                  # Mirror the query-ready tiers to rustfs (#116).
+                  #
+                  # Exists so log analysis can run on the read-only, single-bucket
+                  # `logs-open-llm-proxy-reader` credential instead of the one NRP key,
+                  # which carries read/write/delete on every NRP bucket (#113).
+                  #
+                  # NRP Ceph stays the system of record. rustfs sits on the *same* rook
+                  # Ceph, so this is a convenience mirror, not a second failure domain,
+                  # and must never become the only copy.
+                  #
+                  # Copy-only, never delete: an accidental source deletion must not
+                  # propagate. True mirror semantics would need a --max-delete-style
+                  # guard first (the writer identity can delete objects; this does not).
+                  #
+                  # Runs last, after every tier is written and verified, so a mirror
+                  # failure cannot cost the consolidation work. It does fail the Job
+                  # though — a mirror that quietly stops is a stale mirror nobody
+                  # notices, and the reader would keep serving yesterday's answers.
+                  # -----------------------------------------------------------------
+                  def mirror_to_rustfs(prefixes=('consolidated/', 'sessions/')):
+                      key = os.environ.get('RUSTFS_KEY')
+                      if not key:
+                          print("ℹ️  RUSTFS_KEY not set — skipping rustfs mirror (#116)")
+                          return
+                      dest_bucket = os.environ.get('RUSTFS_BUCKET') or BUCKET
+                      rustfs = boto3.client(
+                          's3',
+                          endpoint_url=os.environ['RUSTFS_ENDPOINT'],
+                          aws_access_key_id=key,
+                          aws_secret_access_key=os.environ['RUSTFS_SECRET'],
+                          config=Config(s3={'addressing_style': 'path'}),
+                      )
+                      copied = skipped = 0
+                      for prefix in prefixes:
+                          for page in paginator.paginate(Bucket=BUCKET, Prefix=prefix):
+                              for obj in page.get('Contents', []):
+                                  k, stamp = obj['Key'], obj['LastModified'].isoformat()
+                                  # Re-upload whenever the source changed. Size alone is
+                                  # not a witness: the reflatten pass rewrites files in
+                                  # place and can land on an identical byte count.
+                                  try:
+                                      head = rustfs.head_object(Bucket=dest_bucket, Key=k)
+                                      if (head['Metadata'].get('src-mtime') == stamp
+                                              and head['ContentLength'] == obj['Size']):
+                                          skipped += 1
+                                          continue
+                                  except ClientError as e:
+                                      if e.response['Error']['Code'] not in ('404', 'NoSuchKey', 'NotFound'):
+                                          raise   # 403 etc. is a real problem — be loud
+                                  body = s3.get_object(Bucket=BUCKET, Key=k)['Body'].read()
+                                  rustfs.put_object(Bucket=dest_bucket, Key=k, Body=body,
+                                                    Metadata={'src-mtime': stamp})
+                                  copied += 1
+                      print(f"rustfs mirror → {dest_bucket}: {copied} copied, {skipped} already current")
+
+                  mirror_to_rustfs()
                   print("Done.")
                   PY
               resources:

--- a/consolidate-monthly-cronjob.yaml
+++ b/consolidate-monthly-cronjob.yaml
@@ -37,6 +37,24 @@ spec:
                   valueFrom: { secretKeyRef: { name: aws, key: AWS_ACCESS_KEY_ID } }
                 - name: AWS_SECRET_ACCESS_KEY
                   valueFrom: { secretKeyRef: { name: aws, key: AWS_SECRET_ACCESS_KEY } }
+                # rustfs mirror target (#116). Deliberately NOT named AWS_* — the
+                # consolidation work above binds those to the `aws` secret for the NRP
+                # source, and reusing the names would overwrite the source credential
+                # and break the job before it ever mirrored anything.
+                # `optional: true` throughout: a cluster without the secret still
+                # consolidates, and the mirror step reports itself skipped.
+                - name: RUSTFS_KEY
+                  valueFrom:
+                    secretKeyRef: { name: rustfs-logs-write, key: AWS_ACCESS_KEY_ID, optional: true }
+                - name: RUSTFS_SECRET
+                  valueFrom:
+                    secretKeyRef: { name: rustfs-logs-write, key: AWS_SECRET_ACCESS_KEY, optional: true }
+                - name: RUSTFS_ENDPOINT
+                  valueFrom:
+                    secretKeyRef: { name: rustfs-logs-write, key: AWS_S3_ENDPOINT, optional: true }
+                - name: RUSTFS_BUCKET
+                  valueFrom:
+                    secretKeyRef: { name: rustfs-logs-write, key: BUCKET, optional: true }
               command:
                 - /bin/bash
                 - -c
@@ -46,6 +64,7 @@ spec:
                   python - <<'PY'
                   import os, datetime, boto3, duckdb
                   from botocore.client import Config
+                  from botocore.exceptions import ClientError
 
                   BUCKET   = 'logs-open-llm-proxy'
                   ENDPOINT = 'http://rook-ceph-rgw-nautiluss3.rook'
@@ -256,6 +275,63 @@ spec:
                   for m in backfill:
                       build_session_view(f's3://{BUCKET}/consolidated/monthly/{m}.parquet',
                                          f's3://{BUCKET}/sessions/monthly/{m}.parquet')
+                  # -----------------------------------------------------------------
+                  # Mirror the query-ready tiers to rustfs (#116).
+                  #
+                  # Exists so log analysis can run on the read-only, single-bucket
+                  # `logs-open-llm-proxy-reader` credential instead of the one NRP key,
+                  # which carries read/write/delete on every NRP bucket (#113).
+                  #
+                  # NRP Ceph stays the system of record. rustfs sits on the *same* rook
+                  # Ceph, so this is a convenience mirror, not a second failure domain,
+                  # and must never become the only copy.
+                  #
+                  # Copy-only, never delete: an accidental source deletion must not
+                  # propagate. True mirror semantics would need a --max-delete-style
+                  # guard first (the writer identity can delete objects; this does not).
+                  #
+                  # Runs last, after every tier is written and verified, so a mirror
+                  # failure cannot cost the consolidation work. It does fail the Job
+                  # though — a mirror that quietly stops is a stale mirror nobody
+                  # notices, and the reader would keep serving yesterday's answers.
+                  # -----------------------------------------------------------------
+                  def mirror_to_rustfs(prefixes=('consolidated/', 'sessions/')):
+                      key = os.environ.get('RUSTFS_KEY')
+                      if not key:
+                          print("ℹ️  RUSTFS_KEY not set — skipping rustfs mirror (#116)")
+                          return
+                      dest_bucket = os.environ.get('RUSTFS_BUCKET') or BUCKET
+                      rustfs = boto3.client(
+                          's3',
+                          endpoint_url=os.environ['RUSTFS_ENDPOINT'],
+                          aws_access_key_id=key,
+                          aws_secret_access_key=os.environ['RUSTFS_SECRET'],
+                          config=Config(s3={'addressing_style': 'path'}),
+                      )
+                      copied = skipped = 0
+                      for prefix in prefixes:
+                          for page in paginator.paginate(Bucket=BUCKET, Prefix=prefix):
+                              for obj in page.get('Contents', []):
+                                  k, stamp = obj['Key'], obj['LastModified'].isoformat()
+                                  # Re-upload whenever the source changed. Size alone is
+                                  # not a witness: the reflatten pass rewrites files in
+                                  # place and can land on an identical byte count.
+                                  try:
+                                      head = rustfs.head_object(Bucket=dest_bucket, Key=k)
+                                      if (head['Metadata'].get('src-mtime') == stamp
+                                              and head['ContentLength'] == obj['Size']):
+                                          skipped += 1
+                                          continue
+                                  except ClientError as e:
+                                      if e.response['Error']['Code'] not in ('404', 'NoSuchKey', 'NotFound'):
+                                          raise   # 403 etc. is a real problem — be loud
+                                  body = s3.get_object(Bucket=BUCKET, Key=k)['Body'].read()
+                                  rustfs.put_object(Bucket=dest_bucket, Key=k, Body=body,
+                                                    Metadata={'src-mtime': stamp})
+                                  copied += 1
+                      print(f"rustfs mirror → {dest_bucket}: {copied} copied, {skipped} already current")
+
+                  mirror_to_rustfs()
                   print("Done.")
                   PY
               resources:


### PR DESCRIPTION
Closes #116. Fills the bucket that `geo-agent-ops` PR #119 minted the credentials for — until this runs, `logs-open-llm-proxy-reader` reads an empty bucket.

Both consolidation CronJobs now copy `consolidated/**` and `sessions/**` to rustfs after the tiers are written and verified.

## Design points, all from #116

**`RUSTFS_*`, not `AWS_*`.** The jobs already bind `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` to the `aws` secret for the NRP *source*, and the consolidation script reads them. Reusing those names would overwrite the source credential and break the job before it mirrored anything — the collision #116 flagged. Endpoint and bucket come from the Secret too, so relocating rustfs doesn't mean editing this repo.

**All four bindings are `optional: true`.** A cluster without `rustfs-logs-write` still consolidates normally and prints the mirror as skipped, so this doesn't become a hard dependency of the log pipeline.

**Copy-only, never delete.** Per #116, an accidental source deletion must not propagate. The writer identity *can* delete objects, but nothing here does; true mirror semantics would want a `--max-delete`-style guard first.

**Re-copies on `LastModified` *or* size change.** Size alone is not a witness — the `reflatten` schema-upgrade pass rewrites files in place and can land on an identical byte count, which would leave the mirror silently stale. Freshness is tracked in a `src-mtime` object metadata field on the destination.

**Ordered last, but it fails the Job.** It runs after every tier is written and verified, so a mirror failure can never cost the consolidation work (already committed, and idempotent on retry). But it does not swallow errors: a mirror that quietly stops is a stale mirror nobody notices, and the reader would keep serving stale answers — the #103 lesson.

No new dependency: the container already `pip install`s `boto3`.

## Verification

Both manifests parse as YAML, and their embedded Python passes `ast.parse` — worth checking explicitly, since the script lives in a heredoc inside a YAML block scalar where indentation errors are easy and silent.

Mirror logic exercised against stub clients, six cases:

| case | result |
|---|---|
| no `RUSTFS_KEY` | skips, 0 puts |
| empty destination | both objects copied |
| destination current (mtime + size match) | 0 copied, 2 skipped |
| source rewritten, same size, newer mtime (**the reflatten case**) | re-copied ✅ |
| `403` on HEAD | **raises** — not swallowed as "missing" |
| any case | zero deletes at destination |

42 tests pass (no app code touched).

**Not run against live rustfs** — that needs the Secret, which exists only in-cluster. The first scheduled run (03:00 UTC daily) is the real test. Worth watching it, or triggering one manually:

```bash
kubectl -n biodiversity create job --from=cronjob/logs-consolidate-daily mirror-test-1
```

## Deliberately not included

The consumer-side retarget of `sync-logs.sh` / LOGGING.md stays in #113 and must not land until this mirror is confirmed non-empty — otherwise the recommended path silently returns *nothing* instead of returning too much, exactly as #116 warns. LOGGING.md gets a note that the mirror exists and is **not yet** the recommended path, referencing the `rustfs-logs-read` Secret by name rather than value so rotation touches no docs here.